### PR TITLE
[Flink] Optimize CDC sink serde with Fury

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -95,6 +95,83 @@ jobs:
           name: lakesoul-nativeio-x86_64-apple-darwin
           path: ./native-io/target/release/liblakesoul_io_c.dylib
 
+  build-native-metadata-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2023-05-20
+          default: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./native-metadata -> target"
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: '--manifest-path native-metadata/Cargo.toml --target x86_64-unknown-linux-gnu --release --all-features'
+      - uses: actions/upload-artifact@master
+        with:
+          name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu
+          path: ./native-metadata/target/x86_64-unknown-linux-gnu/release/liblakesoul_metadata_c.so
+
+  build-native-metadata-windows-x86_64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2023-05-20
+          default: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./native-metadata -> target"
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: '--manifest-path native-metadata/Cargo.toml --release --all-features'
+      - uses: actions/upload-artifact@master
+        with:
+          name: lakesoul-nativemetadata-x86_64-pc-windows-msvc
+          path: ./native-metadata/target/release/lakesoul_metadata_c.dll
+
+  build-native-metadata-macos-x86_64:
+    runs-on: macos-latest
+    steps:
+      - name: Install automake
+        run: brew install automake
+      - uses: actions/checkout@v3
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2023-05-20
+          default: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./native-metadata -> target"
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: '--manifest-path native-metadata/Cargo.toml --release --all-features'
+      - uses: actions/upload-artifact@master
+        with:
+          name: lakesoul-nativemetadata-x86_64-apple-darwin
+          path: ./native-metadata/target/release/liblakesoul_metadata_c.dylib
+
+
   deploy-maven-package:
     runs-on: ubuntu-latest
     needs: [build-linux-x86_64, build-windows-x86_64, build-macos-x86_64]
@@ -112,6 +189,18 @@ jobs:
         with:
           name: lakesoul-nativeio-x86_64-pc-windows-msvc
           path: ./native-io/target/release/
+      - uses: actions/download-artifact@v3
+        with:
+          name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu
+          path: ./native-metadata/target/release/
+      - uses: actions/download-artifact@v3
+        with:
+          name: lakesoul-nativemetadata-x86_64-apple-darwin
+          path: ./native-metadata/target/release/
+      - uses: actions/download-artifact@v3
+        with:
+          name: lakesoul-nativemetadata-x86_64-pc-windows-msvc
+          path: ./native-metadata/target/release/
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/flink-cdc-test.yml
+++ b/.github/workflows/flink-cdc-test.yml
@@ -53,6 +53,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -30,12 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: maven
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -124,6 +118,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
           name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu-maven-test
@@ -191,6 +186,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
           name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu-maven-test
@@ -261,6 +257,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
           name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu-maven-test
@@ -328,6 +325,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
           name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu-maven-test
@@ -406,6 +404,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
           name: lakesoul-nativemetadata-x86_64-unknown-linux-gnu-maven-test

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -111,12 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: maven
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -139,12 +133,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: maven
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:
@@ -173,12 +161,6 @@ jobs:
       - name: Install automake
         run: brew install automake
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: maven
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -149,6 +149,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -182,6 +183,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -238,6 +240,7 @@ jobs:
         uses: arduino/setup-protoc@v2
         with:
           version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Maven
         run: |
           MAVEN_OPTS="-Xmx4000m" mvn -q -B package --file pom.xml -Pcross-build -DskipTests -Dmaven.test.skip=true

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/jnr/LibLakeSoulMetaData.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/jnr/LibLakeSoulMetaData.java
@@ -3,12 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.dmetasoul.lakesoul.meta.jnr;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import jnr.ffi.Pointer;
 import jnr.ffi.annotations.Delegate;
 import jnr.ffi.annotations.LongLong;
