### PR TITLE
update load flink sql from hdfs in yarn application

### DIFF
--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/SubmitMain.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/SubmitMain.java
@@ -21,11 +21,18 @@ package org.apache.flink.lakesoul.entry.sql;
 
 import org.apache.flink.lakesoul.entry.sql.common.SubmitOption;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class SubmitMain {
-    public static void main(String[] args) {
+    private static final Logger LOG = LoggerFactory.getLogger(SubmitMain.class);
+
+    public static void main(String[] args) throws IOException, URISyntaxException {
         for (String arg : args) {
-            System.out.println(arg);
+            LOG.info("arg: {}", arg);
         }
         SubmitOption submitOption = optionBuild(args);
         Submitter submitter = SubmitterFactory.createSubmitter(submitOption);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/Submitter.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/Submitter.java
@@ -21,6 +21,9 @@ package org.apache.flink.lakesoul.entry.sql;
 
 import org.apache.flink.lakesoul.entry.sql.common.SubmitOption;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 public abstract class Submitter {
     protected SubmitOption submitOption;
 
@@ -28,6 +31,6 @@ public abstract class Submitter {
         this.submitOption = submitOption;
     }
 
-    public abstract void submit();
+    public abstract void submit() throws IOException, URISyntaxException;
 
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/common/SubmitOption.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/common/SubmitOption.java
@@ -28,18 +28,22 @@ public class SubmitOption {
     private final String submitType;
     private final String jobType;
     private final String language;
-    private final String content;
+    private final String sqlFilePath;
     private FlinkOption flinkOption;
 
     public SubmitOption(ParameterTool params) {
         this.submitType = params.get("submit_type");
         this.jobType = params.get("job_type");
         this.language = params.get("language");
-        this.content = params.get("content");
+        this.sqlFilePath = params.get("sql_file_path");
         this.checkParam();
         if (SubmitType.getSubmitType(submitType) == SubmitType.FLINK) {
             setFlinkOption(params, this);
         }
+    }
+
+    public String getSqlFilePath() {
+        return sqlFilePath;
     }
 
     public String getSubmitType() {
@@ -54,9 +58,6 @@ public class SubmitOption {
         return language;
     }
 
-    public String getContent() {
-        return content;
-    }
 
     public FlinkOption getFlinkOption() {
         return flinkOption;
@@ -82,7 +83,7 @@ public class SubmitOption {
     private void setFlinkOption(ParameterTool params, SubmitOption submitOption) {
         String checkpointPath = params.get(FLINK_CHECKPOINT.key());
         String savepointPath = params.get(FLINK_SAVEPOINT.key());
-        int checkpointInterval = params.getInt(JOB_CHECKPOINT_INTERVAL.key(), JOB_CHECKPOINT_INTERVAL.defaultValue());
+        long checkpointInterval = params.getLong(JOB_CHECKPOINT_INTERVAL.key(), JOB_CHECKPOINT_INTERVAL.defaultValue());
         String checkpointingMode = params.get(JOB_CHECKPOINT_MODE.key(), JOB_CHECKPOINT_MODE.defaultValue());
         FlinkOption flinkOption = new FlinkOption();
         flinkOption.setCheckpointPath(checkpointPath);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/utils/FileUtil.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/utils/FileUtil.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright [2022] [DMetaSoul Team]
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+package org.apache.flink.lakesoul.entry.sql.utils;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class FileUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(FileUtil.class);
+
+    public static String readHDFSFile(String sqlFilePath) throws IOException, URISyntaxException {
+        URI uri = new URI(sqlFilePath);
+        Path path = new Path(sqlFilePath);
+        if (!FileSystem.get(uri).exists(path)) {
+            LOG.error("Cannot find sql file at " + sqlFilePath);
+            throw new IOException("Cannot find sql file at " + sqlFilePath);
+        }
+        LOG.info("Reading sql file from hdfs: " + sqlFilePath);
+        FileSystem fs = FileSystem.get(path.toUri());
+        String sql = new BufferedReader(new InputStreamReader(fs.open(path)))
+                .lines().collect(Collectors.joining("\n"));
+        String replaceDefaultKeywordFromZeppelinStr = replaceDefaultKeywordFromZeppelin(sql);
+        return replaceDefaultKeywordFromZeppelinStr;
+
+    }
+
+    /*
+     * In zeppelin sql, "use default" is running well,
+     * but in flink sql, "default" is a keyword. need to replace it to "`default`".
+     * so, this function is used to replace "use default" to "use `default`".
+     *
+     * */
+    public static String replaceDefaultKeywordFromZeppelin(String text) {
+        if (text == null || text.length() <= 0) {
+            LOG.info("text is null or empty");
+            return text;
+        }
+        String pattern = "(?i)use\\s+(?i)default";
+        String replaceText = "use `default`";
+        Pattern pc = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+        String replacedStr = pc.matcher(text).replaceAll(replaceText);
+        return replacedStr;
+    }
+}

--- a/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/SubmitMainTest.java
+++ b/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/SubmitMainTest.java
@@ -2,11 +2,13 @@ package org.apache.flink.lakesoul.test;
 
 import org.apache.flink.lakesoul.entry.sql.SubmitMain;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class SubmitMainTest {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException, URISyntaxException {
 
         StringBuffer content = new StringBuffer();
         content.append("DROP table if exists SourceTable;\n");
@@ -22,9 +24,8 @@ public class SubmitMainTest {
         list.add("--job_type");
         list.add("stream");
         list.add("--language");
-        list.add("sql");
-        list.add("--content");
-        list.add(content.toString());
+        list.add("--sql_path");
+        list.add("~/Desktop/sublime-data/flink-sql-blackhole.sql");
         list.add("--flink.checkpoint");
         list.add("file:///tmp/flink/checkpoints");
         list.add("--flink.savepoint");


### PR DESCRIPTION
1. update load flink sql from hdfs in yarn application
2. fix "use default" loaded from zeppelin sql. In zeppelin, "use default" is running well, but in flink sql, "default" is a keyword. So, this update is to replace "use default" to "use `default`" in flink submitter.