### PR TITLE
partition rollback/cleanup add timeZoneId

### DIFF
--- a/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/tables/LakeSoulTable.scala
+++ b/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/tables/LakeSoulTable.scala
@@ -401,8 +401,11 @@ class LakeSoulTable(df: => Dataset[Row], snapshotManagement: SnapshotManagement)
     MetaVersion.rollbackPartitionInfoByVersion(snapshotManagement.getTableInfoOnly.table_id, partitionValue, toVersionNum)
   }
 
-  def rollbackPartition(partitionValue: String, toTime: String): Unit = {
-    val endTime = TimestampFormatter.apply(TimeZone.getTimeZone("GMT+0")).parse(toTime) / 1000
+  def rollbackPartition(partitionValue: String, toTime: String, timeZoneID: String = ""): Unit = {
+    val timeZone =
+      if (timeZoneID.equals("") || !TimeZone.getAvailableIDs.contains(timeZoneID)) TimeZone.getDefault
+      else TimeZone.getTimeZone(timeZoneID)
+    val endTime = TimestampFormatter.apply(timeZone).parse(toTime) / 1000
     val version = MetaVersion.getLastedVersionUptoTime(snapshotManagement.getTableInfoOnly.table_id, partitionValue, endTime)
     if (version < 0) {
       println("No version found in Table before time")
@@ -411,9 +414,11 @@ class LakeSoulTable(df: => Dataset[Row], snapshotManagement: SnapshotManagement)
     }
   }
 
-  def cleanupPartitionData(partitionDesc: String, toTime: String): Unit = {
-    //"1970-01-01 01:00:00"
-    val endTime = TimestampFormatter.apply(TimeZone.getTimeZone("GMT+0")).parse(toTime) / 1000
+  def cleanupPartitionData(partitionDesc: String, toTime: String, timeZoneID: String = ""): Unit = {
+    val timeZone =
+      if (timeZoneID.equals("") || !TimeZone.getAvailableIDs.contains(timeZoneID)) TimeZone.getDefault
+      else TimeZone.getTimeZone(timeZoneID)
+    val endTime = TimestampFormatter.apply(timeZone).parse(toTime) / 1000
     assert(snapshotManagement.snapshot.getTableInfo.range_partition_columns.nonEmpty,
       s"Table `${snapshotManagement.table_path}` is not a range partitioned table, dropTable command can't use on it.")
     executeCleanupPartition(snapshotManagement, partitionDesc, endTime)


### PR DESCRIPTION
partition rollback/cleanup API add timeZoneId, default timeZoneId is null and following with system configuration.