-
-import java.awt.*;
 
 public interface LibLakeSoulMetaData {
 

--- a/lakesoul-flink/pom.xml
+++ b/lakesoul-flink/pom.xml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>lakesoul-flink</artifactId>
-    <version>2.3.0-flink-1.14-SNAPSHOT</version>
+    <version>2.3.0-flink-1.17-SNAPSHOT</version>
     <properties>
         <flink.version>1.17.1</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
@@ -219,8 +219,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
-            <scope>test</scope>
+            <version>32.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -247,6 +246,11 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
             <version>1.12.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.furyio</groupId>
+            <artifactId>fury-core</artifactId>
+            <version>0.1.0</version>
         </dependency>
 
         <dependency>
@@ -526,6 +530,9 @@ SPDX-License-Identifier: Apache-2.0
                             <include>com.fasterxml.jackson.module:jackson-module-scala_2.12</include>
                             <include>com.fasterxml.jackson.module:jackson-module-paranamer</include>
                             <include>com.thoughtworks.paranamer:paranamer</include>
+                            <include>org.furyio:fury-core</include>
+                            <include>com.google.guava:guava</include>
+                            <include>com.google.guava:failureaccess</include>
 
                             <!-- casbin & aspectj -->
                             <include>org.casbin:jdbc-adapter</include>

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/MysqlCdc.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/MysqlCdc.java
@@ -15,6 +15,7 @@ import org.apache.flink.lakesoul.sink.LakeSoulMultiTableSinkStreamBuilder;
 import org.apache.flink.lakesoul.tool.LakeSoulSinkOptions;
 import org.apache.flink.lakesoul.types.BinaryDebeziumDeserializationSchema;
 import org.apache.flink.lakesoul.types.BinarySourceRecord;
+import org.apache.flink.lakesoul.types.BinarySourceRecordSerializer;
 import org.apache.flink.lakesoul.types.LakeSoulRecordConvert;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -82,6 +83,7 @@ public class MysqlCdc {
         conf.set(ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        env.getConfig().registerTypeWithKryoSerializer(BinarySourceRecord.class, BinarySourceRecordSerializer.class);
 
         ParameterTool pt = ParameterTool.fromMap(conf.toMap());
         env.getConfig().setGlobalJobParameters(pt);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/bucket/BulkFormatBuilder.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/bucket/BulkFormatBuilder.java
@@ -91,12 +91,11 @@ public abstract class BulkFormatBuilder<IN, T extends BulkFormatBuilder<IN, T>>
     }
 
     @Override
-    public abstract AbstractLakeSoulMultiTableSinkWriter<IN> createWriter(Sink.InitContext context, int subTaskId);
+    public abstract AbstractLakeSoulMultiTableSinkWriter<IN> createWriter(Sink.InitContext context, int subTaskId) throws IOException;
 
     @Override
     public LakeSoulSinkCommitter createCommitter() throws IOException {
         return null;
-//        return new LakeSoulSinkCommitter();
     }
 
     @Override

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/bucket/DefaultOneTableBulkFormatBuilder.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/bucket/DefaultOneTableBulkFormatBuilder.java
@@ -13,6 +13,8 @@ import org.apache.flink.lakesoul.sink.writer.LakeSoulRowDataOneTableSinkWriter;
 import org.apache.flink.lakesoul.types.TableSchemaIdentity;
 import org.apache.flink.table.data.RowData;
 
+import java.io.IOException;
+
 /**
  * Builder for the vanilla {@link LakeSoulMultiTablesSink} using a bulk format.
  */
@@ -31,7 +33,8 @@ public final class DefaultOneTableBulkFormatBuilder
     }
 
     @Override
-    public AbstractLakeSoulMultiTableSinkWriter<RowData> createWriter(Sink.InitContext context, int subTaskId) {
+    public AbstractLakeSoulMultiTableSinkWriter<RowData> createWriter(Sink.InitContext context, int subTaskId) throws
+            IOException {
         return new LakeSoulRowDataOneTableSinkWriter(
                 subTaskId,
                 identity,

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/committer/LakeSoulSinkGlobalCommitter.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/committer/LakeSoulSinkGlobalCommitter.java
@@ -126,7 +126,7 @@ public class LakeSoulSinkGlobalCommitter
                         identity.tableLocation, msgSchema, identity.useCDC, identity.cdcColumn, partition);
                 JSONObject properties = new JSONObject();
                 if (isCdc) {
-                    properties.put(USE_CDC.key(), true);
+                    properties.put(USE_CDC.key(), "true");
                     properties.put(CDC_CHANGE_COLUMN, CDC_CHANGE_COLUMN_DEFAULT);
                 }
                 dbManager.createNewTable(tableId, tableNamespace, tableName, identity.tableLocation, msgSchema.json(),

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/writer/LakeSoulMultiTableSinkWriter.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/writer/LakeSoulMultiTableSinkWriter.java
@@ -48,7 +48,8 @@ public class LakeSoulMultiTableSinkWriter extends AbstractLakeSoulMultiTableSink
                 element.getTableLocation(),
                 element.getPrimaryKeys(),
                 element.getPartitionKeys(),
-                element.getData().getProperties());
+                element.getData().getUseCDC(),
+                element.getData().getCdcColumn());
     }
 
     @Override

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/writer/TableSchemaWriterCreator.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/writer/TableSchemaWriterCreator.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.List;
 
 import static com.dmetasoul.lakesoul.meta.DBConfig.LAKESOUL_NULL_STRING;
+import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.*;
 
 public class TableSchemaWriterCreator implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(TableSchemaWriterCreator.class);
@@ -55,7 +56,14 @@ public class TableSchemaWriterCreator implements Serializable {
             Configuration conf) throws IOException {
         TableSchemaWriterCreator creator = new TableSchemaWriterCreator();
         creator.conf = conf;
-        creator.identity = new TableSchemaIdentity(tableId, rowType, tableLocation, primaryKeys, partitionKeyList, FlinkUtil.getPropertiesFromConfiguration(conf));
+        creator.identity =
+                new TableSchemaIdentity(tableId,
+                        rowType,
+                        tableLocation,
+                        primaryKeys,
+                        partitionKeyList,
+                        conf.getBoolean(USE_CDC, false),
+                        conf.getString(CDC_CHANGE_COLUMN, CDC_CHANGE_COLUMN_DEFAULT));
         creator.primaryKeys = primaryKeys;
         creator.partitionKeyList = partitionKeyList;
         creator.outputFileConfig = OutputFileConfig.builder().build();
@@ -65,7 +73,7 @@ public class TableSchemaWriterCreator implements Serializable {
                 rowType.getFieldNames().toArray(new String[0]),
                 rowType,
                 partitionKeyList.toArray(new String[0]),
-                conf.getBoolean(LakeSoulSinkOptions.USE_CDC)
+                conf.getBoolean(USE_CDC)
         );
 
         creator.bucketAssigner = new FlinkBucketAssigner(creator.partitionComputer);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/table/LakeSoulTableSink.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/table/LakeSoulTableSink.java
@@ -120,7 +120,9 @@ public class LakeSoulTableSink implements DynamicTableSink, SupportsPartitioning
         LakeSoulMultiTablesSink<RowData> sink = LakeSoulMultiTablesSink.forOneTableBulkFormat(path,
                         new TableSchemaIdentity(new TableId(io.debezium.relational.TableId.parse(summaryName)), rowType,
                                 path.toString(), primaryKeyList, partitionKeyList,
-                                FlinkUtil.getPropertiesFromConfiguration(flinkConf)), flinkConf)
+                                flinkConf.getBoolean(USE_CDC, false),
+                                flinkConf.getString(CDC_CHANGE_COLUMN, CDC_CHANGE_COLUMN_DEFAULT)
+                        ), flinkConf)
                 .withBucketCheckInterval(flinkConf.getLong(BUCKET_CHECK_INTERVAL)).withRollingPolicy(rollingPolicy)
                 .withOutputFileConfig(fileNameConfig).build();
         return dataStream.sinkTo(sink).setParallelism(bucketParallelism);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/FlinkUtil.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/FlinkUtil.java
