### PR TITLE
Fix meta exception handling

### DIFF
--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/DBManager.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/DBManager.java
@@ -291,7 +291,9 @@ public class DBManager {
             p.setCommitOp("DeleteCommit");
             p.setExpression("");
         }
-        partitionInfoDao.transactionInsert(curPartitionInfoList, Collections.emptyList());
+        if (!partitionInfoDao.transactionInsert(curPartitionInfoList, Collections.emptyList())) {
+            throw new RuntimeException("Transactional insert partition info failed");
+        }
     }
 
     public void logicDeletePartitionInfoByRangeId(String tableId, String partitionDesc) {
@@ -761,14 +763,14 @@ public class DBManager {
         return dataCommitInfoDao.selectByTableIdPartitionDescCommitList(tableId, partitionDesc, dataCommitUUIDs);
     }
 
-    public boolean rollbackPartitionByVersion(String tableId, String partitionDesc, int version) {
+    public void rollbackPartitionByVersion(String tableId, String partitionDesc, int version) {
         PartitionInfo partitionInfo = partitionInfoDao.findByKey(tableId, partitionDesc, version);
         if (partitionInfo.getTableId() == null) {
-            return false;
+            return;
         }
         PartitionInfo curPartitionInfo = partitionInfoDao.selectLatestPartitionInfo(tableId, partitionDesc);
         partitionInfo.setVersion(curPartitionInfo.getVersion() + 1);
-        return partitionInfoDao.insert(partitionInfo);
+        partitionInfoDao.insert(partitionInfo);
     }
 
     public void commitDataCommitInfo(DataCommitInfo dataCommitInfo) {

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/DBUtil.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/DBUtil.java
@@ -92,6 +92,7 @@ public class DBUtil {
                 properties.load(Files.newInputStream(Paths.get(configFile)));
             } catch (IOException e) {
                 e.printStackTrace();
+                throw new RuntimeException(e);
             }
         } else {
             properties.setProperty(driverNameKey, getConfigValue(driverNameEnv, driverNameKey, driverNameDefault));
@@ -205,64 +206,10 @@ public class DBUtil {
         return rsList;
     }
 
-    public static String changeUUIDListToString(List<UUID> uuidList) {
-        StringBuilder sb = new StringBuilder();
-        if (uuidList.size() == 0) {
-            return sb.toString();
-        }
-        for (UUID uuid : uuidList) {
-            sb.append(String.format("'%s',", uuid.toString()));
-        }
-        sb = new StringBuilder(sb.substring(0, sb.length() - 1));
-        return sb.toString();
-    }
-
-    public static String changeUUIDListToOrderString(List<UUID> uuidList) {
-        StringBuilder sb = new StringBuilder();
-        if (uuidList.size() == 0) {
-            return sb.toString();
-        }
-        for (UUID uuid : uuidList) {
-            sb.append(String.format("%s,", uuid.toString()));
-        }
-        sb = new StringBuilder(sb.substring(0, sb.length() - 1));
-        return sb.toString();
-    }
-
-    public static List<UUID> changeStringToUUIDList(String s) {
-        List<UUID> uuidList = new ArrayList<>();
-        if (!s.startsWith("{") || !s.endsWith("}")) {
-            // todo
-            return uuidList;
-        }
-        s = s.substring(1, s.length() - 1);
-        String[] uuids = s.split(",");
-        for (String uuid : uuids) {
-            uuidList.add(UUID.fromString(uuid));
-        }
-        return uuidList;
-    }
-
-    public static String changePartitionDescListToString(List<String> partitionDescList) {
-        StringBuilder sb = new StringBuilder();
-        if (partitionDescList.size() < 1) {
-            return sb.append("''").toString();
-        }
-        for (String s : partitionDescList) {
-            sb.append(String.format("'%s',", s));
-        }
-        return sb.substring(0, sb.length() - 1);
-    }
-
     public static String formatTableInfoPartitionsField(List<String> primaryKeys, List<String> rangePartitions) {
         return formatTableInfoPartitionsField(
                 String.join(LAKESOUL_HASH_PARTITION_SPLITTER, primaryKeys),
                 String.join(LAKESOUL_RANGE_PARTITION_SPLITTER, rangePartitions));
-    }
-
-    public static String formatTableInfoPartitionsField(List<String> primaryKeys, String rangePartitions) {
-        return formatTableInfoPartitionsField(String.join(LAKESOUL_HASH_PARTITION_SPLITTER, primaryKeys),
-                rangePartitions);
     }
 
     public static String formatTableInfoPartitionsField(String primaryKeys, List<String> rangePartitions) {

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/DataCommitInfoDao.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/DataCommitInfoDao.java
@@ -146,7 +146,7 @@ public class DataCommitInfoDao {
                 createDataCommitInfoFromRs(rs, dataCommitInfo);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -170,7 +170,7 @@ public class DataCommitInfoDao {
                 createDataCommitInfoFromRs(rs, dataCommitInfo);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -208,7 +208,7 @@ public class DataCommitInfoDao {
                 commitInfoList.add(dataCommitInfo);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -241,7 +241,6 @@ public class DataCommitInfoDao {
             }
             conn.commit();
         } catch (SQLException e) {
-            result = false;
             try {
                 if (conn != null) {
                     conn.rollback();
@@ -249,7 +248,7 @@ public class DataCommitInfoDao {
             } catch (SQLException ex) {
                 ex.printStackTrace();
             }
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/NamespaceDao.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/NamespaceDao.java
@@ -31,10 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NamespaceDao {
-    public boolean insert(Namespace namespace) {
+    public void insert(Namespace namespace) {
         Connection conn = null;
         PreparedStatement pstmt = null;
-        boolean result = true;
         try {
             conn = DBConnector.getConn();
             pstmt = conn.prepareStatement("insert into namespace(namespace, properties, comment) " +
@@ -44,12 +43,10 @@ public class NamespaceDao {
             pstmt.setString(3, namespace.getComment());
             pstmt.execute();
         } catch (SQLException e) {
-            result = false;
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }
-        return result;
     }
 
     public Namespace findByNamespace(String name) {
@@ -69,7 +66,7 @@ public class NamespaceDao {
                 namespace.setComment(rs.getString("comment"));
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -106,7 +103,7 @@ public class NamespaceDao {
                 list.add(namespace);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -126,7 +123,7 @@ public class NamespaceDao {
             pstmt = conn.prepareStatement(sb.toString());
             result = pstmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TableInfoDao.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TableInfoDao.java
@@ -77,17 +77,16 @@ public class TableInfoDao {
                 tableInfo.setTableNamespace(rs.getString("table_namespace"));
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
         return tableInfo;
     }
 
-    public boolean insert(TableInfo tableInfo) {
+    public void insert(TableInfo tableInfo) {
         Connection conn = null;
         PreparedStatement pstmt = null;
-        boolean result = true;
         try {
             conn = DBConnector.getConn();
             pstmt = conn.prepareStatement("insert into table_info(table_id, table_name, table_path, table_schema, properties, partitions, table_namespace) " +
@@ -101,12 +100,10 @@ public class TableInfoDao {
             pstmt.setString(7, tableInfo.getTableNamespace());
             pstmt.execute();
         } catch (SQLException e) {
-            result = false;
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }
-        return result;
     }
 
     public void deleteByTableId(String tableId) {
@@ -152,7 +149,7 @@ public class TableInfoDao {
             pstmt = conn.prepareStatement(sb.toString());
             result = pstmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }
@@ -184,7 +181,7 @@ public class TableInfoDao {
             pstmt = conn.prepareStatement(sb.toString());
             result = pstmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TableNameIdDao.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TableNameIdDao.java
@@ -48,7 +48,7 @@ public class TableNameIdDao {
                 tableNameId.setTableNamespace(rs.getString("table_namespace"));
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -71,17 +71,16 @@ public class TableNameIdDao {
                 list.add(tableName);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
         return list;
     }
 
-    public boolean insert(TableNameId tableNameId) {
+    public void insert(TableNameId tableNameId) {
         Connection conn = null;
         PreparedStatement pstmt = null;
-        boolean result = true;
         try {
             conn = DBConnector.getConn();
             pstmt = conn.prepareStatement(
@@ -91,12 +90,10 @@ public class TableNameIdDao {
             pstmt.setString(3, tableNameId.getTableNamespace());
             pstmt.execute();
         } catch (SQLException e) {
-            result = false;
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }
-        return result;
     }
 
     public void delete(String tableName, String tableNamespace) {
@@ -146,7 +143,7 @@ public class TableNameIdDao {
             pstmt = conn.prepareStatement(sql);
             result = pstmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TablePathIdDao.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TablePathIdDao.java
@@ -46,7 +46,7 @@ public class TablePathIdDao {
                 tablePathId.setTableId(rs.getString("table_id"));
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -71,7 +71,7 @@ public class TablePathIdDao {
                 list.add(tablePathId);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -96,7 +96,7 @@ public class TablePathIdDao {
                 list.add(tablePathId);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -118,7 +118,7 @@ public class TablePathIdDao {
                 list.add(tablePath);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
@@ -140,17 +140,16 @@ public class TablePathIdDao {
                 list.add(tablePath);
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(rs, pstmt, conn);
         }
         return list;
     }
 
-    public boolean insert(TablePathId tablePathId) {
+    public void insert(TablePathId tablePathId) {
         Connection conn = null;
         PreparedStatement pstmt = null;
-        boolean result = true;
         try {
             conn = DBConnector.getConn();
             pstmt = conn.prepareStatement("insert into table_path_id (table_path, table_id, table_namespace) values (?, ?, ?)");
@@ -159,12 +158,10 @@ public class TablePathIdDao {
             pstmt.setString(3, tablePathId.getTableNamespace());
             pstmt.execute();
         } catch (SQLException e) {
-            result = false;
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }
-        return result;
     }
 
     public void delete(String tablePath) {
@@ -210,7 +207,7 @@ public class TablePathIdDao {
             pstmt = conn.prepareStatement(sql);
             result = pstmt.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } finally {
             DBConnector.closeConn(pstmt, conn);
         }

--- a/lakesoul-flink/src/main/scala/com/dmetasoul/lakesoul/meta/MetaVersion.scala
+++ b/lakesoul-flink/src/main/scala/com/dmetasoul/lakesoul/meta/MetaVersion.scala
@@ -216,12 +216,7 @@ object MetaVersion {
   }
 
   def rollbackPartitionInfoByVersion(table_id: String, range_value: String, toVersion: Int): Unit = {
-    if (dbManager.rollbackPartitionByVersion(table_id, range_value, toVersion)) {
-      println(range_value + " toVersion " + toVersion + " success")
-    } else {
-      println(range_value + " toVersion " + toVersion + " failed. Please check partition value or versionNum is right")
-    }
-
+    dbManager.rollbackPartitionByVersion(table_id, range_value, toVersion);
   }
 
   def updateTableSchema(table_name: String,

--- a/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/meta/MetaVersion.scala
+++ b/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/meta/MetaVersion.scala
@@ -212,12 +212,7 @@ object MetaVersion {
   }
 
   def rollbackPartitionInfoByVersion(table_id: String, range_value: String, toVersion: Int): Unit = {
-    if (dbManager.rollbackPartitionByVersion(table_id, range_value, toVersion)) {
-      println(range_value + " toVersion " + toVersion + " success")
-    } else {
-      println(range_value + " toVersion " + toVersion + " failed. Please check partition value or versionNum is right")
-    }
-
+    dbManager.rollbackPartitionByVersion(table_id, range_value, toVersion)
   }
 
   def updateTableSchema(table_name: String,

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulSourceUtils.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulSourceUtils.scala
@@ -42,7 +42,6 @@ object LakeSoulSourceUtils {
   }
 
   def isLakeSoulTableExists(path: String): Boolean = {
-    //val table_name = MetaUtils.modifyTableString(path)
     val table_name = path
     MetaVersion.isTableExists(table_name)
   }


### PR DESCRIPTION
Refine exception handling in meta layer.
Only exception for primary key conflict in partition_info table would be handled with retry in DBManager.
All other exceptions are thrown.