### PR TITLE
[Flink] fix jackson-core package in flink

### DIFF
--- a/lakesoul-flink/pom.xml
+++ b/lakesoul-flink/pom.xml
@@ -189,6 +189,10 @@ SPDX-License-Identifier: Apache-2.0
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>
@@ -405,6 +409,10 @@ SPDX-License-Identifier: Apache-2.0
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/lakesoul-spark/pom.xml
+++ b/lakesoul-spark/pom.xml
@@ -188,12 +188,12 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
             <scope>${local.scope}</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.yaml.version}</version>
-            <scope>${local.scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--hive-->
         <dependency>

--- a/native-io/lakesoul-io-java/pom.xml
+++ b/native-io/lakesoul-io-java/pom.xml
@@ -36,12 +36,6 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
             <version>${arrow.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>


### PR DESCRIPTION
Arrow-vector depends on jackson-core. Flink doesn't package jackson-core by default (flink-s3-hadoop etc. does). So we package it to avoid class not found issue in local testing scenarios.