### PR TITLE
[Spark]optimize incremental read and fix compact operation cause column disorder bug

### DIFF
--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/DBManager.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/DBManager.java
@@ -200,7 +200,7 @@ public class DBManager {
         if (StringUtils.isNotBlank(partitionDesc)) {
             deleteSinglePartitionMetaInfo(tableId, partitionDesc, utcMills, fileOps, deleteFilePathList);
         } else {
-            List<String> allPartitionDesc = partitionInfoDao.getAllPartitionDescByTableId(tableId);
+            List<String> allPartitionDesc = getTableAllPartitionDesc(tableId);
             allPartitionDesc.forEach(partition -> deleteSinglePartitionMetaInfo(tableId, partition, utcMills, fileOps,
                     deleteFilePathList));
         }
@@ -880,6 +880,10 @@ public class DBManager {
             newProperties.put("domain", originProperties.get("domain"));
         }
         namespaceDao.updatePropertiesByNamespace(namespace, newProperties.toJSONString());
+    }
+
+    public List<String> getTableAllPartitionDesc(String tableId) {
+        return partitionInfoDao.getAllPartitionDescByTableId(tableId);
     }
 
     public void deleteNamespace(String namespace) {

--- a/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/spark/clean/CleanExpiredData.scala
+++ b/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/spark/clean/CleanExpiredData.scala
@@ -11,11 +11,12 @@ import com.dmetasoul.lakesoul.spark.clean.CleanUtils.sqlToDataframe
 import org.apache.hadoop.fs.Path
 
 import java.time.{LocalDateTime, Period, ZoneId}
+import java.util.TimeZone
 
 object CleanExpiredData {
 
   private val conn = DBConnector.getConn
-  var serverTimeZone = ""
+  var serverTimeZone = TimeZone.getDefault.getID
 
   def main(args: Array[String]): Unit = {
     val parameter = ParametersTool.fromArgs(args)

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/TransactionalWrite.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/TransactionalWrite.scala
@@ -7,18 +7,19 @@ package org.apache.spark.sql.lakesoul
 import com.dmetasoul.lakesoul.meta.{CommitType, DataFileInfo}
 import com.dmetasoul.lakesoul.meta.DBConfig.LAKESOUL_RANGE_PARTITION_SPLITTER
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.{Column, Dataset}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, EqualTo, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CaseWhen, EqualNullSafe, EqualTo, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, WriteJobStatsTracker}
-import org.apache.spark.sql.execution.{ProjectExec, QueryExecution, SQLExecution}
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.execution.{FilterExec, ProjectExec, QueryExecution, SQLExecution}
+import org.apache.spark.sql.functions.{col, expr, lit}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.lakesoul.exception.LakeSoulErrors
 import org.apache.spark.sql.lakesoul.schema.{InvariantCheckerExec, Invariants, SchemaUtils}
 import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
 import org.apache.spark.sql.lakesoul.utils.SparkUtil
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{BooleanType, StringType, StructType}
 import org.apache.spark.util.SerializableConfiguration
 
 import scala.collection.mutable
@@ -149,12 +150,13 @@ trait TransactionalWrite {
         if (cdcCol.nonEmpty) {
           val tmpSparkPlan = queryExecution.executedPlan
           val outColumns = outputSpec.outputColumns
-          val nonCdcAttrCols = outColumns.filter(p => (!p.name.equalsIgnoreCase(cdcCol.get)))
           val cdcAttrCol = outColumns.filter(p => p.name.equalsIgnoreCase(cdcCol.get))
+          val pos = outColumns.indexOf(cdcAttrCol(0))
           val cdcCaseWhen = CaseWhen.createFromParser(Seq(EqualTo(cdcAttrCol(0), Literal("update")), Literal("insert"), cdcAttrCol(0)))
           val alias = Alias(cdcCaseWhen, cdcCol.get)()
-          val allAttrCols = nonCdcAttrCols :+ alias
-          ProjectExec(allAttrCols, tmpSparkPlan)
+          val allAttrCols = outColumns.updated(pos, alias)
+          val filterCdcAdd = FilterExec(Not(EqualTo(cdcAttrCol(0), Literal("delete"))), tmpSparkPlan)
+          ProjectExec(allAttrCols, filterCdcAdd)
         } else {
           queryExecution.executedPlan
         }

--- a/rust/lakesoul-metadata/src/lib.rs
+++ b/rust/lakesoul-metadata/src/lib.rs
@@ -217,7 +217,7 @@ fn get_prepared_statement(
                 // Select PartitionInfo
                 DaoType::SelectPartitionVersionByTableIdAndDescAndVersion =>
                     "select table_id, partition_desc, version, commit_op, snapshot, expression, domain 
-                    from partition_info from partition_info 
+                    from partition_info
                     where table_id = $1::TEXT and partition_desc = $2::TEXT and version = $3::INT",
                 DaoType::SelectOnePartitionVersionByTableIdAndDesc =>
                     "select m.table_id, t.partition_desc, m.version, m.commit_op, m.snapshot, m.expression, m.domain from (
@@ -1287,7 +1287,7 @@ pub fn execute_query_scalar(
             });
             match result {
                 Ok(Some(row)) => {
-                    let ts = row.get::<_, Option<i64>>(0);
+                    let ts = row.get::<_, Option<i32>>(0);
                     match ts {
                         Some(ts) => Ok(Some(format!("{}", ts))),
                         None => Ok(None)


### PR DESCRIPTION
1. Optimize incremental read: if start timestamp is earliest time of data，reading data from the last version before the end time；
2. Fix compact operation cause column disorder bug and filter rows when cdc column exists and the value is 'delete';
3. Automatically Clean Up Expired Data Task add time zone parameter.