### PR TITLE
disable tcmalloc

### DIFF
--- a/native-io/Cargo.lock
+++ b/native-io/Cargo.lock
@@ -1405,13 +1405,11 @@ dependencies = [
  "derivative",
  "futures",
  "hdrs",
- "link-cplusplus",
  "object_store",
  "parquet",
  "rand",
  "serde",
  "smallvec",
- "tcmalloc",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2376,19 +2374,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tcmalloc"
-version = "2.10.0"
-source = "git+https://github.com/lakesoul-io/tcmalloc-rs.git?tag=2.10.1-minimal#5f393ad50a4206a790e418c2a3e2bf6f940f0d22"
-dependencies = [
- "tcmalloc-sys",
-]
-
-[[package]]
-name = "tcmalloc-sys"
-version = "2.10.0"
-source = "git+https://github.com/lakesoul-io/tcmalloc-rs.git?tag=2.10.1-minimal#5f393ad50a4206a790e418c2a3e2bf6f940f0d22"
 
 [[package]]
 name = "tempfile"

--- a/native-io/lakesoul-io/Cargo.toml
+++ b/native-io/lakesoul-io/Cargo.toml
@@ -26,8 +26,6 @@ smallvec = "1.10"
 dary_heap = "0.3"
 hdrs = { version = "0.2", features = ["async_file"], optional = true }
 bytes = "1.4.0"
-tcmalloc = { git = "https://github.com/lakesoul-io/tcmalloc-rs.git", tag = "2.10.1-minimal" }
-link-cplusplus = "1.0"
 
 [features]
 hdfs = ["dep:hdrs"]

--- a/native-io/lakesoul-io/src/lib.rs
+++ b/native-io/lakesoul-io/src/lib.rs
@@ -19,15 +19,6 @@
 #![feature(io_error_more)]
 #![feature(sync_unsafe_cell)]
 
-extern crate link_cplusplus;
-
-extern crate tcmalloc;
-
-use tcmalloc::TCMalloc;
-
-#[global_allocator]
-static GLOBAL: TCMalloc = TCMalloc;
-
 pub mod lakesoul_reader;
 pub mod filter;
 pub mod lakesoul_writer;


### PR DESCRIPTION
TCMalloc will override malloc/free symbol in the shared lib, which may cause some problem in complex environment.
We may need to find a way to address this.