@@ -75,7 +75,9 @@ public class FlinkUtil {
             String name = field.getName();
             if (name.equals(SORT_FIELD)) continue;
             LogicalType logicalType = field.getType();
-            org.apache.spark.sql.types.DataType dataType = org.apache.spark.sql.arrow.ArrowUtils.fromArrowField(ArrowUtils.toArrowField(name, logicalType));
+            org.apache.spark.sql.types.DataType
+                    dataType =
+                    org.apache.spark.sql.arrow.ArrowUtils.fromArrowField(ArrowUtils.toArrowField(name, logicalType));
             stNew = stNew.add(name, dataType, logicalType.isNullable());
         }
 
@@ -89,7 +91,15 @@ public class FlinkUtil {
             } else {
                 StructField field = stNew.fields()[(Integer) cdcFieldIndex.get()];
                 if (!field.toString().equals(cdcField.toString()))
-                    throw new CatalogException(CDC_CHANGE_COLUMN + "=" + cdcColName + "has an invalid field of" + field + "," + CDC_CHANGE_COLUMN + " require field of " + cdcField);
+                    throw new CatalogException(CDC_CHANGE_COLUMN +
+                            "=" +
+                            cdcColName +
+                            "has an invalid field of" +
+                            field +
+                            "," +
+                            CDC_CHANGE_COLUMN +
+                            " require field of " +
+                            cdcField);
             }
         }
         return stNew;
