### PR TITLE
[Flink] Ignore exception when hadoop env missing

### DIFF
--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/FlinkUtil.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/FlinkUtil.java
@@ -305,11 +305,16 @@ public class FlinkUtil {
 
     public static void setFSConfigs(Configuration conf, NativeIOBase io) {
         conf.addAll(GlobalConfiguration.loadConfiguration());
-        org.apache.hadoop.conf.Configuration
-                hadoopConf =
-                HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
-        String defaultFS = hadoopConf.get("fs.defaultFS");
-        io.setObjectStoreOption("fs.defaultFS", defaultFS);
+        try {
+            FlinkUtil.class.getClassLoader().loadClass("org.apache.hadoop.hdfs.HdfsConfiguration");
+            org.apache.hadoop.conf.Configuration
+                    hadoopConf =
+                    HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
+            String defaultFS = hadoopConf.get("fs.defaultFS");
+            io.setObjectStoreOption("fs.defaultFS", defaultFS);
+        } catch (Exception e) {
+            // ignore
+        }
 
         // try hadoop's s3 configs
         setFSConf(conf, "fs.s3a.access.key", "fs.s3a.access.key", io);


### PR DESCRIPTION
Ignore class not found exception when there's no hadoop env.