### PR TITLE
add scala in common to address build in idea intellij

### DIFF
--- a/lakesoul-common/pom.xml
+++ b/lakesoul-common/pom.xml
@@ -67,7 +67,27 @@ SPDX-License-Identifier: Apache-2.0
                     <execution>
                         <goals>
                             <goal>compile</goal>
+                            <goal>compile-custom</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-proto-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/target/generated-sources</source>
+                            </sources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -76,9 +96,8 @@ SPDX-License-Identifier: Apache-2.0
 
     <properties>
         <postgresql.version>42.5.1</postgresql.version>
-        <debezium.version>1.5.4.Final</debezium.version>
+        <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <mysql.version>8.0.30</mysql.version>
         <local.scope>provided</local.scope>
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
         <protoc.version>3.5.1</protoc.version>
@@ -105,6 +124,25 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.83</version>
+        </dependency>
+        <!-- scala deps -->
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>${local.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
+            <scope>${local.scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+            <scope>${local.scope}</scope>
         </dependency>
         <!-- casbin -->
         <dependency>

--- a/lakesoul-common/pom.xml
+++ b/lakesoul-common/pom.xml
@@ -67,7 +67,6 @@ SPDX-License-Identifier: Apache-2.0
                     <execution>
                         <goals>
                             <goal>compile</goal>
-                            <goal>compile-custom</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Idea Intellij may complain 'No scalac found' when building lakesoul-common. So add scala dependencies to avoid this.