@@ -101,7 +111,10 @@ public class FlinkUtil {
         for (int i = 0; i < tsc.getFieldCount(); i++) {
             String name = tsc.getFieldName(i).get();
             DataType dt = tsc.getFieldDataType(i).get();
-            org.apache.spark.sql.types.DataType dataType = org.apache.spark.sql.arrow.ArrowUtils.fromArrowField(ArrowUtils.toArrowField(name, dt.getLogicalType()));
+            org.apache.spark.sql.types.DataType
+                    dataType =
+                    org.apache.spark.sql.arrow.ArrowUtils.fromArrowField(ArrowUtils.toArrowField(name,
+                            dt.getLogicalType()));
             stNew = stNew.add(name, dataType, dt.getLogicalType().isNullable());
         }
         if (cdcColumn.isPresent()) {
@@ -114,7 +127,15 @@ public class FlinkUtil {
             } else {
                 StructField field = stNew.fields()[(Integer) cdcFieldIndex.get()];
                 if (!field.toString().equals(cdcField.toString()))
-                    throw new CatalogException(CDC_CHANGE_COLUMN + "=" + cdcColName + " has an invalid field of " + field + "," + CDC_CHANGE_COLUMN + " require field of " + cdcField);
+                    throw new CatalogException(CDC_CHANGE_COLUMN +
+                            "=" +
+                            cdcColName +
+                            " has an invalid field of " +
+                            field +
+                            "," +
+                            CDC_CHANGE_COLUMN +
+                            " require field of " +
+                            cdcField);
             }
         }
         return stNew;
@@ -178,12 +199,14 @@ public class FlinkUtil {
         JSONObject properties = JSON.parseObject(tableInfo.getProperties());
 
         StructType struct = (StructType) org.apache.spark.sql.types.DataType.fromJson(tableSchema);
-        org.apache.arrow.vector.types.pojo.Schema arrowSchema = org.apache.spark.sql.arrow.ArrowUtils.toArrowSchema(struct, ZoneId.of("UTC").toString());
+        org.apache.arrow.vector.types.pojo.Schema
+                arrowSchema =
+                org.apache.spark.sql.arrow.ArrowUtils.toArrowSchema(struct, ZoneId.of("UTC").toString());
         RowType rowType = ArrowUtils.fromArrowSchema(arrowSchema);
         Builder bd = Schema.newBuilder();
 
         String lakesoulCdcColumnName = properties.getString(CDC_CHANGE_COLUMN);
-        boolean contains = (lakesoulCdcColumnName != null && !"".equals(lakesoulCdcColumnName));
+        boolean contains = (lakesoulCdcColumnName != null && !lakesoulCdcColumnName.isEmpty());
 
         for (RowType.RowField field : rowType.getFields()) {
             if (contains && field.getName().equals(lakesoulCdcColumnName)) {
@@ -282,7 +305,9 @@ public class FlinkUtil {
 
     public static void setFSConfigs(Configuration conf, NativeIOBase io) {
         conf.addAll(GlobalConfiguration.loadConfiguration());
-        org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
+        org.apache.hadoop.conf.Configuration
+                hadoopConf =
+                HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
         String defaultFS = hadoopConf.get("fs.defaultFS");
         io.setObjectStoreOption("fs.defaultFS", defaultFS);
 
@@ -357,7 +382,8 @@ public class FlinkUtil {
         }
     }
 
-    public static Map<String, Map<Integer, List<Path>>> splitDataInfosToRangeAndHashPartition(String tid, DataFileInfo[] dfinfos) {
+    public static Map<String, Map<Integer, List<Path>>> splitDataInfosToRangeAndHashPartition(String tid,
+                                                                                              DataFileInfo[] dfinfos) {
         Map<String, Map<Integer, List<Path>>> splitByRangeAndHashPartition = new LinkedHashMap<>();
         TableInfo tif = DataOperation.dbManager().getTableInfoByTableId(tid);
         for (DataFileInfo pif : dfinfos) {
@@ -393,7 +419,8 @@ public class FlinkUtil {
 
     public static boolean isExistHashPartition(TableInfo tif) {
         JSONObject tableProperties = JSON.parseObject(tif.getProperties());
-        if (tableProperties.containsKey(LakeSoulOptions.HASH_BUCKET_NUM()) && tableProperties.getString(LakeSoulOptions.HASH_BUCKET_NUM()).equals("-1")) {
+        if (tableProperties.containsKey(LakeSoulOptions.HASH_BUCKET_NUM()) &&
+                tableProperties.getString(LakeSoulOptions.HASH_BUCKET_NUM()).equals("-1")) {
             return false;
         } else {
             return tableProperties.containsKey(LakeSoulOptions.HASH_BUCKET_NUM());

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
@@ -1,0 +1,41 @@
+package org.apache.flink.lakesoul.types;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.fury.Fury;
+import io.fury.Language;
+import io.fury.ThreadLocalFury;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.BinarySection;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.io.Serializable;
+
+public class BinarySourceRecordSerializer extends Serializer<BinarySourceRecord> implements Serializable {
+
+    ThreadLocalFury fury;
+
+    public BinarySourceRecordSerializer() {
+        fury = Fury.builder().withLanguage(Language.JAVA)
+                .withCodegen(true)
+                .requireClassRegistration(false)
+                .withClassVersionCheck(false)
+                .withStringCompressed(false)
+                .withNumberCompressed(false)
+                .buildThreadLocalFury();
+    }
+
+    @Override public void write(Kryo kryo, Output output, BinarySourceRecord object) {
+        fury.getCurrentFury().serialize(output, object);
+    }
+
+    @Override public BinarySourceRecord read(Kryo kryo, Input input, Class<BinarySourceRecord> type) {
+        return (BinarySourceRecord) fury.getCurrentFury().deserialize(input);
+    }
+}

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package org.apache.flink.lakesoul.types;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -7,13 +11,6 @@ import com.esotericsoftware.kryo.io.Output;
 import io.fury.Fury;
 import io.fury.Language;
 import io.fury.ThreadLocalFury;
-import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.data.binary.BinarySection;
-import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.RowType;
 
 import java.io.Serializable;
 
@@ -32,10 +29,10 @@ public class BinarySourceRecordSerializer extends Serializer<BinarySourceRecord>
     }
 
     @Override public void write(Kryo kryo, Output output, BinarySourceRecord object) {
-        fury.getCurrentFury().serialize(output, object);
+        fury.getCurrentFury().serializeJavaObject(output, object);
     }
 
     @Override public BinarySourceRecord read(Kryo kryo, Input input, Class<BinarySourceRecord> type) {
-        return (BinarySourceRecord) fury.getCurrentFury().deserialize(input);
+        return fury.getCurrentFury().deserializeJavaObject(input, BinarySourceRecord.class);
     }
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
@@ -12,7 +12,10 @@ import io.fury.Fury;
 import io.fury.Language;
 import io.fury.ThreadLocalFury;
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryFormat;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.BinarySection;
 import org.apache.flink.table.types.logical.*;
 
 import java.io.Serializable;
@@ -32,9 +35,15 @@ public class BinarySourceRecordSerializer extends Serializer<BinarySourceRecord>
                     .withClassLoader(classLoader).build();
             f.register(RowType.class);
             f.register(BinarySourceRecord.class);
+            f.register(RowData.class);
+            f.register(BinaryFormat.class);
+            f.register(BinaryRowData.class);
+            f.register(MemorySegment.class);
+            f.register(BinarySection.class);
             f.register(TableId.class);
             f.register(LakeSoulRowDataWrapper.class);
             f.register(LogicalTypeRoot.class);
+            f.register(LogicalType.class);
             f.register(RowType.RowField.class);
             f.register(ArrayType.class);
             f.register(IntType.class);
@@ -52,8 +61,6 @@ public class BinarySourceRecordSerializer extends Serializer<BinarySourceRecord>
             f.register(DecimalType.class);
             f.register(DoubleType.class);
             f.register(FloatType.class);
-            f.register(BinaryRowData.class);
-            f.register(MemorySegment.class);
             f.register(MapType.class);
             f.register(ArrayType.class);
             f.register(MultisetType.class);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/BinarySourceRecordSerializer.java
@@ -11,6 +11,9 @@ import com.esotericsoftware.kryo.io.Output;
 import io.fury.Fury;
 import io.fury.Language;
 import io.fury.ThreadLocalFury;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.types.logical.*;
 
 import java.io.Serializable;
 
@@ -19,13 +22,52 @@ public class BinarySourceRecordSerializer extends Serializer<BinarySourceRecord>
     ThreadLocalFury fury;
 
     public BinarySourceRecordSerializer() {
-        fury = Fury.builder().withLanguage(Language.JAVA)
-                .withCodegen(true)
-                .requireClassRegistration(false)
-                .withClassVersionCheck(false)
-                .withStringCompressed(false)
-                .withNumberCompressed(false)
-                .buildThreadLocalFury();
+        fury = new ThreadLocalFury(classLoader -> {
+            Fury f = Fury.builder().withLanguage(Language.JAVA)
+                    .withCodegen(true)
+                    .requireClassRegistration(false)
+                    .withClassVersionCheck(false)
+                    .withStringCompressed(false)
+                    .withNumberCompressed(false)
+                    .withClassLoader(classLoader).build();
+            f.register(RowType.class);
+            f.register(BinarySourceRecord.class);
+            f.register(TableId.class);
+            f.register(LakeSoulRowDataWrapper.class);
+            f.register(LogicalTypeRoot.class);
+            f.register(RowType.RowField.class);
+            f.register(ArrayType.class);
+            f.register(IntType.class);
+            f.register(BigIntType.class);
+            f.register(BinaryType.class);
+            f.register(BooleanType.class);
+            f.register(VarBinaryType.class);
+            f.register(CharType.class);
+            f.register(VarCharType.class);
+            f.register(DateType.class);
+            f.register(DayTimeIntervalType.class);
+            f.register(DistinctType.class);
+            f.register(LocalZonedTimestampType.class);
+            f.register(TimestampKind.class);
+            f.register(DecimalType.class);
+            f.register(DoubleType.class);
+            f.register(FloatType.class);
+            f.register(BinaryRowData.class);
+            f.register(MemorySegment.class);
+            f.register(MapType.class);
+            f.register(ArrayType.class);
+            f.register(MultisetType.class);
+            f.register(NullType.class);
+            f.register(RawType.class);
+            f.register(SmallIntType.class);
+            f.register(StructuredType.class);
+            f.register(SymbolType.class);
+            f.register(TimestampType.class);
+            f.register(TimeType.class);
+            f.register(YearMonthIntervalType.class);
+            f.register(ZonedTimestampType.class);
+            return f;
+        });
     }
 
     @Override public void write(Kryo kryo, Output output, BinarySourceRecord object) {

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/LakeSoulRowDataWrapper.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/LakeSoulRowDataWrapper.java
@@ -9,24 +9,25 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
 public class LakeSoulRowDataWrapper {
-    TableId tableId;
-    String op;
-    RowData before;
-    RowData after;
-    RowType beforeType;
-    RowType afterType;
-
-    JSONObject properties;
+    private final TableId tableId;
+    private final String op;
+    private final RowData before;
+    private final RowData after;
+    private final RowType beforeType;
+    private final RowType afterType;
+    private final boolean useCDC;
+    private final String cdcColumn;
 
     public LakeSoulRowDataWrapper(TableId tableId, String op, RowData before, RowData after, RowType beforeType,
-                                  RowType afterType, JSONObject properties) {
+                                  RowType afterType, boolean useCDC, String cdcColumn) {
         this.tableId = tableId;
         this.op = op;
         this.before = before;
         this.after = after;
         this.beforeType = beforeType;
         this.afterType = afterType;
-        this.properties = properties;
+        this.useCDC = useCDC;
+        this.cdcColumn = cdcColumn;
     }
 
     public TableId getTableId() {
@@ -53,8 +54,12 @@ public class LakeSoulRowDataWrapper {
         return op;
     }
 
-    public JSONObject getProperties() {
-        return properties;
+    public boolean getUseCDC() {
+        return useCDC;
+    }
+
+    public String getCdcColumn() {
+        return cdcColumn;
     }
 
     @Override
@@ -66,7 +71,8 @@ public class LakeSoulRowDataWrapper {
                 ", after=" + after +
                 ", beforeType=" + beforeType +
                 ", afterType=" + afterType +
-                ", properties=" + properties +
+                ", useCDC=" + useCDC +
+                ", cdcColumn=" + cdcColumn +
                 '}';
     }
 
@@ -81,8 +87,8 @@ public class LakeSoulRowDataWrapper {
         RowData after;
         RowType beforeType;
         RowType afterType;
-
-        JSONObject properties;
+        boolean useCDC;
+        String cdcColumn;
 
         public Builder setTableId(TableId tableId) {
             this.tableId = tableId;
@@ -114,14 +120,19 @@ public class LakeSoulRowDataWrapper {
             return this;
         }
 
-        public Builder setProperties(JSONObject properties) {
-            this.properties = properties;
+        public Builder setUseCDC(boolean useCDC) {
+            this.useCDC = useCDC;
+            return this;
+        }
+
+        public Builder setCDCColumn(String cdcColumn) {
+            this.cdcColumn = cdcColumn;
             return this;
         }
 
         public LakeSoulRowDataWrapper build() {
             return new LakeSoulRowDataWrapper(this.tableId, this.op, this.before, this.after, this.beforeType,
-                    this.afterType, this.properties);
+                    this.afterType, useCDC, cdcColumn);
         }
     }
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/TableSchemaIdentity.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/types/TableSchemaIdentity.java
@@ -22,16 +22,19 @@ public final class TableSchemaIdentity implements Serializable {
 
     public final List<String> partitionKeyList;
 
-    public final JSONObject properties;
+    public final boolean useCDC;
+
+    public final String cdcColumn;
 
     public TableSchemaIdentity(TableId tableId, RowType rowType, String tableLocation, List<String> primaryKeys,
-                               List<String> partitionKeyList, JSONObject properties) {
+                               List<String> partitionKeyList, boolean useCDC, String cdcColumn) {
         this.tableId = tableId;
         this.rowType = rowType;
         this.tableLocation = tableLocation;
         this.primaryKeys = primaryKeys;
         this.partitionKeyList = partitionKeyList;
-        this.properties = properties;
+        this.useCDC = useCDC;
+        this.cdcColumn = cdcColumn;
     }
 
     @Override
@@ -48,11 +51,15 @@ public final class TableSchemaIdentity implements Serializable {
         return Objects.hash(tableId, rowType);
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return "TableSchemaIdentity{" +
                 "tableId=" + tableId +
                 ", rowType=" + rowType +
+                ", tableLocation='" + tableLocation + '\'' +
+                ", primaryKeys=" + primaryKeys +
+                ", partitionKeyList=" + partitionKeyList +
+                ", useCDC=" + useCDC +
+                ", cdcColumn='" + cdcColumn + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
[Fury](https://github.com/alipay/fury) is an opensourced serialization library using JIT to improve performance.

In LakeSoul's CDC sync job, we need to pass before and after RowData as well as RowType in each record. From Flink's flamegraph we can confirm these objects are causing excessive serde burden.

Using Fury, single core benchmark shows ~80% improvement on end-to-end throughput (numRecordsInPerSecond from 5800 to 10400).

## Before:
![img_v2_c9f87b2a-667c-43f9-b970-f378f6fd006g](https://github.com/lakesoul-io/LakeSoul/assets/1625005/815e78d0-0e84-4998-bc6d-33a2c4c2d704)

## After using Fury:
![img_v2_757278f5-424d-4b8d-8359-dca3a151eddg](https://github.com/lakesoul-io/LakeSoul/assets/1625005/236bdfbe-e202-4d06-a8de-bb91f4f3e917)

