### PR TITLE
[Flink] rollback flink cdc to 2.3.0 and supplement tables check in benchmark

### DIFF
--- a/lakesoul-flink/pom.xml
+++ b/lakesoul-flink/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-sql-connector-mysql-cdc</artifactId>
-            <version>2.4.1</version>
+            <version>2.3.0</version>
         </dependency>
 
         <dependency>

--- a/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/spark/clean/CleanOldCompaction.scala
+++ b/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/spark/clean/CleanOldCompaction.scala
@@ -7,7 +7,6 @@ package com.dmetasoul.lakesoul.spark.clean
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import com.dmetasoul.lakesoul.spark.clean.CleanUtils.sqlToDataframe
-import sun.java2d.marlin.MarlinUtils.logInfo
 
 import scala.collection.mutable.Set
 


### PR DESCRIPTION
Flink cdc 2.4.1 will not capture new sharding table: https://github.com/ververica/flink-cdc-connectors/issues/2306, so rollback to 2.3.0.

This reverts #303 #289