### PR TITLE
[Bug] turn off native meta query and temporarily disable io prefetch

### DIFF
--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/jnr/NativeUtils.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/jnr/NativeUtils.java
@@ -6,9 +6,9 @@ package com.dmetasoul.lakesoul.meta.jnr;
 
 public class NativeUtils {
 
-    public static boolean NATIVE_METADATA_QUERY_ENABLED = true;
+    public static boolean NATIVE_METADATA_QUERY_ENABLED = false;
 
-    public static boolean NATIVE_METADATA_UPDATE_ENABLED = true;
+    public static boolean NATIVE_METADATA_UPDATE_ENABLED = false;
 
     public static int NATIVE_METADATA_MAX_RETRY_ATTEMPTS = 3;
 

--- a/lakesoul-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/NativeVectorizedReader.java
+++ b/lakesoul-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/NativeVectorizedReader.java
@@ -369,7 +369,7 @@ public class NativeVectorizedReader extends SpecificParquetRecordReaderBase<Obje
 
     private StructType requestSchema = null;
 
-    private int prefetchBufferSize = 2;
+    private int prefetchBufferSize = 1;
 
     private int threadNum = 2;
 

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulSQLConf.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulSQLConf.scala
@@ -112,7 +112,7 @@ object LakeSoulSQLConf {
            |If NATIVE_IO_ENABLE=true, NATIVE_IO_PREFETCHER_BUFFER_SIZE of batches will be buffered while native-io prefetching
         """.stripMargin)
       .intConf
-      .createWithDefault(2)
+      .createWithDefault(1)
 
   val NATIVE_IO_WRITE_MAX_ROW_GROUP_SIZE: ConfigEntry[Int] =
     buildConf("native.io.write.max.rowgroup.size")

--- a/rust/lakesoul-io/src/lakesoul_io_config.rs
+++ b/rust/lakesoul-io/src/lakesoul_io_config.rs
@@ -51,7 +51,7 @@ pub struct LakeSoulIOConfig {
     // write row group max row num
     #[derivative(Default(value = "250000"))]
     pub(crate) max_row_group_size: usize,
-    #[derivative(Default(value = "2"))]
+    #[derivative(Default(value = "1"))]
     pub(crate) prefetch_size: usize,
 
     // arrow schema


### PR DESCRIPTION
 turn off native meta query and set prefetch_size=1 for reading large data error 