### PR TITLE
[Spark] support call sql syntax

### DIFF
--- a/lakesoul-spark/src/main/antlr4/org.apache.spark.sql.catalyst.parser.extensions/LakeSoulSqlExtensions.g4
+++ b/lakesoul-spark/src/main/antlr4/org.apache.spark.sql.catalyst.parser.extensions/LakeSoulSqlExtensions.g4
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+grammar LakeSoulSqlExtensions;
+
+@lexer::members {
+  /**
+   * Verify whether current token is a valid decimal token (which contains dot).
+   * Returns true if the character that follows the token is not a digit or letter or underscore.
+   *
+   * For example:
+   * For char stream "2.3", "2." is not a valid decimal token, because it is followed by digit '3'.
+   * For char stream "2.3_", "2.3" is not a valid decimal token, because it is followed by '_'.
+   * For char stream "2.3W", "2.3" is not a valid decimal token, because it is followed by 'W'.
+   * For char stream "12.0D 34.E2+0.12 "  12.0D is a valid decimal token because it is followed
+   * by a space. 34.E2 is a valid decimal token because it is followed by symbol '+'
+   * which is not a digit or letter or underscore.
+   */
+  public boolean isValidDecimal() {
+    int nextChar = _input.LA(1);
+    if (nextChar >= 'A' && nextChar <= 'Z' || nextChar >= '0' && nextChar <= '9' ||
+      nextChar == '_') {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * This method will be called when we see '/*' and try to match it as a bracketed comment.
+   * If the next character is '+', it should be parsed as hint later, and we cannot match
+   * it as a bracketed comment.
+   *
+   * Returns true if the next character is '+'.
+   */
+  public boolean isHint() {
+    int nextChar = _input.LA(1);
+    if (nextChar == '+') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+singleStatement
+    : statement EOF
+    ;
+
+statement
+    : CALL multipartIdentifier '(' (callArgument (',' callArgument)*)? ')'                  #call
+    ;
+
+callArgument
+    : expression                    #positionalArgument
+    | identifier '=>' expression    #namedArgument
+    ;
+
+expression
+    : constant
+    | stringMap
+    | stringArray
+    ;
+
+constant
+    : number                          #numericLiteral
+    | booleanValue                    #booleanLiteral
+    | STRING+                         #stringLiteral
+    | identifier STRING               #typeConstructor
+    ;
+
+stringMap
+    : MAP '(' constant (',' constant)* ')'
+    ;
+
+stringArray
+    : ARRAY '(' constant (',' constant)* ')'
+    ;
+
+booleanValue
+    : TRUE | FALSE
+    ;
+
+number
+    : MINUS? EXPONENT_VALUE           #exponentLiteral
+    | MINUS? DECIMAL_VALUE            #decimalLiteral
+    | MINUS? INTEGER_VALUE            #integerLiteral
+    | MINUS? BIGINT_LITERAL           #bigIntLiteral
+    | MINUS? SMALLINT_LITERAL         #smallIntLiteral
+    | MINUS? TINYINT_LITERAL          #tinyIntLiteral
+    | MINUS? DOUBLE_LITERAL           #doubleLiteral
+    | MINUS? FLOAT_LITERAL            #floatLiteral
+    | MINUS? BIGDECIMAL_LITERAL       #bigDecimalLiteral
+    ;
+
+multipartIdentifier
+    : parts+=identifier ('.' parts+=identifier)*
+    ;
+
+identifier
+    : IDENTIFIER              #unquotedIdentifier
+    | quotedIdentifier        #quotedIdentifierAlternative
+    | nonReserved             #unquotedIdentifier
+    ;
+
+quotedIdentifier
+    : BACKQUOTED_IDENTIFIER
+    ;
+
+fieldList
+    : fields+=multipartIdentifier (',' fields+=multipartIdentifier)*
+    ;
+
+nonReserved
+    : ADD | ALTER | AS | ASC | BRANCH | BY | CALL | CREATE | DAYS | DESC | DROP | EXISTS | FIELD | FIRST | HOURS | IF | LAST | NOT | NULLS | OF | OR | ORDERED | PARTITION | TABLE | WRITE
+    | DISTRIBUTED | LOCALLY | MINUTES | MONTHS | UNORDERED | REPLACE | RETAIN | RETENTION | VERSION | WITH | IDENTIFIER_KW | FIELDS | SET | SNAPSHOT | SNAPSHOTS
+    | TRUE | FALSE
+    | MAP
+    ;
+
+ADD: 'ADD';
+ALTER: 'ALTER';
+AS: 'AS';
+ASC: 'ASC';
+BRANCH: 'BRANCH';
+BY: 'BY';
+CALL: 'CALL';
+CREATE: 'CREATE';
+DAYS: 'DAYS';
+DESC: 'DESC';
+DISTRIBUTED: 'DISTRIBUTED';
+DROP: 'DROP';
+EXISTS: 'EXISTS';
+FIELD: 'FIELD';
+FIELDS: 'FIELDS';
+FIRST: 'FIRST';
+HOURS: 'HOURS';
+IF : 'IF';
+LAST: 'LAST';
+LOCALLY: 'LOCALLY';
+MINUTES: 'MINUTES';
+MONTHS: 'MONTHS';
+NOT: 'NOT';
+NULLS: 'NULLS';
+OF: 'OF';
+OR: 'OR';
+ORDERED: 'ORDERED';
+PARTITION: 'PARTITION';
+REPLACE: 'REPLACE';
+RETAIN: 'RETAIN';
+RETENTION: 'RETENTION';
+IDENTIFIER_KW: 'IDENTIFIER';
+SET: 'SET';
+SNAPSHOT: 'SNAPSHOT';
+SNAPSHOTS: 'SNAPSHOTS';
+TABLE: 'TABLE';
+UNORDERED: 'UNORDERED';
+VERSION: 'VERSION';
+WITH: 'WITH';
+WRITE: 'WRITE';
+
+TRUE: 'TRUE';
+FALSE: 'FALSE';
+
+MAP: 'MAP';
+ARRAY: 'ARRAY';
+
+PLUS: '+';
+MINUS: '-';
+
+STRING
+    : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''
+    | '"' ( ~('"'|'\\') | ('\\' .) )* '"'
+    ;
+
+BIGINT_LITERAL
+    : DIGIT+ 'L'
+    ;
+
+SMALLINT_LITERAL
+    : DIGIT+ 'S'
+    ;
+
+TINYINT_LITERAL
+    : DIGIT+ 'Y'
+    ;
+
+INTEGER_VALUE
+    : DIGIT+
+    ;
+
+EXPONENT_VALUE
+    : DIGIT+ EXPONENT
+    | DECIMAL_DIGITS EXPONENT {isValidDecimal()}?
+    ;
+
+DECIMAL_VALUE
+    : DECIMAL_DIGITS {isValidDecimal()}?
+    ;
+
+FLOAT_LITERAL
+    : DIGIT+ EXPONENT? 'F'
+    | DECIMAL_DIGITS EXPONENT? 'F' {isValidDecimal()}?
+    ;
+
+DOUBLE_LITERAL
+    : DIGIT+ EXPONENT? 'D'
+    | DECIMAL_DIGITS EXPONENT? 'D' {isValidDecimal()}?
+    ;
+
+BIGDECIMAL_LITERAL
+    : DIGIT+ EXPONENT? 'BD'
+    | DECIMAL_DIGITS EXPONENT? 'BD' {isValidDecimal()}?
+    ;
+
+IDENTIFIER
+    : (LETTER | DIGIT | '_')+
+    ;
+
+BACKQUOTED_IDENTIFIER
+    : '`' ( ~'`' | '``' )* '`'
+    ;
+
+fragment DECIMAL_DIGITS
+    : DIGIT+ '.' DIGIT*
+    | '.' DIGIT+
+    ;
+
+fragment EXPONENT
+    : 'E' [+-]? DIGIT+
+    ;
+
+fragment DIGIT
+    : [0-9]
+    ;
+
+fragment LETTER
+    : [A-Z]
+    ;
+
+SIMPLE_COMMENT
+    : '--' ('\\\n' | ~[\r\n])* '\r'? '\n'? -> channel(HIDDEN)
+    ;
+
+BRACKETED_COMMENT
+    : '/*' {!isHint()}? (BRACKETED_COMMENT|.)*? '*/' -> channel(HIDDEN)
+    ;
+
+WS
+    : [ \r\n\t]+ -> channel(HIDDEN)
+    ;
+
+// Catch-all for anything we can't recognize.
+// We use this to be able to ignore and recover all the text
+// when splitting statements with DelimiterLexer
+UNRECOGNIZED
+    : .
+    ;

--- a/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/sql/LakeSoulSparkSessionExtension.scala
+++ b/lakesoul-spark/src/main/scala/com/dmetasoul/lakesoul/sql/LakeSoulSparkSessionExtension.scala
@@ -5,6 +5,7 @@
 package com.dmetasoul.lakesoul.sql
 
 import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSparkSqlExtensionsParser
 import org.apache.spark.sql.lakesoul.rules._
 
 /**
@@ -59,11 +60,8 @@ import org.apache.spark.sql.lakesoul.rules._
 class LakeSoulSparkSessionExtension extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {
-    //    extensions.injectParser { (session, parser) =>
-    //      new LakeSoulSqlParser(parser)
-    //    }
 
-
+    extensions.injectParser{ case (_,parser) => new LakeSoulSparkSqlExtensionsParser(parser)}
     extensions.injectResolutionRule { session =>
       ExtractMergeOperator(session)
     }
@@ -103,7 +101,9 @@ class LakeSoulSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule { session =>
       ProcessCDCTableMergeOnRead(session.sessionState.conf)
     }
-
+    extensions.injectResolutionRule { session =>
+      ProcessCall(session)
+    }
     extensions.injectPlannerStrategy { session =>
       SetPartitionAndOrdering(session)
     }

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSparkSqlExtensionsParser.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSparkSqlExtensionsParser.scala
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.apache.parquet.util.DynConstructors
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.command.ExplainCommand
+import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.internal.VariableSubstitution
+import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.atn.PredictionMode
+import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
+import org.antlr.v4.runtime.tree.TerminalNodeImpl
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.{NonReservedContext, QuotedIdentifierContext}
+
+import java.util.Locale
+
+class LakeSoulSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface {
+  private lazy val substitutor = new VariableSubstitution
+  private lazy val astBuilder = new LakeSoulSqlExtensionsAstBuilder(delegate)
+
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    val sqlTextAfter = substitutor.substitute(sqlText)
+    if(isLakeSoulCommand(sqlTextAfter)){
+      parse(sqlTextAfter) { parser => astBuilder.visit(parser.singleStatement()) }.asInstanceOf[LogicalPlan]
+
+    }else{
+      delegate.parsePlan(sqlText)
+    }
+  }
+  protected def parse[T](command: String)(toResult: LakeSoulSqlExtensionsParser => T): T = {
+    val lexer = new LakeSoulSqlExtensionsLexer(new UpperCaseCharStream(CharStreams.fromString(command)))
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(LakeSoulParseErrorListener)
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser = new LakeSoulSqlExtensionsParser(tokenStream)
+    parser.addParseListener(IcebergSqlExtensionsPostProcessor)
+    parser.removeErrorListeners()
+    parser.addErrorListener(LakeSoulParseErrorListener)
+    try {
+      try {
+        // first, try parsing with potentially faster SLL mode
+        parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
+        toResult(parser)
+      }
+      catch {
+        case _: ParseCancellationException =>
+          // if we fail, parse with LL mode
+          tokenStream.seek(0) // rewind input stream
+          parser.reset()
+
+          // Try Again.
+          parser.getInterpreter.setPredictionMode(PredictionMode.LL)
+          toResult(parser)
+      }
+    }
+    catch {
+      case e: LakeSoulParseException if e.command.isDefined =>
+        throw e
+      case e: LakeSoulParseException =>
+        throw e.withCommand(command)
+      case e: AnalysisException =>
+        val position = Origin(e.line, e.startPosition)
+        throw new LakeSoulParseException(Option(command), e.message, position, position)
+    }
+  }
+
+  /**
+   * Parse a string to a DataType.
+   */
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+
+  /**
+   * Parse a string to a raw DataType without CHAR/VARCHAR replacement.
+   */
+  def parseRawDataType(sqlText: String): DataType = throw new UnsupportedOperationException()
+
+  /**
+   * Parse a string to an Expression.
+   */
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  /**
+   * Parse a string to a TableIdentifier.
+   */
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  /**
+   * Parse a string to a FunctionIdentifier.
+   */
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  /**
+   * Parse a string to a multi-part identifier.
+   */
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  /**
+   * Creates StructType for a given SQL string, which is a comma separated list of field
+   * definitions which will preserve the correct Hive metadata.
+   */
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+
+  override def parseQuery(sqlText: String): LogicalPlan = ???
+
+
+  private def isLakeSoulCommand(sqlText: String): Boolean = {
+    val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
+      // Strip simple SQL comments that terminate a line, e.g. comments starting with `--` .
+      .replaceAll("--.*?\\n", " ")
+      // Strip newlines.
+      .replaceAll("\\s+", " ")
+      // Strip comments of the form  /* ... */. This must come after stripping newlines so that
+      // comments that span multiple lines are caught.
+      .replaceAll("/\\*.*?\\*/", " ")
+      .trim()
+    normalized.startsWith("call")
+  }
+}
+case object IcebergSqlExtensionsPostProcessor extends LakeSoulSqlExtensionsListener {
+
+  /** Remove the back ticks from an Identifier. */
+  override def exitQuotedIdentifier(ctx: QuotedIdentifierContext): Unit = {
+    replaceTokenByIdentifier(ctx, 1) { token =>
+      // Remove the double back ticks in the string.
+      token.setText(token.getText.replace("``", "`"))
+      token
+    }
+  }
+
+  /** Treat non-reserved keywords as Identifiers. */
+  override def exitNonReserved(ctx: NonReservedContext): Unit = {
+    replaceTokenByIdentifier(ctx, 0)(identity)
+  }
+
+  private def replaceTokenByIdentifier(
+                                        ctx: ParserRuleContext,
+                                        stripMargins: Int)(
+                                        f: CommonToken => CommonToken = identity): Unit = {
+    val parent = ctx.getParent
+    parent.removeLastChild()
+    val token = ctx.getChild(0).getPayload.asInstanceOf[Token]
+    val newToken = new CommonToken(
+      new org.antlr.v4.runtime.misc.Pair(token.getTokenSource, token.getInputStream),
+      LakeSoulSqlExtensionsParser.IDENTIFIER,
+      token.getChannel,
+      token.getStartIndex + stripMargins,
+      token.getStopIndex - stripMargins)
+    parent.addChild(new TerminalNodeImpl(f(newToken)))
+  }
+}
+
+class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
+  override def consume(): Unit = wrapped.consume
+  override def getSourceName(): String = wrapped.getSourceName
+  override def index(): Int = wrapped.index
+  override def mark(): Int = wrapped.mark
+  override def release(marker: Int): Unit = wrapped.release(marker)
+  override def seek(where: Int): Unit = wrapped.seek(where)
+  override def size(): Int = wrapped.size
+
+  override def getText(interval: Interval): String = wrapped.getText(interval)
+
+  // scalastyle:off
+  override def LA(i: Int): Int = {
+    val la = wrapped.LA(i)
+    if (la == 0 || la == IntStream.EOF) la
+    else Character.toUpperCase(la)
+  }
+  // scalastyle:on
+}
+class LakeSoulParseException(
+                             val command: Option[String],
+                             message: String,
+                             val start: Origin,
+                             val stop: Origin) extends AnalysisException(message, start.line, start.startPosition) {
+
+  def this(message: String, ctx: ParserRuleContext) = {
+    this(Option(LakeSoulParserUtils.command(ctx)),
+      message,
+      LakeSoulParserUtils.position(ctx.getStart),
+      LakeSoulParserUtils.position(ctx.getStop))
+  }
+
+  override def getMessage: String = {
+    val builder = new StringBuilder
+    builder ++= "\n" ++= message
+    start match {
+      case Origin(Some(l), Some(p),Some(t),Some(m),Some(n),Some(s),Some(o)) =>
+        builder ++= s"(line $l, pos $p)\n"
+        command.foreach { cmd =>
+          val (above, below) = cmd.split("\n").splitAt(l)
+          builder ++= "\n== SQL ==\n"
+          above.foreach(builder ++= _ += '\n')
+          builder ++= (0 until p).map(_ => "-").mkString("") ++= "^^^\n"
+          below.foreach(builder ++= _ += '\n')
+        }
+      case _ =>
+        command.foreach { cmd =>
+          builder ++= "\n== SQL ==\n" ++= cmd
+        }
+    }
+    builder.toString
+  }
+
+  def withCommand(cmd: String): LakeSoulParseException = {
+    new LakeSoulParseException(Option(cmd), message, start, stop)
+  }
+}
+case object LakeSoulParseErrorListener extends BaseErrorListener {
+  override def syntaxError(
+                            recognizer: Recognizer[_, _],
+                            offendingSymbol: scala.Any,
+                            line: Int,
+                            charPositionInLine: Int,
+                            msg: String,
+                            e: RecognitionException): Unit = {
+    val (start, stop) = offendingSymbol match {
+      case token: CommonToken =>
+        val start = Origin(Some(line), Some(token.getCharPositionInLine))
+        val length = token.getStopIndex - token.getStartIndex + 1
+        val stop = Origin(Some(line), Some(token.getCharPositionInLine + length))
+        (start, stop)
+      case _ =>
+        val start = Origin(Some(line), Some(charPositionInLine))
+        (start, start)
+    }
+    throw new LakeSoulParseException(None, msg, start, stop)
+  }
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSparkSqlExtensionsParser.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSparkSqlExtensionsParser.scala
@@ -120,7 +120,9 @@ class LakeSoulSparkSqlExtensionsParser(delegate: ParserInterface) extends Parser
   }
 
 
-  override def parseQuery(sqlText: String): LogicalPlan = ???
+  override def parseQuery(sqlText: String): LogicalPlan = {
+    delegate.parseQuery(sqlText)
+  }
 
 
   private def isLakeSoulCommand(sqlText: String): Boolean = {

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsAstBuilder.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsAstBuilder.scala
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.antlr.v4.runtime.misc.Interval
+import org.antlr.v4.runtime.tree.{ErrorNode, ParseTree, RuleNode, TerminalNode}
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.extensions.LakeSoulParserUtils.withOrigin
+import org.apache.spark.sql.catalyst.plans.logical.{CallArgument, CallStatement, LogicalPlan,NamedArgument,PositionalArgument}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
+
+import scala.collection.JavaConverters._
+
+
+class LakeSoulSqlExtensionsAstBuilder(delegate: ParserInterface) extends LakeSoulSqlExtensionsBasicVisitor[AnyRef]{
+  private def toSeq[T](list: java.util.List[T]): Seq[T] = toBuffer(list).toSeq
+  private def toBuffer[T](list: java.util.List[T]): scala.collection.mutable.Buffer[T] = list.asScala
+
+  override def visitSingleStatement(ctx: org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SingleStatementContext): LogicalPlan = {
+    visit(ctx.statement).asInstanceOf[LogicalPlan]
+
+  }
+  override def visitCall(ctx: org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.CallContext): CallStatement = withOrigin(ctx) {
+    val name = toSeq(ctx.multipartIdentifier.parts).map(_.getText)
+    val args = toSeq(ctx.callArgument).map(typedVisit[CallArgument])
+    CallStatement(name, args)
+  }
+  override def visitPositionalArgument(ctx: org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.PositionalArgumentContext): CallArgument = withOrigin(ctx) {
+    val expr = typedVisit[Expression](ctx.expression)
+    PositionalArgument(expr)
+  }
+  override def visitNamedArgument(ctx: org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NamedArgumentContext): NamedArgument = withOrigin(ctx) {
+    val name = ctx.identifier.getText
+    val expr = typedVisit[Expression](ctx.expression)
+    NamedArgument(name, expr)
+  }
+
+  override def visitExpression(ctx: org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExpressionContext): Expression = {
+    // reconstruct the SQL string and parse it using the main Spark parser
+    // while we can avoid the logic to build Spark expressions, we still have to parse them
+    // we cannot call ctx.getText directly since it will not render spaces correctly
+    // that's why we need to recurse down the tree in reconstructSqlString
+    val sqlString = reconstructSqlString(ctx)
+    delegate.parseExpression(sqlString)
+  }
+
+  override def visitMultipartIdentifier(ctx: org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.MultipartIdentifierContext): Seq[String] = withOrigin(ctx) {
+    toSeq(ctx.parts).map(_.getText)
+  }
+
+  private def typedVisit[T](ctx: ParseTree): T = {
+    ctx.accept(this).asInstanceOf[T]
+  }
+
+  private def reconstructSqlString(ctx: ParserRuleContext): String = {
+    toBuffer(ctx.children).map {
+      case c: ParserRuleContext => reconstructSqlString(c)
+      case t: TerminalNode => t.getText
+    }.mkString(" ")
+  }
+
+}
+
+
+object LakeSoulParserUtils {
+
+  private[sql] def withOrigin[T](ctx: ParserRuleContext)(f: => T): T = {
+    val current = CurrentOrigin.get
+    CurrentOrigin.set(position(ctx.getStart))
+    try {
+      f
+    } finally {
+      CurrentOrigin.set(current)
+    }
+  }
+
+  private[sql] def position(token: Token): Origin = {
+    val opt = Option(token)
+    Origin(opt.map(_.getLine), opt.map(_.getCharPositionInLine))
+  }
+
+  /** Get the command which created the token. */
+  private[sql] def command(ctx: ParserRuleContext): String = {
+    val stream = ctx.getStart.getInputStream
+    stream.getText(Interval.of(0, stream.size() - 1))
+  }
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsBasicVisitor.java
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsBasicVisitor.java
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions;
+
+import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
+
+public class LakeSoulSqlExtensionsBasicVisitor<T> extends AbstractParseTreeVisitor<T> implements LakeSoulSqlExtensionsVisitor<T>{
+    @Override
+    public T visitSingleStatement(LakeSoulSqlExtensionsParser.SingleStatementContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitCall(LakeSoulSqlExtensionsParser.CallContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitPositionalArgument(LakeSoulSqlExtensionsParser.PositionalArgumentContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitNamedArgument(LakeSoulSqlExtensionsParser.NamedArgumentContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitExpression(LakeSoulSqlExtensionsParser.ExpressionContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitNumericLiteral(LakeSoulSqlExtensionsParser.NumericLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitBooleanLiteral(LakeSoulSqlExtensionsParser.BooleanLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitStringLiteral(LakeSoulSqlExtensionsParser.StringLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitTypeConstructor(LakeSoulSqlExtensionsParser.TypeConstructorContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitStringMap(LakeSoulSqlExtensionsParser.StringMapContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitStringArray(LakeSoulSqlExtensionsParser.StringArrayContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitBooleanValue(LakeSoulSqlExtensionsParser.BooleanValueContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitExponentLiteral(LakeSoulSqlExtensionsParser.ExponentLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitDecimalLiteral(LakeSoulSqlExtensionsParser.DecimalLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitIntegerLiteral(LakeSoulSqlExtensionsParser.IntegerLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitBigIntLiteral(LakeSoulSqlExtensionsParser.BigIntLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitSmallIntLiteral(LakeSoulSqlExtensionsParser.SmallIntLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitTinyIntLiteral(LakeSoulSqlExtensionsParser.TinyIntLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitDoubleLiteral(LakeSoulSqlExtensionsParser.DoubleLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitFloatLiteral(LakeSoulSqlExtensionsParser.FloatLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitBigDecimalLiteral(LakeSoulSqlExtensionsParser.BigDecimalLiteralContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitMultipartIdentifier(LakeSoulSqlExtensionsParser.MultipartIdentifierContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitUnquotedIdentifier(LakeSoulSqlExtensionsParser.UnquotedIdentifierContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitQuotedIdentifierAlternative(LakeSoulSqlExtensionsParser.QuotedIdentifierAlternativeContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitQuotedIdentifier(LakeSoulSqlExtensionsParser.QuotedIdentifierContext ctx) {
+        return visitChildren(ctx); 
+    }
+
+    @Override
+    public T visitNonReserved(LakeSoulSqlExtensionsParser.NonReservedContext ctx) {
+        return visitChildren(ctx); 
+    }
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsLexer.java
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsLexer.java
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions;
+
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNDeserializer;
+import org.antlr.v4.runtime.atn.LexerATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.dfa.DFA;
+
+public class LakeSoulSqlExtensionsLexer extends Lexer {
+    static { RuntimeMetaData.checkVersion("4.8", RuntimeMetaData.VERSION); }
+
+    protected static final DFA[] _decisionToDFA;
+    protected static final PredictionContextCache _sharedContextCache =
+            new PredictionContextCache();
+    public static final int
+            T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, ADD=6, ALTER=7, AS=8, ASC=9, BRANCH=10,
+            BY=11, CALL=12, DAYS=13, DESC=14, DISTRIBUTED=15, DROP=16, EXISTS=17,
+            FIELD=18, FIELDS=19, FIRST=20, HOURS=21, IF=22, LAST=23, LOCALLY=24, MINUTES=25,
+            MONTHS=26, CREATE=27, NOT=28, NULLS=29, OF=30, OR=31, ORDERED=32, PARTITION=33,
+            REPLACE=34, RETAIN=35, RETENTION=36, IDENTIFIER_KW=37, SET=38, SNAPSHOT=39,
+            SNAPSHOTS=40, TABLE=41, TAG=42, UNORDERED=43, VERSION=44, WITH=45, WRITE=46,
+            TRUE=47, FALSE=48, MAP=49, ARRAY=50, PLUS=51, MINUS=52, STRING=53, BIGINT_LITERAL=54,
+            SMALLINT_LITERAL=55, TINYINT_LITERAL=56, INTEGER_VALUE=57, EXPONENT_VALUE=58,
+            DECIMAL_VALUE=59, FLOAT_LITERAL=60, DOUBLE_LITERAL=61, BIGDECIMAL_LITERAL=62,
+            IDENTIFIER=63, BACKQUOTED_IDENTIFIER=64, SIMPLE_COMMENT=65, BRACKETED_COMMENT=66,
+            WS=67, UNRECOGNIZED=68;
+    public static String[] channelNames = {
+            "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
+    };
+
+    public static String[] modeNames = {
+            "DEFAULT_MODE"
+    };
+
+    private static String[] makeRuleNames() {
+        return new String[] {
+                "T__0", "T__1", "T__2", "T__3", "T__4", "ADD", "ALTER", "AS", "ASC",
+                "BRANCH", "BY", "CALL", "DAYS", "DESC", "DISTRIBUTED", "DROP", "EXISTS",
+                "FIELD", "FIELDS", "FIRST", "HOURS", "IF", "LAST", "LOCALLY", "MINUTES",
+                "MONTHS", "CREATE", "NOT", "NULLS", "OF", "OR", "ORDERED", "PARTITION",
+                "REPLACE", "RETAIN", "RETENTION", "IDENTIFIER_KW", "SET", "SNAPSHOT",
+                "SNAPSHOTS", "TABLE", "TAG", "UNORDERED", "VERSION", "WITH", "WRITE",
+                "TRUE", "FALSE", "MAP", "ARRAY", "PLUS", "MINUS", "STRING", "BIGINT_LITERAL",
+                "SMALLINT_LITERAL", "TINYINT_LITERAL", "INTEGER_VALUE", "EXPONENT_VALUE",
+                "DECIMAL_VALUE", "FLOAT_LITERAL", "DOUBLE_LITERAL", "BIGDECIMAL_LITERAL",
+                "IDENTIFIER", "BACKQUOTED_IDENTIFIER", "DECIMAL_DIGITS", "EXPONENT",
+                "DIGIT", "LETTER", "SIMPLE_COMMENT", "BRACKETED_COMMENT", "WS", "UNRECOGNIZED"
+        };
+    }
+    public static final String[] ruleNames = makeRuleNames();
+
+    private static String[] makeLiteralNames() {
+        return new String[] {
+                null, "'('", "','", "')'", "'=>'", "'.'", "'ADD'", "'ALTER'", "'AS'",
+                "'ASC'", "'BRANCH'", "'BY'", "'CALL'", "'DAYS'", "'DESC'", "'DISTRIBUTED'",
+                "'DROP'", "'EXISTS'", "'FIELD'", "'FIELDS'", "'FIRST'", "'HOURS'", "'IF'",
+                "'LAST'", "'LOCALLY'", "'MINUTES'", "'MONTHS'", "'CREATE'", "'NOT'",
+                "'NULLS'", "'OF'", "'OR'", "'ORDERED'", "'PARTITION'", "'REPLACE'", "'RETAIN'",
+                "'RETENTION'", "'IDENTIFIER'", "'SET'", "'SNAPSHOT'", "'SNAPSHOTS'",
+                "'TABLE'", "'TAG'", "'UNORDERED'", "'VERSION'", "'WITH'", "'WRITE'",
+                "'TRUE'", "'FALSE'", "'MAP'", "'ARRAY'", "'+'", "'-'"
+        };
+    }
+    private static final String[] _LITERAL_NAMES = makeLiteralNames();
+    private static String[] makeSymbolicNames() {
+        return new String[] {
+                null, null, null, null, null, null, "ADD", "ALTER", "AS", "ASC", "BRANCH",
+                "BY", "CALL", "DAYS", "DESC", "DISTRIBUTED", "DROP", "EXISTS", "FIELD",
+                "FIELDS", "FIRST", "HOURS", "IF", "LAST", "LOCALLY", "MINUTES", "MONTHS",
+                "CREATE", "NOT", "NULLS", "OF", "OR", "ORDERED", "PARTITION", "REPLACE",
+                "RETAIN", "RETENTION", "IDENTIFIER_KW", "SET", "SNAPSHOT", "SNAPSHOTS",
+                "TABLE", "TAG", "UNORDERED", "VERSION", "WITH", "WRITE", "TRUE", "FALSE",
+                "MAP", "ARRAY", "PLUS", "MINUS", "STRING", "BIGINT_LITERAL", "SMALLINT_LITERAL",
+                "TINYINT_LITERAL", "INTEGER_VALUE", "EXPONENT_VALUE", "DECIMAL_VALUE",
+                "FLOAT_LITERAL", "DOUBLE_LITERAL", "BIGDECIMAL_LITERAL", "IDENTIFIER",
+                "BACKQUOTED_IDENTIFIER", "SIMPLE_COMMENT", "BRACKETED_COMMENT", "WS",
+                "UNRECOGNIZED"
+        };
+    }
+    private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
+    public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
+
+    /**
+     * @deprecated Use {@link #VOCABULARY} instead.
+     */
+    @Deprecated
+    public static final String[] tokenNames;
+    static {
+        tokenNames = new String[_SYMBOLIC_NAMES.length];
+        for (int i = 0; i < tokenNames.length; i++) {
+            tokenNames[i] = VOCABULARY.getLiteralName(i);
+            if (tokenNames[i] == null) {
+                tokenNames[i] = VOCABULARY.getSymbolicName(i);
+            }
+
+            if (tokenNames[i] == null) {
+                tokenNames[i] = "<INVALID>";
+            }
+        }
+    }
+
+    @Override
+    @Deprecated
+    public String[] getTokenNames() {
+        return tokenNames;
+    }
+
+    @Override
+
+    public Vocabulary getVocabulary() {
+        return VOCABULARY;
+    }
+
+
+    /**
+     * Verify whether current token is a valid decimal token (which contains dot).
+     * Returns true if the character that follows the token is not a digit or letter or underscore.
+     *
+     * For example:
+     * For char stream "2.3", "2." is not a valid decimal token, because it is followed by digit '3'.
+     * For char stream "2.3_", "2.3" is not a valid decimal token, because it is followed by '_'.
+     * For char stream "2.3W", "2.3" is not a valid decimal token, because it is followed by 'W'.
+     * For char stream "12.0D 34.E2+0.12 "  12.0D is a valid decimal token because it is followed
+     * by a space. 34.E2 is a valid decimal token because it is followed by symbol '+'
+     * which is not a digit or letter or underscore.
+     */
+    public boolean isValidDecimal() {
+        int nextChar = _input.LA(1);
+        if (nextChar >= 'A' && nextChar <= 'Z' || nextChar >= '0' && nextChar <= '9' ||
+                nextChar == '_') {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * This method will be called when we see '/*' and try to match it as a bracketed comment.
+     * If the next character is '+', it should be parsed as hint later, and we cannot match
+     * it as a bracketed comment.
+     *
+     * Returns true if the next character is '+'.
+     */
+    public boolean isHint() {
+        int nextChar = _input.LA(1);
+        if (nextChar == '+') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    public LakeSoulSqlExtensionsLexer(CharStream input) {
+        super(input);
+        _interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
+    }
+
+    @Override
+    public String getGrammarFileName() { return "LakeSoulSqlExtensions.g4"; }
+
+    @Override
+    public String[] getRuleNames() { return ruleNames; }
+
+    @Override
+    public String getSerializedATN() { return _serializedATN; }
+
+    @Override
+    public String[] getChannelNames() { return channelNames; }
+
+    @Override
+    public String[] getModeNames() { return modeNames; }
+
+    @Override
+    public ATN getATN() { return _ATN; }
+
+    @Override
+    public boolean sempred(RuleContext _localctx, int ruleIndex, int predIndex) {
+        switch (ruleIndex) {
+            case 57:
+                return EXPONENT_VALUE_sempred((RuleContext)_localctx, predIndex);
+            case 58:
+                return DECIMAL_VALUE_sempred((RuleContext)_localctx, predIndex);
+            case 59:
+                return FLOAT_LITERAL_sempred((RuleContext)_localctx, predIndex);
+            case 60:
+                return DOUBLE_LITERAL_sempred((RuleContext)_localctx, predIndex);
+            case 61:
+                return BIGDECIMAL_LITERAL_sempred((RuleContext)_localctx, predIndex);
+            case 69:
+                return BRACKETED_COMMENT_sempred((RuleContext)_localctx, predIndex);
+        }
+        return true;
+    }
+    private boolean EXPONENT_VALUE_sempred(RuleContext _localctx, int predIndex) {
+        switch (predIndex) {
+            case 0:
+                return isValidDecimal();
+        }
+        return true;
+    }
+    private boolean DECIMAL_VALUE_sempred(RuleContext _localctx, int predIndex) {
+        switch (predIndex) {
+            case 1:
+                return isValidDecimal();
+        }
+        return true;
+    }
+    private boolean FLOAT_LITERAL_sempred(RuleContext _localctx, int predIndex) {
+        switch (predIndex) {
+            case 2:
+                return isValidDecimal();
+        }
+        return true;
+    }
+    private boolean DOUBLE_LITERAL_sempred(RuleContext _localctx, int predIndex) {
+        switch (predIndex) {
+            case 3:
+                return isValidDecimal();
+        }
+        return true;
+    }
+    private boolean BIGDECIMAL_LITERAL_sempred(RuleContext _localctx, int predIndex) {
+        switch (predIndex) {
+            case 4:
+                return isValidDecimal();
+        }
+        return true;
+    }
+    private boolean BRACKETED_COMMENT_sempred(RuleContext _localctx, int predIndex) {
+        switch (predIndex) {
+            case 5:
+                return !isHint();
+        }
+        return true;
+    }
+
+    public static final String _serializedATN =
+            "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2F\u0297\b\1\4\2\t"+
+                    "\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
+                    "\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
+                    "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
+                    "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
+                    "\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t+\4"+
+                    ",\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63\t\63\4\64\t"+
+                    "\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\49\t9\4:\t:\4;\t;\4<\t<\4=\t="+
+                    "\4>\t>\4?\t?\4@\t@\4A\tA\4B\tB\4C\tC\4D\tD\4E\tE\4F\tF\4G\tG\4H\tH\4I"+
+                    "\tI\3\2\3\2\3\3\3\3\3\4\3\4\3\5\3\5\3\5\3\6\3\6\3\7\3\7\3\7\3\7\3\b\3"+
+                    "\b\3\b\3\b\3\b\3\b\3\t\3\t\3\t\3\n\3\n\3\n\3\n\3\13\3\13\3\13\3\13\3\13"+
+                    "\3\13\3\13\3\f\3\f\3\f\3\r\3\r\3\r\3\r\3\r\3\16\3\16\3\16\3\16\3\16\3"+
+                    "\17\3\17\3\17\3\17\3\17\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3"+
+                    "\20\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3\22\3\22\3\22\3\22\3\22\3\22\3"+
+                    "\22\3\23\3\23\3\23\3\23\3\23\3\23\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3"+
+                    "\25\3\25\3\25\3\25\3\25\3\25\3\26\3\26\3\26\3\26\3\26\3\26\3\27\3\27\3"+
+                    "\27\3\30\3\30\3\30\3\30\3\30\3\31\3\31\3\31\3\31\3\31\3\31\3\31\3\31\3"+
+                    "\32\3\32\3\32\3\32\3\32\3\32\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\33\3"+
+                    "\33\3\34\3\34\3\34\3\34\3\34\3\34\3\34\3\35\3\35\3\35\3\35\3\36\3\36\3"+
+                    "\36\3\36\3\36\3\36\3\37\3\37\3\37\3 \3 \3 \3!\3!\3!\3!\3!\3!\3!\3!\3\""+
+                    "\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3#\3#\3#\3#\3#\3#\3#\3#\3$\3$\3$"+
+                    "\3$\3$\3$\3$\3%\3%\3%\3%\3%\3%\3%\3%\3%\3%\3&\3&\3&\3&\3&\3&\3&\3&\3&"+
+                    "\3&\3&\3\'\3\'\3\'\3\'\3(\3(\3(\3(\3(\3(\3(\3(\3(\3)\3)\3)\3)\3)\3)\3"+
+                    ")\3)\3)\3)\3*\3*\3*\3*\3*\3*\3+\3+\3+\3+\3,\3,\3,\3,\3,\3,\3,\3,\3,\3"+
+                    ",\3-\3-\3-\3-\3-\3-\3-\3-\3.\3.\3.\3.\3.\3/\3/\3/\3/\3/\3/\3\60\3\60\3"+
+                    "\60\3\60\3\60\3\61\3\61\3\61\3\61\3\61\3\61\3\62\3\62\3\62\3\62\3\63\3"+
+                    "\63\3\63\3\63\3\63\3\63\3\64\3\64\3\65\3\65\3\66\3\66\3\66\3\66\7\66\u01c1"+
+                    "\n\66\f\66\16\66\u01c4\13\66\3\66\3\66\3\66\3\66\3\66\7\66\u01cb\n\66"+
+                    "\f\66\16\66\u01ce\13\66\3\66\5\66\u01d1\n\66\3\67\6\67\u01d4\n\67\r\67"+
+                    "\16\67\u01d5\3\67\3\67\38\68\u01db\n8\r8\168\u01dc\38\38\39\69\u01e2\n"+
+                    "9\r9\169\u01e3\39\39\3:\6:\u01e9\n:\r:\16:\u01ea\3;\6;\u01ee\n;\r;\16"+
+                    ";\u01ef\3;\3;\3;\3;\3;\3;\5;\u01f8\n;\3<\3<\3<\3=\6=\u01fe\n=\r=\16=\u01ff"+
+                    "\3=\5=\u0203\n=\3=\3=\3=\3=\5=\u0209\n=\3=\3=\3=\5=\u020e\n=\3>\6>\u0211"+
+                    "\n>\r>\16>\u0212\3>\5>\u0216\n>\3>\3>\3>\3>\5>\u021c\n>\3>\3>\3>\5>\u0221"+
+                    "\n>\3?\6?\u0224\n?\r?\16?\u0225\3?\5?\u0229\n?\3?\3?\3?\3?\3?\5?\u0230"+
+                    "\n?\3?\3?\3?\3?\3?\5?\u0237\n?\3@\3@\3@\6@\u023c\n@\r@\16@\u023d\3A\3"+
+                    "A\3A\3A\7A\u0244\nA\fA\16A\u0247\13A\3A\3A\3B\6B\u024c\nB\rB\16B\u024d"+
+                    "\3B\3B\7B\u0252\nB\fB\16B\u0255\13B\3B\3B\6B\u0259\nB\rB\16B\u025a\5B"+
+                    "\u025d\nB\3C\3C\5C\u0261\nC\3C\6C\u0264\nC\rC\16C\u0265\3D\3D\3E\3E\3"+
+                    "F\3F\3F\3F\3F\3F\7F\u0272\nF\fF\16F\u0275\13F\3F\5F\u0278\nF\3F\5F\u027b"+
+                    "\nF\3F\3F\3G\3G\3G\3G\3G\3G\7G\u0285\nG\fG\16G\u0288\13G\3G\3G\3G\3G\3"+
+                    "G\3H\6H\u0290\nH\rH\16H\u0291\3H\3H\3I\3I\3\u0286\2J\3\3\5\4\7\5\t\6\13"+
+                    "\7\r\b\17\t\21\n\23\13\25\f\27\r\31\16\33\17\35\20\37\21!\22#\23%\24\'"+
+                    "\25)\26+\27-\30/\31\61\32\63\33\65\34\67\359\36;\37= ?!A\"C#E$G%I&K\'"+
+                    "M(O)Q*S+U,W-Y.[/]\60_\61a\62c\63e\64g\65i\66k\67m8o9q:s;u<w=y>{?}@\177"+
+                    "A\u0081B\u0083\2\u0085\2\u0087\2\u0089\2\u008bC\u008dD\u008fE\u0091F\3"+
+                    "\2\n\4\2))^^\4\2$$^^\3\2bb\4\2--//\3\2\62;\3\2C\\\4\2\f\f\17\17\5\2\13"+
+                    "\f\17\17\"\"\2\u02bb\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t\3\2\2\2\2"+
+                    "\13\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\2\21\3\2\2\2\2\23\3\2\2\2\2\25\3"+
+                    "\2\2\2\2\27\3\2\2\2\2\31\3\2\2\2\2\33\3\2\2\2\2\35\3\2\2\2\2\37\3\2\2"+
+                    "\2\2!\3\2\2\2\2#\3\2\2\2\2%\3\2\2\2\2\'\3\2\2\2\2)\3\2\2\2\2+\3\2\2\2"+
+                    "\2-\3\2\2\2\2/\3\2\2\2\2\61\3\2\2\2\2\63\3\2\2\2\2\65\3\2\2\2\2\67\3\2"+
+                    "\2\2\29\3\2\2\2\2;\3\2\2\2\2=\3\2\2\2\2?\3\2\2\2\2A\3\2\2\2\2C\3\2\2\2"+
+                    "\2E\3\2\2\2\2G\3\2\2\2\2I\3\2\2\2\2K\3\2\2\2\2M\3\2\2\2\2O\3\2\2\2\2Q"+
+                    "\3\2\2\2\2S\3\2\2\2\2U\3\2\2\2\2W\3\2\2\2\2Y\3\2\2\2\2[\3\2\2\2\2]\3\2"+
+                    "\2\2\2_\3\2\2\2\2a\3\2\2\2\2c\3\2\2\2\2e\3\2\2\2\2g\3\2\2\2\2i\3\2\2\2"+
+                    "\2k\3\2\2\2\2m\3\2\2\2\2o\3\2\2\2\2q\3\2\2\2\2s\3\2\2\2\2u\3\2\2\2\2w"+
+                    "\3\2\2\2\2y\3\2\2\2\2{\3\2\2\2\2}\3\2\2\2\2\177\3\2\2\2\2\u0081\3\2\2"+
+                    "\2\2\u008b\3\2\2\2\2\u008d\3\2\2\2\2\u008f\3\2\2\2\2\u0091\3\2\2\2\3\u0093"+
+                    "\3\2\2\2\5\u0095\3\2\2\2\7\u0097\3\2\2\2\t\u0099\3\2\2\2\13\u009c\3\2"+
+                    "\2\2\r\u009e\3\2\2\2\17\u00a2\3\2\2\2\21\u00a8\3\2\2\2\23\u00ab\3\2\2"+
+                    "\2\25\u00af\3\2\2\2\27\u00b6\3\2\2\2\31\u00b9\3\2\2\2\33\u00be\3\2\2\2"+
+                    "\35\u00c3\3\2\2\2\37\u00c8\3\2\2\2!\u00d4\3\2\2\2#\u00d9\3\2\2\2%\u00e0"+
+                    "\3\2\2\2\'\u00e6\3\2\2\2)\u00ed\3\2\2\2+\u00f3\3\2\2\2-\u00f9\3\2\2\2"+
+                    "/\u00fc\3\2\2\2\61\u0101\3\2\2\2\63\u0109\3\2\2\2\65\u0111\3\2\2\2\67"+
+                    "\u0118\3\2\2\29\u011f\3\2\2\2;\u0123\3\2\2\2=\u0129\3\2\2\2?\u012c\3\2"+
+                    "\2\2A\u012f\3\2\2\2C\u0137\3\2\2\2E\u0141\3\2\2\2G\u0149\3\2\2\2I\u0150"+
+                    "\3\2\2\2K\u015a\3\2\2\2M\u0165\3\2\2\2O\u0169\3\2\2\2Q\u0172\3\2\2\2S"+
+                    "\u017c\3\2\2\2U\u0182\3\2\2\2W\u0186\3\2\2\2Y\u0190\3\2\2\2[\u0198\3\2"+
+                    "\2\2]\u019d\3\2\2\2_\u01a3\3\2\2\2a\u01a8\3\2\2\2c\u01ae\3\2\2\2e\u01b2"+
+                    "\3\2\2\2g\u01b8\3\2\2\2i\u01ba\3\2\2\2k\u01d0\3\2\2\2m\u01d3\3\2\2\2o"+
+                    "\u01da\3\2\2\2q\u01e1\3\2\2\2s\u01e8\3\2\2\2u\u01f7\3\2\2\2w\u01f9\3\2"+
+                    "\2\2y\u020d\3\2\2\2{\u0220\3\2\2\2}\u0236\3\2\2\2\177\u023b\3\2\2\2\u0081"+
+                    "\u023f\3\2\2\2\u0083\u025c\3\2\2\2\u0085\u025e\3\2\2\2\u0087\u0267\3\2"+
+                    "\2\2\u0089\u0269\3\2\2\2\u008b\u026b\3\2\2\2\u008d\u027e\3\2\2\2\u008f"+
+                    "\u028f\3\2\2\2\u0091\u0295\3\2\2\2\u0093\u0094\7*\2\2\u0094\4\3\2\2\2"+
+                    "\u0095\u0096\7.\2\2\u0096\6\3\2\2\2\u0097\u0098\7+\2\2\u0098\b\3\2\2\2"+
+                    "\u0099\u009a\7?\2\2\u009a\u009b\7@\2\2\u009b\n\3\2\2\2\u009c\u009d\7\60"+
+                    "\2\2\u009d\f\3\2\2\2\u009e\u009f\7C\2\2\u009f\u00a0\7F\2\2\u00a0\u00a1"+
+                    "\7F\2\2\u00a1\16\3\2\2\2\u00a2\u00a3\7C\2\2\u00a3\u00a4\7N\2\2\u00a4\u00a5"+
+                    "\7V\2\2\u00a5\u00a6\7G\2\2\u00a6\u00a7\7T\2\2\u00a7\20\3\2\2\2\u00a8\u00a9"+
+                    "\7C\2\2\u00a9\u00aa\7U\2\2\u00aa\22\3\2\2\2\u00ab\u00ac\7C\2\2\u00ac\u00ad"+
+                    "\7U\2\2\u00ad\u00ae\7E\2\2\u00ae\24\3\2\2\2\u00af\u00b0\7D\2\2\u00b0\u00b1"+
+                    "\7T\2\2\u00b1\u00b2\7C\2\2\u00b2\u00b3\7P\2\2\u00b3\u00b4\7E\2\2\u00b4"+
+                    "\u00b5\7J\2\2\u00b5\26\3\2\2\2\u00b6\u00b7\7D\2\2\u00b7\u00b8\7[\2\2\u00b8"+
+                    "\30\3\2\2\2\u00b9\u00ba\7E\2\2\u00ba\u00bb\7C\2\2\u00bb\u00bc\7N\2\2\u00bc"+
+                    "\u00bd\7N\2\2\u00bd\32\3\2\2\2\u00be\u00bf\7F\2\2\u00bf\u00c0\7C\2\2\u00c0"+
+                    "\u00c1\7[\2\2\u00c1\u00c2\7U\2\2\u00c2\34\3\2\2\2\u00c3\u00c4\7F\2\2\u00c4"+
+                    "\u00c5\7G\2\2\u00c5\u00c6\7U\2\2\u00c6\u00c7\7E\2\2\u00c7\36\3\2\2\2\u00c8"+
+                    "\u00c9\7F\2\2\u00c9\u00ca\7K\2\2\u00ca\u00cb\7U\2\2\u00cb\u00cc\7V\2\2"+
+                    "\u00cc\u00cd\7T\2\2\u00cd\u00ce\7K\2\2\u00ce\u00cf\7D\2\2\u00cf\u00d0"+
+                    "\7W\2\2\u00d0\u00d1\7V\2\2\u00d1\u00d2\7G\2\2\u00d2\u00d3\7F\2\2\u00d3"+
+                    " \3\2\2\2\u00d4\u00d5\7F\2\2\u00d5\u00d6\7T\2\2\u00d6\u00d7\7Q\2\2\u00d7"+
+                    "\u00d8\7R\2\2\u00d8\"\3\2\2\2\u00d9\u00da\7G\2\2\u00da\u00db\7Z\2\2\u00db"+
+                    "\u00dc\7K\2\2\u00dc\u00dd\7U\2\2\u00dd\u00de\7V\2\2\u00de\u00df\7U\2\2"+
+                    "\u00df$\3\2\2\2\u00e0\u00e1\7H\2\2\u00e1\u00e2\7K\2\2\u00e2\u00e3\7G\2"+
+                    "\2\u00e3\u00e4\7N\2\2\u00e4\u00e5\7F\2\2\u00e5&\3\2\2\2\u00e6\u00e7\7"+
+                    "H\2\2\u00e7\u00e8\7K\2\2\u00e8\u00e9\7G\2\2\u00e9\u00ea\7N\2\2\u00ea\u00eb"+
+                    "\7F\2\2\u00eb\u00ec\7U\2\2\u00ec(\3\2\2\2\u00ed\u00ee\7H\2\2\u00ee\u00ef"+
+                    "\7K\2\2\u00ef\u00f0\7T\2\2\u00f0\u00f1\7U\2\2\u00f1\u00f2\7V\2\2\u00f2"+
+                    "*\3\2\2\2\u00f3\u00f4\7J\2\2\u00f4\u00f5\7Q\2\2\u00f5\u00f6\7W\2\2\u00f6"+
+                    "\u00f7\7T\2\2\u00f7\u00f8\7U\2\2\u00f8,\3\2\2\2\u00f9\u00fa\7K\2\2\u00fa"+
+                    "\u00fb\7H\2\2\u00fb.\3\2\2\2\u00fc\u00fd\7N\2\2\u00fd\u00fe\7C\2\2\u00fe"+
+                    "\u00ff\7U\2\2\u00ff\u0100\7V\2\2\u0100\60\3\2\2\2\u0101\u0102\7N\2\2\u0102"+
+                    "\u0103\7Q\2\2\u0103\u0104\7E\2\2\u0104\u0105\7C\2\2\u0105\u0106\7N\2\2"+
+                    "\u0106\u0107\7N\2\2\u0107\u0108\7[\2\2\u0108\62\3\2\2\2\u0109\u010a\7"+
+                    "O\2\2\u010a\u010b\7K\2\2\u010b\u010c\7P\2\2\u010c\u010d\7W\2\2\u010d\u010e"+
+                    "\7V\2\2\u010e\u010f\7G\2\2\u010f\u0110\7U\2\2\u0110\64\3\2\2\2\u0111\u0112"+
+                    "\7O\2\2\u0112\u0113\7Q\2\2\u0113\u0114\7P\2\2\u0114\u0115\7V\2\2\u0115"+
+                    "\u0116\7J\2\2\u0116\u0117\7U\2\2\u0117\66\3\2\2\2\u0118\u0119\7E\2\2\u0119"+
+                    "\u011a\7T\2\2\u011a\u011b\7G\2\2\u011b\u011c\7C\2\2\u011c\u011d\7V\2\2"+
+                    "\u011d\u011e\7G\2\2\u011e8\3\2\2\2\u011f\u0120\7P\2\2\u0120\u0121\7Q\2"+
+                    "\2\u0121\u0122\7V\2\2\u0122:\3\2\2\2\u0123\u0124\7P\2\2\u0124\u0125\7"+
+                    "W\2\2\u0125\u0126\7N\2\2\u0126\u0127\7N\2\2\u0127\u0128\7U\2\2\u0128<"+
+                    "\3\2\2\2\u0129\u012a\7Q\2\2\u012a\u012b\7H\2\2\u012b>\3\2\2\2\u012c\u012d"+
+                    "\7Q\2\2\u012d\u012e\7T\2\2\u012e@\3\2\2\2\u012f\u0130\7Q\2\2\u0130\u0131"+
+                    "\7T\2\2\u0131\u0132\7F\2\2\u0132\u0133\7G\2\2\u0133\u0134\7T\2\2\u0134"+
+                    "\u0135\7G\2\2\u0135\u0136\7F\2\2\u0136B\3\2\2\2\u0137\u0138\7R\2\2\u0138"+
+                    "\u0139\7C\2\2\u0139\u013a\7T\2\2\u013a\u013b\7V\2\2\u013b\u013c\7K\2\2"+
+                    "\u013c\u013d\7V\2\2\u013d\u013e\7K\2\2\u013e\u013f\7Q\2\2\u013f\u0140"+
+                    "\7P\2\2\u0140D\3\2\2\2\u0141\u0142\7T\2\2\u0142\u0143\7G\2\2\u0143\u0144"+
+                    "\7R\2\2\u0144\u0145\7N\2\2\u0145\u0146\7C\2\2\u0146\u0147\7E\2\2\u0147"+
+                    "\u0148\7G\2\2\u0148F\3\2\2\2\u0149\u014a\7T\2\2\u014a\u014b\7G\2\2\u014b"+
+                    "\u014c\7V\2\2\u014c\u014d\7C\2\2\u014d\u014e\7K\2\2\u014e\u014f\7P\2\2"+
+                    "\u014fH\3\2\2\2\u0150\u0151\7T\2\2\u0151\u0152\7G\2\2\u0152\u0153\7V\2"+
+                    "\2\u0153\u0154\7G\2\2\u0154\u0155\7P\2\2\u0155\u0156\7V\2\2\u0156\u0157"+
+                    "\7K\2\2\u0157\u0158\7Q\2\2\u0158\u0159\7P\2\2\u0159J\3\2\2\2\u015a\u015b"+
+                    "\7K\2\2\u015b\u015c\7F\2\2\u015c\u015d\7G\2\2\u015d\u015e\7P\2\2\u015e"+
+                    "\u015f\7V\2\2\u015f\u0160\7K\2\2\u0160\u0161\7H\2\2\u0161\u0162\7K\2\2"+
+                    "\u0162\u0163\7G\2\2\u0163\u0164\7T\2\2\u0164L\3\2\2\2\u0165\u0166\7U\2"+
+                    "\2\u0166\u0167\7G\2\2\u0167\u0168\7V\2\2\u0168N\3\2\2\2\u0169\u016a\7"+
+                    "U\2\2\u016a\u016b\7P\2\2\u016b\u016c\7C\2\2\u016c\u016d\7R\2\2\u016d\u016e"+
+                    "\7U\2\2\u016e\u016f\7J\2\2\u016f\u0170\7Q\2\2\u0170\u0171\7V\2\2\u0171"+
+                    "P\3\2\2\2\u0172\u0173\7U\2\2\u0173\u0174\7P\2\2\u0174\u0175\7C\2\2\u0175"+
+                    "\u0176\7R\2\2\u0176\u0177\7U\2\2\u0177\u0178\7J\2\2\u0178\u0179\7Q\2\2"+
+                    "\u0179\u017a\7V\2\2\u017a\u017b\7U\2\2\u017bR\3\2\2\2\u017c\u017d\7V\2"+
+                    "\2\u017d\u017e\7C\2\2\u017e\u017f\7D\2\2\u017f\u0180\7N\2\2\u0180\u0181"+
+                    "\7G\2\2\u0181T\3\2\2\2\u0182\u0183\7V\2\2\u0183\u0184\7C\2\2\u0184\u0185"+
+                    "\7I\2\2\u0185V\3\2\2\2\u0186\u0187\7W\2\2\u0187\u0188\7P\2\2\u0188\u0189"+
+                    "\7Q\2\2\u0189\u018a\7T\2\2\u018a\u018b\7F\2\2\u018b\u018c\7G\2\2\u018c"+
+                    "\u018d\7T\2\2\u018d\u018e\7G\2\2\u018e\u018f\7F\2\2\u018fX\3\2\2\2\u0190"+
+                    "\u0191\7X\2\2\u0191\u0192\7G\2\2\u0192\u0193\7T\2\2\u0193\u0194\7U\2\2"+
+                    "\u0194\u0195\7K\2\2\u0195\u0196\7Q\2\2\u0196\u0197\7P\2\2\u0197Z\3\2\2"+
+                    "\2\u0198\u0199\7Y\2\2\u0199\u019a\7K\2\2\u019a\u019b\7V\2\2\u019b\u019c"+
+                    "\7J\2\2\u019c\\\3\2\2\2\u019d\u019e\7Y\2\2\u019e\u019f\7T\2\2\u019f\u01a0"+
+                    "\7K\2\2\u01a0\u01a1\7V\2\2\u01a1\u01a2\7G\2\2\u01a2^\3\2\2\2\u01a3\u01a4"+
+                    "\7V\2\2\u01a4\u01a5\7T\2\2\u01a5\u01a6\7W\2\2\u01a6\u01a7\7G\2\2\u01a7"+
+                    "`\3\2\2\2\u01a8\u01a9\7H\2\2\u01a9\u01aa\7C\2\2\u01aa\u01ab\7N\2\2\u01ab"+
+                    "\u01ac\7U\2\2\u01ac\u01ad\7G\2\2\u01adb\3\2\2\2\u01ae\u01af\7O\2\2\u01af"+
+                    "\u01b0\7C\2\2\u01b0\u01b1\7R\2\2\u01b1d\3\2\2\2\u01b2\u01b3\7C\2\2\u01b3"+
+                    "\u01b4\7T\2\2\u01b4\u01b5\7T\2\2\u01b5\u01b6\7C\2\2\u01b6\u01b7\7[\2\2"+
+                    "\u01b7f\3\2\2\2\u01b8\u01b9\7-\2\2\u01b9h\3\2\2\2\u01ba\u01bb\7/\2\2\u01bb"+
+                    "j\3\2\2\2\u01bc\u01c2\7)\2\2\u01bd\u01c1\n\2\2\2\u01be\u01bf\7^\2\2\u01bf"+
+                    "\u01c1\13\2\2\2\u01c0\u01bd\3\2\2\2\u01c0\u01be\3\2\2\2\u01c1\u01c4\3"+
+                    "\2\2\2\u01c2\u01c0\3\2\2\2\u01c2\u01c3\3\2\2\2\u01c3\u01c5\3\2\2\2\u01c4"+
+                    "\u01c2\3\2\2\2\u01c5\u01d1\7)\2\2\u01c6\u01cc\7$\2\2\u01c7\u01cb\n\3\2"+
+                    "\2\u01c8\u01c9\7^\2\2\u01c9\u01cb\13\2\2\2\u01ca\u01c7\3\2\2\2\u01ca\u01c8"+
+                    "\3\2\2\2\u01cb\u01ce\3\2\2\2\u01cc\u01ca\3\2\2\2\u01cc\u01cd\3\2\2\2\u01cd"+
+                    "\u01cf\3\2\2\2\u01ce\u01cc\3\2\2\2\u01cf\u01d1\7$\2\2\u01d0\u01bc\3\2"+
+                    "\2\2\u01d0\u01c6\3\2\2\2\u01d1l\3\2\2\2\u01d2\u01d4\5\u0087D\2\u01d3\u01d2"+
+                    "\3\2\2\2\u01d4\u01d5\3\2\2\2\u01d5\u01d3\3\2\2\2\u01d5\u01d6\3\2\2\2\u01d6"+
+                    "\u01d7\3\2\2\2\u01d7\u01d8\7N\2\2\u01d8n\3\2\2\2\u01d9\u01db\5\u0087D"+
+                    "\2\u01da\u01d9\3\2\2\2\u01db\u01dc\3\2\2\2\u01dc\u01da\3\2\2\2\u01dc\u01dd"+
+                    "\3\2\2\2\u01dd\u01de\3\2\2\2\u01de\u01df\7U\2\2\u01dfp\3\2\2\2\u01e0\u01e2"+
+                    "\5\u0087D\2\u01e1\u01e0\3\2\2\2\u01e2\u01e3\3\2\2\2\u01e3\u01e1\3\2\2"+
+                    "\2\u01e3\u01e4\3\2\2\2\u01e4\u01e5\3\2\2\2\u01e5\u01e6\7[\2\2\u01e6r\3"+
+                    "\2\2\2\u01e7\u01e9\5\u0087D\2\u01e8\u01e7\3\2\2\2\u01e9\u01ea\3\2\2\2"+
+                    "\u01ea\u01e8\3\2\2\2\u01ea\u01eb\3\2\2\2\u01ebt\3\2\2\2\u01ec\u01ee\5"+
+                    "\u0087D\2\u01ed\u01ec\3\2\2\2\u01ee\u01ef\3\2\2\2\u01ef\u01ed\3\2\2\2"+
+                    "\u01ef\u01f0\3\2\2\2\u01f0\u01f1\3\2\2\2\u01f1\u01f2\5\u0085C\2\u01f2"+
+                    "\u01f8\3\2\2\2\u01f3\u01f4\5\u0083B\2\u01f4\u01f5\5\u0085C\2\u01f5\u01f6"+
+                    "\6;\2\2\u01f6\u01f8\3\2\2\2\u01f7\u01ed\3\2\2\2\u01f7\u01f3\3\2\2\2\u01f8"+
+                    "v\3\2\2\2\u01f9\u01fa\5\u0083B\2\u01fa\u01fb\6<\3\2\u01fbx\3\2\2\2\u01fc"+
+                    "\u01fe\5\u0087D\2\u01fd\u01fc\3\2\2\2\u01fe\u01ff\3\2\2\2\u01ff\u01fd"+
+                    "\3\2\2\2\u01ff\u0200\3\2\2\2\u0200\u0202\3\2\2\2\u0201\u0203\5\u0085C"+
+                    "\2\u0202\u0201\3\2\2\2\u0202\u0203\3\2\2\2\u0203\u0204\3\2\2\2\u0204\u0205"+
+                    "\7H\2\2\u0205\u020e\3\2\2\2\u0206\u0208\5\u0083B\2\u0207\u0209\5\u0085"+
+                    "C\2\u0208\u0207\3\2\2\2\u0208\u0209\3\2\2\2\u0209\u020a\3\2\2\2\u020a"+
+                    "\u020b\7H\2\2\u020b\u020c\6=\4\2\u020c\u020e\3\2\2\2\u020d\u01fd\3\2\2"+
+                    "\2\u020d\u0206\3\2\2\2\u020ez\3\2\2\2\u020f\u0211\5\u0087D\2\u0210\u020f"+
+                    "\3\2\2\2\u0211\u0212\3\2\2\2\u0212\u0210\3\2\2\2\u0212\u0213\3\2\2\2\u0213"+
+                    "\u0215\3\2\2\2\u0214\u0216\5\u0085C\2\u0215\u0214\3\2\2\2\u0215\u0216"+
+                    "\3\2\2\2\u0216\u0217\3\2\2\2\u0217\u0218\7F\2\2\u0218\u0221\3\2\2\2\u0219"+
+                    "\u021b\5\u0083B\2\u021a\u021c\5\u0085C\2\u021b\u021a\3\2\2\2\u021b\u021c"+
+                    "\3\2\2\2\u021c\u021d\3\2\2\2\u021d\u021e\7F\2\2\u021e\u021f\6>\5\2\u021f"+
+                    "\u0221\3\2\2\2\u0220\u0210\3\2\2\2\u0220\u0219\3\2\2\2\u0221|\3\2\2\2"+
+                    "\u0222\u0224\5\u0087D\2\u0223\u0222\3\2\2\2\u0224\u0225\3\2\2\2\u0225"+
+                    "\u0223\3\2\2\2\u0225\u0226\3\2\2\2\u0226\u0228\3\2\2\2\u0227\u0229\5\u0085"+
+                    "C\2\u0228\u0227\3\2\2\2\u0228\u0229\3\2\2\2\u0229\u022a\3\2\2\2\u022a"+
+                    "\u022b\7D\2\2\u022b\u022c\7F\2\2\u022c\u0237\3\2\2\2\u022d\u022f\5\u0083"+
+                    "B\2\u022e\u0230\5\u0085C\2\u022f\u022e\3\2\2\2\u022f\u0230\3\2\2\2\u0230"+
+                    "\u0231\3\2\2\2\u0231\u0232\7D\2\2\u0232\u0233\7F\2\2\u0233\u0234\3\2\2"+
+                    "\2\u0234\u0235\6?\6\2\u0235\u0237\3\2\2\2\u0236\u0223\3\2\2\2\u0236\u022d"+
+                    "\3\2\2\2\u0237~\3\2\2\2\u0238\u023c\5\u0089E\2\u0239\u023c\5\u0087D\2"+
+                    "\u023a\u023c\7a\2\2\u023b\u0238\3\2\2\2\u023b\u0239\3\2\2\2\u023b\u023a"+
+                    "\3\2\2\2\u023c\u023d\3\2\2\2\u023d\u023b\3\2\2\2\u023d\u023e\3\2\2\2\u023e"+
+                    "\u0080\3\2\2\2\u023f\u0245\7b\2\2\u0240\u0244\n\4\2\2\u0241\u0242\7b\2"+
+                    "\2\u0242\u0244\7b\2\2\u0243\u0240\3\2\2\2\u0243\u0241\3\2\2\2\u0244\u0247"+
+                    "\3\2\2\2\u0245\u0243\3\2\2\2\u0245\u0246\3\2\2\2\u0246\u0248\3\2\2\2\u0247"+
+                    "\u0245\3\2\2\2\u0248\u0249\7b\2\2\u0249\u0082\3\2\2\2\u024a\u024c\5\u0087"+
+                    "D\2\u024b\u024a\3\2\2\2\u024c\u024d\3\2\2\2\u024d\u024b\3\2\2\2\u024d"+
+                    "\u024e\3\2\2\2\u024e\u024f\3\2\2\2\u024f\u0253\7\60\2\2\u0250\u0252\5"+
+                    "\u0087D\2\u0251\u0250\3\2\2\2\u0252\u0255\3\2\2\2\u0253\u0251\3\2\2\2"+
+                    "\u0253\u0254\3\2\2\2\u0254\u025d\3\2\2\2\u0255\u0253\3\2\2\2\u0256\u0258"+
+                    "\7\60\2\2\u0257\u0259\5\u0087D\2\u0258\u0257\3\2\2\2\u0259\u025a\3\2\2"+
+                    "\2\u025a\u0258\3\2\2\2\u025a\u025b\3\2\2\2\u025b\u025d\3\2\2\2\u025c\u024b"+
+                    "\3\2\2\2\u025c\u0256\3\2\2\2\u025d\u0084\3\2\2\2\u025e\u0260\7G\2\2\u025f"+
+                    "\u0261\t\5\2\2\u0260\u025f\3\2\2\2\u0260\u0261\3\2\2\2\u0261\u0263\3\2"+
+                    "\2\2\u0262\u0264\5\u0087D\2\u0263\u0262\3\2\2\2\u0264\u0265\3\2\2\2\u0265"+
+                    "\u0263\3\2\2\2\u0265\u0266\3\2\2\2\u0266\u0086\3\2\2\2\u0267\u0268\t\6"+
+                    "\2\2\u0268\u0088\3\2\2\2\u0269\u026a\t\7\2\2\u026a\u008a\3\2\2\2\u026b"+
+                    "\u026c\7/\2\2\u026c\u026d\7/\2\2\u026d\u0273\3\2\2\2\u026e\u026f\7^\2"+
+                    "\2\u026f\u0272\7\f\2\2\u0270\u0272\n\b\2\2\u0271\u026e\3\2\2\2\u0271\u0270"+
+                    "\3\2\2\2\u0272\u0275\3\2\2\2\u0273\u0271\3\2\2\2\u0273\u0274\3\2\2\2\u0274"+
+                    "\u0277\3\2\2\2\u0275\u0273\3\2\2\2\u0276\u0278\7\17\2\2\u0277\u0276\3"+
+                    "\2\2\2\u0277\u0278\3\2\2\2\u0278\u027a\3\2\2\2\u0279\u027b\7\f\2\2\u027a"+
+                    "\u0279\3\2\2\2\u027a\u027b\3\2\2\2\u027b\u027c\3\2\2\2\u027c\u027d\bF"+
+                    "\2\2\u027d\u008c\3\2\2\2\u027e\u027f\7\61\2\2\u027f\u0280\7,\2\2\u0280"+
+                    "\u0281\3\2\2\2\u0281\u0286\6G\7\2\u0282\u0285\5\u008dG\2\u0283\u0285\13"+
+                    "\2\2\2\u0284\u0282\3\2\2\2\u0284\u0283\3\2\2\2\u0285\u0288\3\2\2\2\u0286"+
+                    "\u0287\3\2\2\2\u0286\u0284\3\2\2\2\u0287\u0289\3\2\2\2\u0288\u0286\3\2"+
+                    "\2\2\u0289\u028a\7,\2\2\u028a\u028b\7\61\2\2\u028b\u028c\3\2\2\2\u028c"+
+                    "\u028d\bG\2\2\u028d\u008e\3\2\2\2\u028e\u0290\t\t\2\2\u028f\u028e\3\2"+
+                    "\2\2\u0290\u0291\3\2\2\2\u0291\u028f\3\2\2\2\u0291\u0292\3\2\2\2\u0292"+
+                    "\u0293\3\2\2\2\u0293\u0294\bH\2\2\u0294\u0090\3\2\2\2\u0295\u0296\13\2"+
+                    "\2\2\u0296\u0092\3\2\2\2+\2\u01c0\u01c2\u01ca\u01cc\u01d0\u01d5\u01dc"+
+                    "\u01e3\u01ea\u01ef\u01f7\u01ff\u0202\u0208\u020d\u0212\u0215\u021b\u0220"+
+                    "\u0225\u0228\u022f\u0236\u023b\u023d\u0243\u0245\u024d\u0253\u025a\u025c"+
+                    "\u0260\u0265\u0271\u0273\u0277\u027a\u0284\u0286\u0291\3\2\3\2";
+    public static final ATN _ATN =
+            new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+    static {
+        _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
+        for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
+            _decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
+        }
+    }
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsListener.java
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsListener.java
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+public class LakeSoulSqlExtensionsListener implements ParseTreeListener {
+
+    public void enterSingleStatement(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SingleStatementContext ctx) {
+
+    }
+
+    public void exitSingleStatement(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SingleStatementContext ctx) {
+
+    }
+
+    public void enterCall(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.CallContext ctx) {
+
+    }
+
+    public void exitCall(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.CallContext ctx) {
+
+    }
+
+    public void enterPositionalArgument(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.PositionalArgumentContext ctx) {
+
+    }
+
+    public void exitPositionalArgument(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.PositionalArgumentContext ctx) {
+
+    }
+
+    public void enterNamedArgument(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NamedArgumentContext ctx) {
+
+    }
+
+    public void exitNamedArgument(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NamedArgumentContext ctx) {
+
+    }
+
+    public void enterExpression(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExpressionContext ctx) {
+
+    }
+
+    public void exitExpression(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExpressionContext ctx) {
+
+    }
+
+    public void enterNumericLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NumericLiteralContext ctx) {
+
+    }
+
+    public void exitNumericLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NumericLiteralContext ctx) {
+
+    }
+
+    public void enterBooleanLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BooleanLiteralContext ctx) {
+
+    }
+
+    public void exitBooleanLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BooleanLiteralContext ctx) {
+
+    }
+
+    public void enterStringLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringLiteralContext ctx) {
+
+    }
+
+    public void exitStringLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringLiteralContext ctx) {
+
+    }
+
+    public void enterTypeConstructor(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.TypeConstructorContext ctx) {
+
+    }
+
+    public void exitTypeConstructor(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.TypeConstructorContext ctx) {
+
+    }
+
+    public void enterStringMap(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringMapContext ctx) {
+
+    }
+
+    public void exitStringMap(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringMapContext ctx) {
+
+    }
+
+    public void enterStringArray(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringArrayContext ctx) {
+
+    }
+
+    public void exitStringArray(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringArrayContext ctx) {
+
+    }
+
+    public void enterBooleanValue(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BooleanValueContext ctx) {
+
+    }
+
+    public void exitBooleanValue(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BooleanValueContext ctx) {
+
+    }
+
+    public void enterExponentLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExponentLiteralContext ctx) {
+
+    }
+
+    public void exitExponentLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExponentLiteralContext ctx) {
+
+    }
+
+    public void enterDecimalLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.DecimalLiteralContext ctx) {
+
+    }
+
+    public void exitDecimalLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.DecimalLiteralContext ctx) {
+
+    }
+
+    public void enterIntegerLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.IntegerLiteralContext ctx) {
+
+    }
+
+    public void exitIntegerLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.IntegerLiteralContext ctx) {
+
+    }
+
+    public void enterBigIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BigIntLiteralContext ctx) {
+
+    }
+
+    public void exitBigIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BigIntLiteralContext ctx) {
+
+    }
+
+    public void enterSmallIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SmallIntLiteralContext ctx) {
+
+    }
+
+    public void exitSmallIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SmallIntLiteralContext ctx) {
+
+    }
+
+    public void enterTinyIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.TinyIntLiteralContext ctx) {
+
+    }
+
+    public void exitTinyIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.TinyIntLiteralContext ctx) {
+
+    }
+
+    public void enterDoubleLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.DoubleLiteralContext ctx) {
+
+    }
+
+    public void exitDoubleLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.DoubleLiteralContext ctx) {
+
+    }
+
+    public void enterFloatLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.FloatLiteralContext ctx) {
+
+    }
+
+    public void exitFloatLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.FloatLiteralContext ctx) {
+
+    }
+
+    public void enterBigDecimalLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BigDecimalLiteralContext ctx) {
+
+    }
+
+    public void exitBigDecimalLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BigDecimalLiteralContext ctx) {
+
+    }
+
+    public void enterMultipartIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.MultipartIdentifierContext ctx) {
+
+    }
+
+    void exitMultipartIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.MultipartIdentifierContext ctx) {
+
+    }
+
+    public void enterUnquotedIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.UnquotedIdentifierContext ctx) {
+
+    }
+
+    public void exitUnquotedIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.UnquotedIdentifierContext ctx) {
+
+    }
+
+    public void enterQuotedIdentifierAlternative(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.QuotedIdentifierAlternativeContext ctx) {
+
+    }
+
+    public void exitQuotedIdentifierAlternative(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.QuotedIdentifierAlternativeContext ctx) {
+
+    }
+
+    public void enterQuotedIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.QuotedIdentifierContext ctx) {
+
+    }
+
+    public void exitQuotedIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.QuotedIdentifierContext ctx) {
+
+    }
+
+    void enterNonReserved(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NonReservedContext ctx) {
+
+    }
+
+   public void exitNonReserved(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NonReservedContext ctx) {
+
+    }
+
+
+    @Override
+    public void visitTerminal(TerminalNode node) {
+
+    }
+
+    @Override
+    public void visitErrorNode(ErrorNode node) {
+
+    }
+
+    @Override
+    public void enterEveryRule(ParserRuleContext ctx) {
+
+    }
+
+    @Override
+    public void exitEveryRule(ParserRuleContext ctx) {
+
+    }
+
+
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsParser.java
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsParser.java
@@ -1,0 +1,1651 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions;
+
+import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.misc.*;
+import org.antlr.v4.runtime.tree.*;
+import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
+@SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
+public class LakeSoulSqlExtensionsParser extends Parser {
+    static { RuntimeMetaData.checkVersion("4.8", RuntimeMetaData.VERSION); }
+
+    protected static final DFA[] _decisionToDFA;
+    protected static final PredictionContextCache _sharedContextCache =
+            new PredictionContextCache();
+    public static final int
+            T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, ADD=6, ALTER=7, AS=8, ASC=9, BRANCH=10,
+            BY=11, CALL=12, DAYS=13, DESC=14, DISTRIBUTED=15, DROP=16, EXISTS=17,
+            FIELD=18, FIELDS=19, FIRST=20, HOURS=21, IF=22, LAST=23, LOCALLY=24, MINUTES=25,
+            MONTHS=26, CREATE=27, NOT=28, NULLS=29, OF=30, OR=31, ORDERED=32, PARTITION=33,
+            REPLACE=34, RETAIN=35, RETENTION=36, IDENTIFIER_KW=37, SET=38, SNAPSHOT=39,
+            SNAPSHOTS=40, TABLE=41, TAG=42, UNORDERED=43, VERSION=44, WITH=45, WRITE=46,
+            TRUE=47, FALSE=48, MAP=49, ARRAY=50, PLUS=51, MINUS=52, STRING=53, BIGINT_LITERAL=54,
+            SMALLINT_LITERAL=55, TINYINT_LITERAL=56, INTEGER_VALUE=57, EXPONENT_VALUE=58,
+            DECIMAL_VALUE=59, FLOAT_LITERAL=60, DOUBLE_LITERAL=61, BIGDECIMAL_LITERAL=62,
+            IDENTIFIER=63, BACKQUOTED_IDENTIFIER=64, SIMPLE_COMMENT=65, BRACKETED_COMMENT=66,
+            WS=67, UNRECOGNIZED=68;
+    public static final int
+            RULE_singleStatement = 0, RULE_statement = 1, RULE_createReplaceTagClause = 2,
+            RULE_createReplaceBranchClause = 3, RULE_tagOptions = 4, RULE_branchOptions = 5,
+            RULE_snapshotRetention = 6, RULE_refRetain = 7, RULE_maxSnapshotAge = 8,
+            RULE_minSnapshotsToKeep = 9, RULE_writeSpec = 10, RULE_writeDistributionSpec = 11,
+            RULE_writeOrderingSpec = 12, RULE_callArgument = 13, RULE_singleOrder = 14,
+            RULE_order = 15, RULE_orderField = 16, RULE_transform = 17, RULE_transformArgument = 18,
+            RULE_expression = 19, RULE_constant = 20, RULE_stringMap = 21, RULE_stringArray = 22,
+            RULE_booleanValue = 23, RULE_number = 24, RULE_multipartIdentifier = 25,
+            RULE_identifier = 26, RULE_quotedIdentifier = 27, RULE_fieldList = 28,
+            RULE_nonReserved = 29, RULE_snapshotId = 30, RULE_numSnapshots = 31, RULE_timeUnit = 32;
+    private static String[] makeRuleNames() {
+        return new String[] {
+                "singleStatement", "statement", "createReplaceTagClause", "createReplaceBranchClause",
+                "tagOptions", "branchOptions", "snapshotRetention", "refRetain", "maxSnapshotAge",
+                "minSnapshotsToKeep", "writeSpec", "writeDistributionSpec", "writeOrderingSpec",
+                "callArgument", "singleOrder", "order", "orderField", "transform", "transformArgument",
+                "expression", "constant", "stringMap", "stringArray", "booleanValue",
+                "number", "multipartIdentifier", "identifier", "quotedIdentifier", "fieldList",
+                "nonReserved", "snapshotId", "numSnapshots", "timeUnit"
+        };
+    }
+    public static final String[] ruleNames = makeRuleNames();
+
+    private static String[] makeLiteralNames() {
+        return new String[] {
+                null, "'('", "','", "')'", "'=>'", "'.'", "'ADD'", "'ALTER'", "'AS'",
+                "'ASC'", "'BRANCH'", "'BY'", "'CALL'", "'DAYS'", "'DESC'", "'DISTRIBUTED'",
+                "'DROP'", "'EXISTS'", "'FIELD'", "'FIELDS'", "'FIRST'", "'HOURS'", "'IF'",
+                "'LAST'", "'LOCALLY'", "'MINUTES'", "'MONTHS'", "'CREATE'", "'NOT'",
+                "'NULLS'", "'OF'", "'OR'", "'ORDERED'", "'PARTITION'", "'REPLACE'", "'RETAIN'",
+                "'RETENTION'", "'IDENTIFIER'", "'SET'", "'SNAPSHOT'", "'SNAPSHOTS'",
+                "'TABLE'", "'TAG'", "'UNORDERED'", "'VERSION'", "'WITH'", "'WRITE'",
+                "'TRUE'", "'FALSE'", "'MAP'", "'ARRAY'", "'+'", "'-'"
+        };
+    }
+    private static final String[] _LITERAL_NAMES = makeLiteralNames();
+    private static String[] makeSymbolicNames() {
+        return new String[] {
+                null, null, null, null, null, null, "ADD", "ALTER", "AS", "ASC", "BRANCH",
+                "BY", "CALL", "DAYS", "DESC", "DISTRIBUTED", "DROP", "EXISTS", "FIELD",
+                "FIELDS", "FIRST", "HOURS", "IF", "LAST", "LOCALLY", "MINUTES", "MONTHS",
+                "CREATE", "NOT", "NULLS", "OF", "OR", "ORDERED", "PARTITION", "REPLACE",
+                "RETAIN", "RETENTION", "IDENTIFIER_KW", "SET", "SNAPSHOT", "SNAPSHOTS",
+                "TABLE", "TAG", "UNORDERED", "VERSION", "WITH", "WRITE", "TRUE", "FALSE",
+                "MAP", "ARRAY", "PLUS", "MINUS", "STRING", "BIGINT_LITERAL", "SMALLINT_LITERAL",
+                "TINYINT_LITERAL", "INTEGER_VALUE", "EXPONENT_VALUE", "DECIMAL_VALUE",
+                "FLOAT_LITERAL", "DOUBLE_LITERAL", "BIGDECIMAL_LITERAL", "IDENTIFIER",
+                "BACKQUOTED_IDENTIFIER", "SIMPLE_COMMENT", "BRACKETED_COMMENT", "WS",
+                "UNRECOGNIZED"
+        };
+    }
+    private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
+    public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
+
+    /**
+     * @deprecated Use {@link #VOCABULARY} instead.
+     */
+    @Deprecated
+    public static final String[] tokenNames;
+    static {
+        tokenNames = new String[_SYMBOLIC_NAMES.length];
+        for (int i = 0; i < tokenNames.length; i++) {
+            tokenNames[i] = VOCABULARY.getLiteralName(i);
+            if (tokenNames[i] == null) {
+                tokenNames[i] = VOCABULARY.getSymbolicName(i);
+            }
+
+            if (tokenNames[i] == null) {
+                tokenNames[i] = "<INVALID>";
+            }
+        }
+    }
+
+    @Override
+    @Deprecated
+    public String[] getTokenNames() {
+        return tokenNames;
+    }
+
+    @Override
+
+    public Vocabulary getVocabulary() {
+        return VOCABULARY;
+    }
+
+    @Override
+    public String getGrammarFileName() { return "LakeSoulSqlExtensions.g4"; }
+
+    @Override
+    public String[] getRuleNames() { return ruleNames; }
+
+    @Override
+    public String getSerializedATN() { return _serializedATN; }
+
+    @Override
+    public ATN getATN() { return _ATN; }
+
+    public LakeSoulSqlExtensionsParser(TokenStream input) {
+        super(input);
+        _interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
+    }
+    public static class StatementContext extends ParserRuleContext {
+        public StatementContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_statement; }
+
+        public StatementContext() { }
+        public void copyFrom(StatementContext ctx) {
+            super.copyFrom(ctx);
+        }
+    }
+    public static class CallContext extends StatementContext {
+        public TerminalNode CALL() { return getToken(LakeSoulSqlExtensionsParser.CALL, 0); }
+        public MultipartIdentifierContext multipartIdentifier() {
+            return getRuleContext(MultipartIdentifierContext.class,0);
+        }
+        public List<CallArgumentContext> callArgument() {
+            return getRuleContexts(CallArgumentContext.class);
+        }
+        public CallArgumentContext callArgument(int i) {
+            return getRuleContext(CallArgumentContext.class,i);
+        }
+        public CallContext(StatementContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterCall(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitCall(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitCall(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class SingleStatementContext extends ParserRuleContext {
+        public StatementContext statement() {
+            return getRuleContext(StatementContext.class,0);
+        }
+        public TerminalNode EOF() { return getToken(LakeSoulSqlExtensionsParser.EOF, 0); }
+        public SingleStatementContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_singleStatement; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterSingleStatement(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitSingleStatement(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitSingleStatement(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public final SingleStatementContext singleStatement() throws RecognitionException {
+        SingleStatementContext _localctx = new SingleStatementContext(_ctx, getState());
+        enterRule(_localctx, 0, RULE_singleStatement);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(66);
+                statement();
+                setState(67);
+                match(EOF);
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static class CallArgumentContext extends ParserRuleContext {
+        public CallArgumentContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_callArgument; }
+
+        public CallArgumentContext() { }
+        public void copyFrom(CallArgumentContext ctx) {
+            super.copyFrom(ctx);
+        }
+    }
+    public static class ConstantContext extends ParserRuleContext {
+        public ConstantContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_constant; }
+
+        public ConstantContext() { }
+        public void copyFrom(ConstantContext ctx) {
+            super.copyFrom(ctx);
+        }
+    }
+    public static class StringMapContext extends ParserRuleContext {
+        public TerminalNode MAP() { return getToken(LakeSoulSqlExtensionsParser.MAP, 0); }
+        public List<ConstantContext> constant() {
+            return getRuleContexts(ConstantContext.class);
+        }
+        public ConstantContext constant(int i) {
+            return getRuleContext(ConstantContext.class,i);
+        }
+        public StringMapContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_stringMap; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterStringMap(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitStringMap(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitStringMap(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+
+    public final StringMapContext stringMap() throws RecognitionException {
+        StringMapContext _localctx = new StringMapContext(_ctx, getState());
+        enterRule(_localctx, 42, RULE_stringMap);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(356);
+                match(MAP);
+                setState(357);
+                match(T__0);
+                setState(358);
+                constant();
+                setState(363);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la==T__1) {
+                    {
+                        {
+                            setState(359);
+                            match(T__1);
+                            setState(360);
+                            constant();
+                        }
+                    }
+                    setState(365);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(366);
+                match(T__2);
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class StringArrayContext extends ParserRuleContext {
+        public TerminalNode ARRAY() { return getToken(LakeSoulSqlExtensionsParser.ARRAY, 0); }
+        public List<ConstantContext> constant() {
+            return getRuleContexts(ConstantContext.class);
+        }
+        public ConstantContext constant(int i) {
+            return getRuleContext(ConstantContext.class,i);
+        }
+        public StringArrayContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_stringArray; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterStringArray(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitStringArray(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitStringArray(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class TypeConstructorContext extends ConstantContext {
+        public IdentifierContext identifier() {
+            return getRuleContext(IdentifierContext.class,0);
+        }
+        public TerminalNode STRING() { return getToken(LakeSoulSqlExtensionsParser.STRING, 0); }
+        public TypeConstructorContext(ConstantContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterTypeConstructor(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitTypeConstructor(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitTypeConstructor(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class IdentifierContext extends ParserRuleContext {
+        public IdentifierContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_identifier; }
+
+        public IdentifierContext() { }
+        public void copyFrom(IdentifierContext ctx) {
+            super.copyFrom(ctx);
+        }
+    }
+    public static class NumberContext extends ParserRuleContext {
+        public NumberContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_number; }
+
+        public NumberContext() { }
+        public void copyFrom(NumberContext ctx) {
+            super.copyFrom(ctx);
+        }
+    }
+    public static class NumericLiteralContext extends ConstantContext {
+        public NumberContext number() {
+            return getRuleContext(NumberContext.class,0);
+        }
+        public NumericLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterNumericLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitNumericLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitNumericLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+
+
+    public static class DecimalLiteralContext extends NumberContext {
+        public TerminalNode DECIMAL_VALUE() { return getToken(LakeSoulSqlExtensionsParser.DECIMAL_VALUE, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public DecimalLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterDecimalLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitDecimalLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitDecimalLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class BigIntLiteralContext extends NumberContext {
+        public TerminalNode BIGINT_LITERAL() { return getToken(LakeSoulSqlExtensionsParser.BIGINT_LITERAL, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public BigIntLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterBigIntLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitBigIntLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitBigIntLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class TinyIntLiteralContext extends NumberContext {
+        public TerminalNode TINYINT_LITERAL() { return getToken(LakeSoulSqlExtensionsParser.TINYINT_LITERAL, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public TinyIntLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterTinyIntLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitTinyIntLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitTinyIntLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class BigDecimalLiteralContext extends NumberContext {
+        public TerminalNode BIGDECIMAL_LITERAL() { return getToken(LakeSoulSqlExtensionsParser.BIGDECIMAL_LITERAL, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public BigDecimalLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterBigDecimalLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitBigDecimalLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitBigDecimalLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class ExponentLiteralContext extends NumberContext {
+        public TerminalNode EXPONENT_VALUE() { return getToken(LakeSoulSqlExtensionsParser.EXPONENT_VALUE, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public ExponentLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterExponentLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitExponentLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitExponentLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class DoubleLiteralContext extends NumberContext {
+        public TerminalNode DOUBLE_LITERAL() { return getToken(LakeSoulSqlExtensionsParser.DOUBLE_LITERAL, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public DoubleLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterDoubleLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitDoubleLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitDoubleLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class IntegerLiteralContext extends NumberContext {
+        public TerminalNode INTEGER_VALUE() { return getToken(LakeSoulSqlExtensionsParser.INTEGER_VALUE, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public IntegerLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterIntegerLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitIntegerLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitIntegerLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class FloatLiteralContext extends NumberContext {
+        public TerminalNode FLOAT_LITERAL() { return getToken(LakeSoulSqlExtensionsParser.FLOAT_LITERAL, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public FloatLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterFloatLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitFloatLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitFloatLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class SmallIntLiteralContext extends NumberContext {
+        public TerminalNode SMALLINT_LITERAL() { return getToken(LakeSoulSqlExtensionsParser.SMALLINT_LITERAL, 0); }
+        public TerminalNode MINUS() { return getToken(LakeSoulSqlExtensionsParser.MINUS, 0); }
+        public SmallIntLiteralContext(NumberContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterSmallIntLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitSmallIntLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitSmallIntLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    
+    public final NumberContext number() throws RecognitionException {
+        NumberContext _localctx = new NumberContext(_ctx, getState());
+        enterRule(_localctx, 48, RULE_number);
+        int _la;
+        try {
+            setState(418);
+            _errHandler.sync(this);
+            switch ( getInterpreter().adaptivePredict(_input,46,_ctx) ) {
+                case 1:
+                    _localctx = new ExponentLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(383);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(382);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(385);
+                    match(EXPONENT_VALUE);
+                }
+                break;
+                case 2:
+                    _localctx = new DecimalLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(387);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(386);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(389);
+                    match(DECIMAL_VALUE);
+                }
+                break;
+                case 3:
+                    _localctx = new IntegerLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(391);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(390);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(393);
+                    match(INTEGER_VALUE);
+                }
+                break;
+                case 4:
+                    _localctx = new BigIntLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 4);
+                {
+                    setState(395);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(394);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(397);
+                    match(BIGINT_LITERAL);
+                }
+                break;
+                case 5:
+                    _localctx = new SmallIntLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 5);
+                {
+                    setState(399);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(398);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(401);
+                    match(SMALLINT_LITERAL);
+                }
+                break;
+                case 6:
+                    _localctx = new TinyIntLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 6);
+                {
+                    setState(403);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(402);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(405);
+                    match(TINYINT_LITERAL);
+                }
+                break;
+                case 7:
+                    _localctx = new DoubleLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 7);
+                {
+                    setState(407);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(406);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(409);
+                    match(DOUBLE_LITERAL);
+                }
+                break;
+                case 8:
+                    _localctx = new FloatLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 8);
+                {
+                    setState(411);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(410);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(413);
+                    match(FLOAT_LITERAL);
+                }
+                break;
+                case 9:
+                    _localctx = new BigDecimalLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 9);
+                {
+                    setState(415);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (_la==MINUS) {
+                        {
+                            setState(414);
+                            match(MINUS);
+                        }
+                    }
+
+                    setState(417);
+                    match(BIGDECIMAL_LITERAL);
+                }
+                break;
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static class BooleanLiteralContext extends ConstantContext {
+        public BooleanValueContext booleanValue() {
+            return getRuleContext(BooleanValueContext.class,0);
+        }
+        public BooleanLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterBooleanLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitBooleanLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitBooleanLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class StringLiteralContext extends ConstantContext {
+        public List<TerminalNode> STRING() { return getTokens(LakeSoulSqlExtensionsParser.STRING); }
+        public TerminalNode STRING(int i) {
+            return getToken(LakeSoulSqlExtensionsParser.STRING, i);
+        }
+        public StringLiteralContext(ConstantContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterStringLiteral(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitStringLiteral(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitStringLiteral(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class BooleanValueContext extends ParserRuleContext {
+        public TerminalNode TRUE() { return getToken(LakeSoulSqlExtensionsParser.TRUE, 0); }
+        public TerminalNode FALSE() { return getToken(LakeSoulSqlExtensionsParser.FALSE, 0); }
+        public BooleanValueContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_booleanValue; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterBooleanValue(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitBooleanValue(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitBooleanValue(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public final BooleanValueContext booleanValue() throws RecognitionException {
+        BooleanValueContext _localctx = new BooleanValueContext(_ctx, getState());
+        enterRule(_localctx, 46, RULE_booleanValue);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(380);
+                _la = _input.LA(1);
+                if ( !(_la==TRUE || _la==FALSE) ) {
+                    _errHandler.recoverInline(this);
+                }
+                else {
+                    if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public final ConstantContext constant() throws RecognitionException {
+        ConstantContext _localctx = new ConstantContext(_ctx, getState());
+        enterRule(_localctx, 40, RULE_constant);
+        int _la;
+        try {
+            setState(354);
+            _errHandler.sync(this);
+            switch ( getInterpreter().adaptivePredict(_input,34,_ctx) ) {
+                case 1:
+                    _localctx = new NumericLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(344);
+                    number();
+                }
+                break;
+                case 2:
+                    _localctx = new BooleanLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(345);
+                    booleanValue();
+                }
+                break;
+                case 3:
+                    _localctx = new StringLiteralContext(_localctx);
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(347);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    do {
+                        {
+                            {
+                                setState(346);
+                                match(STRING);
+                            }
+                        }
+                        setState(349);
+                        _errHandler.sync(this);
+                        _la = _input.LA(1);
+                    } while ( _la==STRING );
+                }
+                break;
+                case 4:
+                    _localctx = new TypeConstructorContext(_localctx);
+                    enterOuterAlt(_localctx, 4);
+                {
+                    setState(351);
+                    identifier();
+                    setState(352);
+                    match(STRING);
+                }
+                break;
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    
+    public final StringArrayContext stringArray() throws RecognitionException {
+        StringArrayContext _localctx = new StringArrayContext(_ctx, getState());
+        enterRule(_localctx, 44, RULE_stringArray);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(368);
+                match(ARRAY);
+                setState(369);
+                match(T__0);
+                setState(370);
+                constant();
+                setState(375);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la==T__1) {
+                    {
+                        {
+                            setState(371);
+                            match(T__1);
+                            setState(372);
+                            constant();
+                        }
+                    }
+                    setState(377);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(378);
+                match(T__2);
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static class ExpressionContext extends ParserRuleContext {
+        public ConstantContext constant() {
+            return getRuleContext(ConstantContext.class,0);
+        }
+        public StringMapContext stringMap() {
+            return getRuleContext(StringMapContext.class,0);
+        }
+        public StringArrayContext stringArray() {
+            return getRuleContext(StringArrayContext.class,0);
+        }
+        public ExpressionContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_expression; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterExpression(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitExpression(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitExpression(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class PositionalArgumentContext extends CallArgumentContext {
+        public ExpressionContext expression() {
+            return getRuleContext(ExpressionContext.class,0);
+        }
+        public PositionalArgumentContext(CallArgumentContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterPositionalArgument(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitPositionalArgument(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitPositionalArgument(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public final ExpressionContext expression() throws RecognitionException {
+        ExpressionContext _localctx = new ExpressionContext(_ctx, getState());
+        enterRule(_localctx, 38, RULE_expression);
+        try {
+            setState(342);
+            _errHandler.sync(this);
+            switch ( getInterpreter().adaptivePredict(_input,32,_ctx) ) {
+                case 1:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(339);
+                    constant();
+                }
+                break;
+                case 2:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(340);
+                    stringMap();
+                }
+                break;
+                case 3:
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(341);
+                    stringArray();
+                }
+                break;
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static class NamedArgumentContext extends CallArgumentContext {
+        public IdentifierContext identifier() {
+            return getRuleContext(IdentifierContext.class,0);
+        }
+        public ExpressionContext expression() {
+            return getRuleContext(ExpressionContext.class,0);
+        }
+        public NamedArgumentContext(CallArgumentContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterNamedArgument(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitNamedArgument(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitNamedArgument(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public final CallArgumentContext callArgument() throws RecognitionException {
+        CallArgumentContext _localctx = new CallArgumentContext(_ctx, getState());
+        enterRule(_localctx, 26, RULE_callArgument);
+        try {
+            setState(286);
+            _errHandler.sync(this);
+            switch ( getInterpreter().adaptivePredict(_input,23,_ctx) ) {
+                case 1:
+                    _localctx = new PositionalArgumentContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(281);
+                    expression();
+                }
+                break;
+                case 2:
+                    _localctx = new NamedArgumentContext(_localctx);
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(282);
+                    identifier();
+                    setState(283);
+                    match(T__3);
+                    setState(284);
+                    expression();
+                }
+                break;
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public final StatementContext statement() throws RecognitionException {
+        StatementContext _localctx = new StatementContext(_ctx, getState());
+        enterRule(_localctx, 2, RULE_statement);
+        int _la;
+        try {
+            setState(170);
+            _errHandler.sync(this);
+            switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
+                case 1:
+                    _localctx = new CallContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(69);
+                    match(CALL);
+                    setState(70);
+                    multipartIdentifier();
+                    setState(71);
+                    match(T__0);
+                    setState(80);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (((((_la - 6)) & ~0x3f) == 0 && ((1L << (_la - 6)) & ((1L << (ADD - 6)) | (1L << (ALTER - 6)) | (1L << (AS - 6)) | (1L << (ASC - 6)) | (1L << (BRANCH - 6)) | (1L << (BY - 6)) | (1L << (CALL - 6)) | (1L << (DAYS - 6)) | (1L << (DESC - 6)) | (1L << (DISTRIBUTED - 6)) | (1L << (DROP - 6)) | (1L << (EXISTS - 6)) | (1L << (FIELD - 6)) | (1L << (FIELDS - 6)) | (1L << (FIRST - 6)) | (1L << (HOURS - 6)) | (1L << (IF - 6)) | (1L << (LAST - 6)) | (1L << (LOCALLY - 6)) | (1L << (MINUTES - 6)) | (1L << (MONTHS - 6)) | (1L << (CREATE - 6)) | (1L << (NOT - 6)) | (1L << (NULLS - 6)) | (1L << (OF - 6)) | (1L << (OR - 6)) | (1L << (ORDERED - 6)) | (1L << (PARTITION - 6)) | (1L << (REPLACE - 6)) | (1L << (RETAIN - 6)) | (1L << (IDENTIFIER_KW - 6)) | (1L << (SET - 6)) | (1L << (SNAPSHOT - 6)) | (1L << (SNAPSHOTS - 6)) | (1L << (TABLE - 6)) | (1L << (TAG - 6)) | (1L << (UNORDERED - 6)) | (1L << (VERSION - 6)) | (1L << (WITH - 6)) | (1L << (WRITE - 6)) | (1L << (TRUE - 6)) | (1L << (FALSE - 6)) | (1L << (MAP - 6)) | (1L << (ARRAY - 6)) | (1L << (MINUS - 6)) | (1L << (STRING - 6)) | (1L << (BIGINT_LITERAL - 6)) | (1L << (SMALLINT_LITERAL - 6)) | (1L << (TINYINT_LITERAL - 6)) | (1L << (INTEGER_VALUE - 6)) | (1L << (EXPONENT_VALUE - 6)) | (1L << (DECIMAL_VALUE - 6)) | (1L << (FLOAT_LITERAL - 6)) | (1L << (DOUBLE_LITERAL - 6)) | (1L << (BIGDECIMAL_LITERAL - 6)) | (1L << (IDENTIFIER - 6)) | (1L << (BACKQUOTED_IDENTIFIER - 6)))) != 0)) {
+                        {
+                            setState(72);
+                            callArgument();
+                            setState(77);
+                            _errHandler.sync(this);
+                            _la = _input.LA(1);
+                            while (_la==T__1) {
+                                {
+                                    {
+                                        setState(73);
+                                        match(T__1);
+                                        setState(74);
+                                        callArgument();
+                                    }
+                                }
+                                setState(79);
+                                _errHandler.sync(this);
+                                _la = _input.LA(1);
+                            }
+                        }
+                    }
+
+                    setState(82);
+                    match(T__2);
+                }
+                break;
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static class MultipartIdentifierContext extends ParserRuleContext {
+        public IdentifierContext identifier;
+        public List<IdentifierContext> parts = new ArrayList<IdentifierContext>();
+        public List<IdentifierContext> identifier() {
+            return getRuleContexts(IdentifierContext.class);
+        }
+        public IdentifierContext identifier(int i) {
+            return getRuleContext(IdentifierContext.class,i);
+        }
+        public MultipartIdentifierContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_multipartIdentifier; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterMultipartIdentifier(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitMultipartIdentifier(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitMultipartIdentifier(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public final MultipartIdentifierContext multipartIdentifier() throws RecognitionException {
+        MultipartIdentifierContext _localctx = new MultipartIdentifierContext(_ctx, getState());
+        enterRule(_localctx, 50, RULE_multipartIdentifier);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(420);
+                ((MultipartIdentifierContext)_localctx).identifier = identifier();
+                ((MultipartIdentifierContext)_localctx).parts.add(((MultipartIdentifierContext)_localctx).identifier);
+                setState(425);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la==T__4) {
+                    {
+                        {
+                            setState(421);
+                            match(T__4);
+                            setState(422);
+                            ((MultipartIdentifierContext)_localctx).identifier = identifier();
+                            ((MultipartIdentifierContext)_localctx).parts.add(((MultipartIdentifierContext)_localctx).identifier);
+                        }
+                    }
+                    setState(427);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static class NonReservedContext extends ParserRuleContext {
+        public TerminalNode ADD() { return getToken(LakeSoulSqlExtensionsParser.ADD, 0); }
+        public TerminalNode ALTER() { return getToken(LakeSoulSqlExtensionsParser.ALTER, 0); }
+        public TerminalNode AS() { return getToken(LakeSoulSqlExtensionsParser.AS, 0); }
+        public TerminalNode ASC() { return getToken(LakeSoulSqlExtensionsParser.ASC, 0); }
+        public TerminalNode BRANCH() { return getToken(LakeSoulSqlExtensionsParser.BRANCH, 0); }
+        public TerminalNode BY() { return getToken(LakeSoulSqlExtensionsParser.BY, 0); }
+        public TerminalNode CALL() { return getToken(LakeSoulSqlExtensionsParser.CALL, 0); }
+        public TerminalNode CREATE() { return getToken(LakeSoulSqlExtensionsParser.CREATE, 0); }
+        public TerminalNode DAYS() { return getToken(LakeSoulSqlExtensionsParser.DAYS, 0); }
+        public TerminalNode DESC() { return getToken(LakeSoulSqlExtensionsParser.DESC, 0); }
+        public TerminalNode DROP() { return getToken(LakeSoulSqlExtensionsParser.DROP, 0); }
+        public TerminalNode EXISTS() { return getToken(LakeSoulSqlExtensionsParser.EXISTS, 0); }
+        public TerminalNode FIELD() { return getToken(LakeSoulSqlExtensionsParser.FIELD, 0); }
+        public TerminalNode FIRST() { return getToken(LakeSoulSqlExtensionsParser.FIRST, 0); }
+        public TerminalNode HOURS() { return getToken(LakeSoulSqlExtensionsParser.HOURS, 0); }
+        public TerminalNode IF() { return getToken(LakeSoulSqlExtensionsParser.IF, 0); }
+        public TerminalNode LAST() { return getToken(LakeSoulSqlExtensionsParser.LAST, 0); }
+        public TerminalNode NOT() { return getToken(LakeSoulSqlExtensionsParser.NOT, 0); }
+        public TerminalNode NULLS() { return getToken(LakeSoulSqlExtensionsParser.NULLS, 0); }
+        public TerminalNode OF() { return getToken(LakeSoulSqlExtensionsParser.OF, 0); }
+        public TerminalNode OR() { return getToken(LakeSoulSqlExtensionsParser.OR, 0); }
+        public TerminalNode ORDERED() { return getToken(LakeSoulSqlExtensionsParser.ORDERED, 0); }
+        public TerminalNode PARTITION() { return getToken(LakeSoulSqlExtensionsParser.PARTITION, 0); }
+        public TerminalNode TABLE() { return getToken(LakeSoulSqlExtensionsParser.TABLE, 0); }
+        public TerminalNode WRITE() { return getToken(LakeSoulSqlExtensionsParser.WRITE, 0); }
+        public TerminalNode DISTRIBUTED() { return getToken(LakeSoulSqlExtensionsParser.DISTRIBUTED, 0); }
+        public TerminalNode LOCALLY() { return getToken(LakeSoulSqlExtensionsParser.LOCALLY, 0); }
+        public TerminalNode MINUTES() { return getToken(LakeSoulSqlExtensionsParser.MINUTES, 0); }
+        public TerminalNode MONTHS() { return getToken(LakeSoulSqlExtensionsParser.MONTHS, 0); }
+        public TerminalNode UNORDERED() { return getToken(LakeSoulSqlExtensionsParser.UNORDERED, 0); }
+        public TerminalNode REPLACE() { return getToken(LakeSoulSqlExtensionsParser.REPLACE, 0); }
+        public TerminalNode RETAIN() { return getToken(LakeSoulSqlExtensionsParser.RETAIN, 0); }
+        public TerminalNode VERSION() { return getToken(LakeSoulSqlExtensionsParser.VERSION, 0); }
+        public TerminalNode WITH() { return getToken(LakeSoulSqlExtensionsParser.WITH, 0); }
+        public TerminalNode IDENTIFIER_KW() { return getToken(LakeSoulSqlExtensionsParser.IDENTIFIER_KW, 0); }
+        public TerminalNode FIELDS() { return getToken(LakeSoulSqlExtensionsParser.FIELDS, 0); }
+        public TerminalNode SET() { return getToken(LakeSoulSqlExtensionsParser.SET, 0); }
+        public TerminalNode SNAPSHOT() { return getToken(LakeSoulSqlExtensionsParser.SNAPSHOT, 0); }
+        public TerminalNode SNAPSHOTS() { return getToken(LakeSoulSqlExtensionsParser.SNAPSHOTS, 0); }
+        public TerminalNode TAG() { return getToken(LakeSoulSqlExtensionsParser.TAG, 0); }
+        public TerminalNode TRUE() { return getToken(LakeSoulSqlExtensionsParser.TRUE, 0); }
+        public TerminalNode FALSE() { return getToken(LakeSoulSqlExtensionsParser.FALSE, 0); }
+        public TerminalNode MAP() { return getToken(LakeSoulSqlExtensionsParser.MAP, 0); }
+        public NonReservedContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_nonReserved; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterNonReserved(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitNonReserved(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitNonReserved(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class UnquotedIdentifierContext extends IdentifierContext {
+        public TerminalNode IDENTIFIER() { return getToken(LakeSoulSqlExtensionsParser.IDENTIFIER, 0); }
+        public NonReservedContext nonReserved() {
+            return getRuleContext(NonReservedContext.class,0);
+        }
+        public UnquotedIdentifierContext(IdentifierContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterUnquotedIdentifier(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitUnquotedIdentifier(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitUnquotedIdentifier(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class QuotedIdentifierContext extends ParserRuleContext {
+        public TerminalNode BACKQUOTED_IDENTIFIER() { return getToken(LakeSoulSqlExtensionsParser.BACKQUOTED_IDENTIFIER, 0); }
+        public QuotedIdentifierContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+        @Override public int getRuleIndex() { return RULE_quotedIdentifier; }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterQuotedIdentifier(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitQuotedIdentifier(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitQuotedIdentifier(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public static class QuotedIdentifierAlternativeContext extends IdentifierContext {
+        public QuotedIdentifierContext quotedIdentifier() {
+            return getRuleContext(QuotedIdentifierContext.class,0);
+        }
+        public QuotedIdentifierAlternativeContext(IdentifierContext ctx) { copyFrom(ctx); }
+        @Override
+        public void enterRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).enterQuotedIdentifierAlternative(this);
+        }
+        @Override
+        public void exitRule(ParseTreeListener listener) {
+            if ( listener instanceof LakeSoulSqlExtensionsListener ) ((LakeSoulSqlExtensionsListener)listener).exitQuotedIdentifierAlternative(this);
+        }
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if ( visitor instanceof LakeSoulSqlExtensionsVisitor ) return ((LakeSoulSqlExtensionsVisitor<? extends T>)visitor).visitQuotedIdentifierAlternative(this);
+            else return visitor.visitChildren(this);
+        }
+    }
+    public final QuotedIdentifierContext quotedIdentifier() throws RecognitionException {
+        QuotedIdentifierContext _localctx = new QuotedIdentifierContext(_ctx, getState());
+        enterRule(_localctx, 54, RULE_quotedIdentifier);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(433);
+                match(BACKQUOTED_IDENTIFIER);
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public final IdentifierContext identifier() throws RecognitionException {
+        IdentifierContext _localctx = new IdentifierContext(_ctx, getState());
+        enterRule(_localctx, 52, RULE_identifier);
+        try {
+            setState(431);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case IDENTIFIER:
+                    _localctx = new UnquotedIdentifierContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(428);
+                    match(IDENTIFIER);
+                }
+                break;
+                case BACKQUOTED_IDENTIFIER:
+                    _localctx = new QuotedIdentifierAlternativeContext(_localctx);
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(429);
+                    quotedIdentifier();
+                }
+                break;
+                case ADD:
+                case ALTER:
+                case AS:
+                case ASC:
+                case BRANCH:
+                case BY:
+                case CALL:
+                case DAYS:
+                case DESC:
+                case DISTRIBUTED:
+                case DROP:
+                case EXISTS:
+                case FIELD:
+                case FIELDS:
+                case FIRST:
+                case HOURS:
+                case IF:
+                case LAST:
+                case LOCALLY:
+                case MINUTES:
+                case MONTHS:
+                case CREATE:
+                case NOT:
+                case NULLS:
+                case OF:
+                case OR:
+                case ORDERED:
+                case PARTITION:
+                case REPLACE:
+                case RETAIN:
+                case IDENTIFIER_KW:
+                case SET:
+                case SNAPSHOT:
+                case SNAPSHOTS:
+                case TABLE:
+                case TAG:
+                case UNORDERED:
+                case VERSION:
+                case WITH:
+                case WRITE:
+                case TRUE:
+                case FALSE:
+                case MAP:
+                    _localctx = new UnquotedIdentifierContext(_localctx);
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(430);
+                    nonReserved();
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public final NonReservedContext nonReserved() throws RecognitionException {
+        NonReservedContext _localctx = new NonReservedContext(_ctx, getState());
+        enterRule(_localctx, 58, RULE_nonReserved);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(443);
+                _la = _input.LA(1);
+                if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ADD) | (1L << ALTER) | (1L << AS) | (1L << ASC) | (1L << BRANCH) | (1L << BY) | (1L << CALL) | (1L << DAYS) | (1L << DESC) | (1L << DISTRIBUTED) | (1L << DROP) | (1L << EXISTS) | (1L << FIELD) | (1L << FIELDS) | (1L << FIRST) | (1L << HOURS) | (1L << IF) | (1L << LAST) | (1L << LOCALLY) | (1L << MINUTES) | (1L << MONTHS) | (1L << CREATE) | (1L << NOT) | (1L << NULLS) | (1L << OF) | (1L << OR) | (1L << ORDERED) | (1L << PARTITION) | (1L << REPLACE) | (1L << RETAIN) | (1L << IDENTIFIER_KW) | (1L << SET) | (1L << SNAPSHOT) | (1L << SNAPSHOTS) | (1L << TABLE) | (1L << TAG) | (1L << UNORDERED) | (1L << VERSION) | (1L << WITH) | (1L << WRITE) | (1L << TRUE) | (1L << FALSE) | (1L << MAP))) != 0)) ) {
+                    _errHandler.recoverInline(this);
+                }
+                else {
+                    if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        }
+        catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        }
+        finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+    public static final String _serializedATN =
+            "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3F\u01c6\4\2\t\2\4"+
+                    "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
+                    "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
+                    "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
+                    "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
+                    "\t!\4\"\t\"\3\2\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3\3\7\3N\n\3\f\3\16\3Q\13"+
+                    "\3\5\3S\n\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\5\3`\n\3\3\3\3"+
+                    "\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3"+
+                    "\5\3u\n\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3"+
+                    "\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3"+
+                    "\3\3\3\3\3\3\3\3\3\3\3\3\3\5\3\u009e\n\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3"+
+                    "\3\3\3\5\3\u00a9\n\3\3\3\3\3\5\3\u00ad\n\3\3\4\3\4\5\4\u00b1\n\4\3\4\3"+
+                    "\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\5\4\u00bd\n\4\3\4\3\4\3\4\5\4\u00c2"+
+                    "\n\4\3\5\3\5\5\5\u00c6\n\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\3\5\5\5"+
+                    "\u00d2\n\5\3\5\3\5\3\5\5\5\u00d7\n\5\3\6\3\6\3\6\3\6\5\6\u00dd\n\6\3\6"+
+                    "\5\6\u00e0\n\6\3\7\3\7\3\7\3\7\5\7\u00e6\n\7\3\7\5\7\u00e9\n\7\3\7\5\7"+
+                    "\u00ec\n\7\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\3\b\5\b"+
+                    "\u00fc\n\b\3\t\3\t\3\t\3\t\3\n\3\n\3\n\3\13\3\13\3\13\3\f\3\f\7\f\u010a"+
+                    "\n\f\f\f\16\f\u010d\13\f\3\r\3\r\3\r\3\r\3\16\5\16\u0114\n\16\3\16\3\16"+
+                    "\3\16\3\16\5\16\u011a\n\16\3\17\3\17\3\17\3\17\3\17\5\17\u0121\n\17\3"+
+                    "\20\3\20\3\20\3\21\3\21\3\21\7\21\u0129\n\21\f\21\16\21\u012c\13\21\3"+
+                    "\21\3\21\3\21\3\21\7\21\u0132\n\21\f\21\16\21\u0135\13\21\3\21\3\21\5"+
+                    "\21\u0139\n\21\3\22\3\22\5\22\u013d\n\22\3\22\3\22\5\22\u0141\n\22\3\23"+
+                    "\3\23\3\23\3\23\3\23\3\23\7\23\u0149\n\23\f\23\16\23\u014c\13\23\3\23"+
+                    "\3\23\5\23\u0150\n\23\3\24\3\24\5\24\u0154\n\24\3\25\3\25\3\25\5\25\u0159"+
+                    "\n\25\3\26\3\26\3\26\6\26\u015e\n\26\r\26\16\26\u015f\3\26\3\26\3\26\5"+
+                    "\26\u0165\n\26\3\27\3\27\3\27\3\27\3\27\7\27\u016c\n\27\f\27\16\27\u016f"+
+                    "\13\27\3\27\3\27\3\30\3\30\3\30\3\30\3\30\7\30\u0178\n\30\f\30\16\30\u017b"+
+                    "\13\30\3\30\3\30\3\31\3\31\3\32\5\32\u0182\n\32\3\32\3\32\5\32\u0186\n"+
+                    "\32\3\32\3\32\5\32\u018a\n\32\3\32\3\32\5\32\u018e\n\32\3\32\3\32\5\32"+
+                    "\u0192\n\32\3\32\3\32\5\32\u0196\n\32\3\32\3\32\5\32\u019a\n\32\3\32\3"+
+                    "\32\5\32\u019e\n\32\3\32\3\32\5\32\u01a2\n\32\3\32\5\32\u01a5\n\32\3\33"+
+                    "\3\33\3\33\7\33\u01aa\n\33\f\33\16\33\u01ad\13\33\3\34\3\34\3\34\5\34"+
+                    "\u01b2\n\34\3\35\3\35\3\36\3\36\3\36\7\36\u01b9\n\36\f\36\16\36\u01bc"+
+                    "\13\36\3\37\3\37\3 \3 \3!\3!\3\"\3\"\3\"\2\2#\2\4\6\b\n\f\16\20\22\24"+
+                    "\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@B\2\7\4\2\13\13\20\20\4\2\26"+
+                    "\26\31\31\3\2\61\62\4\2\b%\'\63\5\2\17\17\27\27\33\33\2\u01eb\2D\3\2\2"+
+                    "\2\4\u00ac\3\2\2\2\6\u00c1\3\2\2\2\b\u00d6\3\2\2\2\n\u00dc\3\2\2\2\f\u00e5"+
+                    "\3\2\2\2\16\u00fb\3\2\2\2\20\u00fd\3\2\2\2\22\u0101\3\2\2\2\24\u0104\3"+
+                    "\2\2\2\26\u010b\3\2\2\2\30\u010e\3\2\2\2\32\u0119\3\2\2\2\34\u0120\3\2"+
+                    "\2\2\36\u0122\3\2\2\2 \u0138\3\2\2\2\"\u013a\3\2\2\2$\u014f\3\2\2\2&\u0153"+
+                    "\3\2\2\2(\u0158\3\2\2\2*\u0164\3\2\2\2,\u0166\3\2\2\2.\u0172\3\2\2\2\60"+
+                    "\u017e\3\2\2\2\62\u01a4\3\2\2\2\64\u01a6\3\2\2\2\66\u01b1\3\2\2\28\u01b3"+
+                    "\3\2\2\2:\u01b5\3\2\2\2<\u01bd\3\2\2\2>\u01bf\3\2\2\2@\u01c1\3\2\2\2B"+
+                    "\u01c3\3\2\2\2DE\5\4\3\2EF\7\2\2\3F\3\3\2\2\2GH\7\16\2\2HI\5\64\33\2I"+
+                    "R\7\3\2\2JO\5\34\17\2KL\7\4\2\2LN\5\34\17\2MK\3\2\2\2NQ\3\2\2\2OM\3\2"+
+                    "\2\2OP\3\2\2\2PS\3\2\2\2QO\3\2\2\2RJ\3\2\2\2RS\3\2\2\2ST\3\2\2\2TU\7\5"+
+                    "\2\2U\u00ad\3\2\2\2VW\7\t\2\2WX\7+\2\2XY\5\64\33\2YZ\7\b\2\2Z[\7#\2\2"+
+                    "[\\\7\24\2\2\\_\5$\23\2]^\7\n\2\2^`\5\66\34\2_]\3\2\2\2_`\3\2\2\2`\u00ad"+
+                    "\3\2\2\2ab\7\t\2\2bc\7+\2\2cd\5\64\33\2de\7\22\2\2ef\7#\2\2fg\7\24\2\2"+
+                    "gh\5$\23\2h\u00ad\3\2\2\2ij\7\t\2\2jk\7+\2\2kl\5\64\33\2lm\7$\2\2mn\7"+
+                    "#\2\2no\7\24\2\2op\5$\23\2pq\7/\2\2qt\5$\23\2rs\7\n\2\2su\5\66\34\2tr"+
+                    "\3\2\2\2tu\3\2\2\2u\u00ad\3\2\2\2vw\7\t\2\2wx\7+\2\2xy\5\64\33\2yz\7\60"+
+                    "\2\2z{\5\26\f\2{\u00ad\3\2\2\2|}\7\t\2\2}~\7+\2\2~\177\5\64\33\2\177\u0080"+
+                    "\7(\2\2\u0080\u0081\7\'\2\2\u0081\u0082\7\25\2\2\u0082\u0083\5:\36\2\u0083"+
+                    "\u00ad\3\2\2\2\u0084\u0085\7\t\2\2\u0085\u0086\7+\2\2\u0086\u0087\5\64"+
+                    "\33\2\u0087\u0088\7\22\2\2\u0088\u0089\7\'\2\2\u0089\u008a\7\25\2\2\u008a"+
+                    "\u008b\5:\36\2\u008b\u00ad\3\2\2\2\u008c\u008d\7\t\2\2\u008d\u008e\7+"+
+                    "\2\2\u008e\u008f\5\64\33\2\u008f\u0090\5\b\5\2\u0090\u00ad\3\2\2\2\u0091"+
+                    "\u0092\7\t\2\2\u0092\u0093\7+\2\2\u0093\u0094\5\64\33\2\u0094\u0095\5"+
+                    "\6\4\2\u0095\u00ad\3\2\2\2\u0096\u0097\7\t\2\2\u0097\u0098\7+\2\2\u0098"+
+                    "\u0099\5\64\33\2\u0099\u009a\7\22\2\2\u009a\u009d\7\f\2\2\u009b\u009c"+
+                    "\7\30\2\2\u009c\u009e\7\23\2\2\u009d\u009b\3\2\2\2\u009d\u009e\3\2\2\2"+
+                    "\u009e\u009f\3\2\2\2\u009f\u00a0\5\66\34\2\u00a0\u00ad\3\2\2\2\u00a1\u00a2"+
+                    "\7\t\2\2\u00a2\u00a3\7+\2\2\u00a3\u00a4\5\64\33\2\u00a4\u00a5\7\22\2\2"+
+                    "\u00a5\u00a8\7,\2\2\u00a6\u00a7\7\30\2\2\u00a7\u00a9\7\23\2\2\u00a8\u00a6"+
+                    "\3\2\2\2\u00a8\u00a9\3\2\2\2\u00a9\u00aa\3\2\2\2\u00aa\u00ab\5\66\34\2"+
+                    "\u00ab\u00ad\3\2\2\2\u00acG\3\2\2\2\u00acV\3\2\2\2\u00aca\3\2\2\2\u00ac"+
+                    "i\3\2\2\2\u00acv\3\2\2\2\u00ac|\3\2\2\2\u00ac\u0084\3\2\2\2\u00ac\u008c"+
+                    "\3\2\2\2\u00ac\u0091\3\2\2\2\u00ac\u0096\3\2\2\2\u00ac\u00a1\3\2\2\2\u00ad"+
+                    "\5\3\2\2\2\u00ae\u00af\7\35\2\2\u00af\u00b1\7!\2\2\u00b0\u00ae\3\2\2\2"+
+                    "\u00b0\u00b1\3\2\2\2\u00b1\u00b2\3\2\2\2\u00b2\u00b3\7$\2\2\u00b3\u00b4"+
+                    "\7,\2\2\u00b4\u00b5\5\66\34\2\u00b5\u00b6\5\n\6\2\u00b6\u00c2\3\2\2\2"+
+                    "\u00b7\u00b8\7\35\2\2\u00b8\u00bc\7,\2\2\u00b9\u00ba\7\30\2\2\u00ba\u00bb"+
+                    "\7\36\2\2\u00bb\u00bd\7\23\2\2\u00bc\u00b9\3\2\2\2\u00bc\u00bd\3\2\2\2"+
+                    "\u00bd\u00be\3\2\2\2\u00be\u00bf\5\66\34\2\u00bf\u00c0\5\n\6\2\u00c0\u00c2"+
+                    "\3\2\2\2\u00c1\u00b0\3\2\2\2\u00c1\u00b7\3\2\2\2\u00c2\7\3\2\2\2\u00c3"+
+                    "\u00c4\7\35\2\2\u00c4\u00c6\7!\2\2\u00c5\u00c3\3\2\2\2\u00c5\u00c6\3\2"+
+                    "\2\2\u00c6\u00c7\3\2\2\2\u00c7\u00c8\7$\2\2\u00c8\u00c9\7\f\2\2\u00c9"+
+                    "\u00ca\5\66\34\2\u00ca\u00cb\5\f\7\2\u00cb\u00d7\3\2\2\2\u00cc\u00cd\7"+
+                    "\35\2\2\u00cd\u00d1\7\f\2\2\u00ce\u00cf\7\30\2\2\u00cf\u00d0\7\36\2\2"+
+                    "\u00d0\u00d2\7\23\2\2\u00d1\u00ce\3\2\2\2\u00d1\u00d2\3\2\2\2\u00d2\u00d3"+
+                    "\3\2\2\2\u00d3\u00d4\5\66\34\2\u00d4\u00d5\5\f\7\2\u00d5\u00d7\3\2\2\2"+
+                    "\u00d6\u00c5\3\2\2\2\u00d6\u00cc\3\2\2\2\u00d7\t\3\2\2\2\u00d8\u00d9\7"+
+                    "\n\2\2\u00d9\u00da\7 \2\2\u00da\u00db\7.\2\2\u00db\u00dd\5> \2\u00dc\u00d8"+
+                    "\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd\u00df\3\2\2\2\u00de\u00e0\5\20\t\2"+
+                    "\u00df\u00de\3\2\2\2\u00df\u00e0\3\2\2\2\u00e0\13\3\2\2\2\u00e1\u00e2"+
+                    "\7\n\2\2\u00e2\u00e3\7 \2\2\u00e3\u00e4\7.\2\2\u00e4\u00e6\5> \2\u00e5"+
+                    "\u00e1\3\2\2\2\u00e5\u00e6\3\2\2\2\u00e6\u00e8\3\2\2\2\u00e7\u00e9\5\20"+
+                    "\t\2\u00e8\u00e7\3\2\2\2\u00e8\u00e9\3\2\2\2\u00e9\u00eb\3\2\2\2\u00ea"+
+                    "\u00ec\5\16\b\2\u00eb\u00ea\3\2\2\2\u00eb\u00ec\3\2\2\2\u00ec\r\3\2\2"+
+                    "\2\u00ed\u00ee\7/\2\2\u00ee\u00ef\7)\2\2\u00ef\u00f0\7&\2\2\u00f0\u00fc"+
+                    "\5\24\13\2\u00f1\u00f2\7/\2\2\u00f2\u00f3\7)\2\2\u00f3\u00f4\7&\2\2\u00f4"+
+                    "\u00fc\5\22\n\2\u00f5\u00f6\7/\2\2\u00f6\u00f7\7)\2\2\u00f7\u00f8\7&\2"+
+                    "\2\u00f8\u00f9\5\24\13\2\u00f9\u00fa\5\22\n\2\u00fa\u00fc\3\2\2\2\u00fb"+
+                    "\u00ed\3\2\2\2\u00fb\u00f1\3\2\2\2\u00fb\u00f5\3\2\2\2\u00fc\17\3\2\2"+
+                    "\2\u00fd\u00fe\7%\2\2\u00fe\u00ff\5\62\32\2\u00ff\u0100\5B\"\2\u0100\21"+
+                    "\3\2\2\2\u0101\u0102\5\62\32\2\u0102\u0103\5B\"\2\u0103\23\3\2\2\2\u0104"+
+                    "\u0105\5\62\32\2\u0105\u0106\7*\2\2\u0106\25\3\2\2\2\u0107\u010a\5\30"+
+                    "\r\2\u0108\u010a\5\32\16\2\u0109\u0107\3\2\2\2\u0109\u0108\3\2\2\2\u010a"+
+                    "\u010d\3\2\2\2\u010b\u0109\3\2\2\2\u010b\u010c\3\2\2\2\u010c\27\3\2\2"+
+                    "\2\u010d\u010b\3\2\2\2\u010e\u010f\7\21\2\2\u010f\u0110\7\r\2\2\u0110"+
+                    "\u0111\7#\2\2\u0111\31\3\2\2\2\u0112\u0114\7\32\2\2\u0113\u0112\3\2\2"+
+                    "\2\u0113\u0114\3\2\2\2\u0114\u0115\3\2\2\2\u0115\u0116\7\"\2\2\u0116\u0117"+
+                    "\7\r\2\2\u0117\u011a\5 \21\2\u0118\u011a\7-\2\2\u0119\u0113\3\2\2\2\u0119"+
+                    "\u0118\3\2\2\2\u011a\33\3\2\2\2\u011b\u0121\5(\25\2\u011c\u011d\5\66\34"+
+                    "\2\u011d\u011e\7\6\2\2\u011e\u011f\5(\25\2\u011f\u0121\3\2\2\2\u0120\u011b"+
+                    "\3\2\2\2\u0120\u011c\3\2\2\2\u0121\35\3\2\2\2\u0122\u0123\5 \21\2\u0123"+
+                    "\u0124\7\2\2\3\u0124\37\3\2\2\2\u0125\u012a\5\"\22\2\u0126\u0127\7\4\2"+
+                    "\2\u0127\u0129\5\"\22\2\u0128\u0126\3\2\2\2\u0129\u012c\3\2\2\2\u012a"+
+                    "\u0128\3\2\2\2\u012a\u012b\3\2\2\2\u012b\u0139\3\2\2\2\u012c\u012a\3\2"+
+                    "\2\2\u012d\u012e\7\3\2\2\u012e\u0133\5\"\22\2\u012f\u0130\7\4\2\2\u0130"+
+                    "\u0132\5\"\22\2\u0131\u012f\3\2\2\2\u0132\u0135\3\2\2\2\u0133\u0131\3"+
+                    "\2\2\2\u0133\u0134\3\2\2\2\u0134\u0136\3\2\2\2\u0135\u0133\3\2\2\2\u0136"+
+                    "\u0137\7\5\2\2\u0137\u0139\3\2\2\2\u0138\u0125\3\2\2\2\u0138\u012d\3\2"+
+                    "\2\2\u0139!\3\2\2\2\u013a\u013c\5$\23\2\u013b\u013d\t\2\2\2\u013c\u013b"+
+                    "\3\2\2\2\u013c\u013d\3\2\2\2\u013d\u0140\3\2\2\2\u013e\u013f\7\37\2\2"+
+                    "\u013f\u0141\t\3\2\2\u0140\u013e\3\2\2\2\u0140\u0141\3\2\2\2\u0141#\3"+
+                    "\2\2\2\u0142\u0150\5\64\33\2\u0143\u0144\5\66\34\2\u0144\u0145\7\3\2\2"+
+                    "\u0145\u014a\5&\24\2\u0146\u0147\7\4\2\2\u0147\u0149\5&\24\2\u0148\u0146"+
+                    "\3\2\2\2\u0149\u014c\3\2\2\2\u014a\u0148\3\2\2\2\u014a\u014b\3\2\2\2\u014b"+
+                    "\u014d\3\2\2\2\u014c\u014a\3\2\2\2\u014d\u014e\7\5\2\2\u014e\u0150\3\2"+
+                    "\2\2\u014f\u0142\3\2\2\2\u014f\u0143\3\2\2\2\u0150%\3\2\2\2\u0151\u0154"+
+                    "\5\64\33\2\u0152\u0154\5*\26\2\u0153\u0151\3\2\2\2\u0153\u0152\3\2\2\2"+
+                    "\u0154\'\3\2\2\2\u0155\u0159\5*\26\2\u0156\u0159\5,\27\2\u0157\u0159\5"+
+                    ".\30\2\u0158\u0155\3\2\2\2\u0158\u0156\3\2\2\2\u0158\u0157\3\2\2\2\u0159"+
+                    ")\3\2\2\2\u015a\u0165\5\62\32\2\u015b\u0165\5\60\31\2\u015c\u015e\7\67"+
+                    "\2\2\u015d\u015c\3\2\2\2\u015e\u015f\3\2\2\2\u015f\u015d\3\2\2\2\u015f"+
+                    "\u0160\3\2\2\2\u0160\u0165\3\2\2\2\u0161\u0162\5\66\34\2\u0162\u0163\7"+
+                    "\67\2\2\u0163\u0165\3\2\2\2\u0164\u015a\3\2\2\2\u0164\u015b\3\2\2\2\u0164"+
+                    "\u015d\3\2\2\2\u0164\u0161\3\2\2\2\u0165+\3\2\2\2\u0166\u0167\7\63\2\2"+
+                    "\u0167\u0168\7\3\2\2\u0168\u016d\5*\26\2\u0169\u016a\7\4\2\2\u016a\u016c"+
+                    "\5*\26\2\u016b\u0169\3\2\2\2\u016c\u016f\3\2\2\2\u016d\u016b\3\2\2\2\u016d"+
+                    "\u016e\3\2\2\2\u016e\u0170\3\2\2\2\u016f\u016d\3\2\2\2\u0170\u0171\7\5"+
+                    "\2\2\u0171-\3\2\2\2\u0172\u0173\7\64\2\2\u0173\u0174\7\3\2\2\u0174\u0179"+
+                    "\5*\26\2\u0175\u0176\7\4\2\2\u0176\u0178\5*\26\2\u0177\u0175\3\2\2\2\u0178"+
+                    "\u017b\3\2\2\2\u0179\u0177\3\2\2\2\u0179\u017a\3\2\2\2\u017a\u017c\3\2"+
+                    "\2\2\u017b\u0179\3\2\2\2\u017c\u017d\7\5\2\2\u017d/\3\2\2\2\u017e\u017f"+
+                    "\t\4\2\2\u017f\61\3\2\2\2\u0180\u0182\7\66\2\2\u0181\u0180\3\2\2\2\u0181"+
+                    "\u0182\3\2\2\2\u0182\u0183\3\2\2\2\u0183\u01a5\7<\2\2\u0184\u0186\7\66"+
+                    "\2\2\u0185\u0184\3\2\2\2\u0185\u0186\3\2\2\2\u0186\u0187\3\2\2\2\u0187"+
+                    "\u01a5\7=\2\2\u0188\u018a\7\66\2\2\u0189\u0188\3\2\2\2\u0189\u018a\3\2"+
+                    "\2\2\u018a\u018b\3\2\2\2\u018b\u01a5\7;\2\2\u018c\u018e\7\66\2\2\u018d"+
+                    "\u018c\3\2\2\2\u018d\u018e\3\2\2\2\u018e\u018f\3\2\2\2\u018f\u01a5\78"+
+                    "\2\2\u0190\u0192\7\66\2\2\u0191\u0190\3\2\2\2\u0191\u0192\3\2\2\2\u0192"+
+                    "\u0193\3\2\2\2\u0193\u01a5\79\2\2\u0194\u0196\7\66\2\2\u0195\u0194\3\2"+
+                    "\2\2\u0195\u0196\3\2\2\2\u0196\u0197\3\2\2\2\u0197\u01a5\7:\2\2\u0198"+
+                    "\u019a\7\66\2\2\u0199\u0198\3\2\2\2\u0199\u019a\3\2\2\2\u019a\u019b\3"+
+                    "\2\2\2\u019b\u01a5\7?\2\2\u019c\u019e\7\66\2\2\u019d\u019c\3\2\2\2\u019d"+
+                    "\u019e\3\2\2\2\u019e\u019f\3\2\2\2\u019f\u01a5\7>\2\2\u01a0\u01a2\7\66"+
+                    "\2\2\u01a1\u01a0\3\2\2\2\u01a1\u01a2\3\2\2\2\u01a2\u01a3\3\2\2\2\u01a3"+
+                    "\u01a5\7@\2\2\u01a4\u0181\3\2\2\2\u01a4\u0185\3\2\2\2\u01a4\u0189\3\2"+
+                    "\2\2\u01a4\u018d\3\2\2\2\u01a4\u0191\3\2\2\2\u01a4\u0195\3\2\2\2\u01a4"+
+                    "\u0199\3\2\2\2\u01a4\u019d\3\2\2\2\u01a4\u01a1\3\2\2\2\u01a5\63\3\2\2"+
+                    "\2\u01a6\u01ab\5\66\34\2\u01a7\u01a8\7\7\2\2\u01a8\u01aa\5\66\34\2\u01a9"+
+                    "\u01a7\3\2\2\2\u01aa\u01ad\3\2\2\2\u01ab\u01a9\3\2\2\2\u01ab\u01ac\3\2"+
+                    "\2\2\u01ac\65\3\2\2\2\u01ad\u01ab\3\2\2\2\u01ae\u01b2\7A\2\2\u01af\u01b2"+
+                    "\58\35\2\u01b0\u01b2\5<\37\2\u01b1\u01ae\3\2\2\2\u01b1\u01af\3\2\2\2\u01b1"+
+                    "\u01b0\3\2\2\2\u01b2\67\3\2\2\2\u01b3\u01b4\7B\2\2\u01b49\3\2\2\2\u01b5"+
+                    "\u01ba\5\64\33\2\u01b6\u01b7\7\4\2\2\u01b7\u01b9\5\64\33\2\u01b8\u01b6"+
+                    "\3\2\2\2\u01b9\u01bc\3\2\2\2\u01ba\u01b8\3\2\2\2\u01ba\u01bb\3\2\2\2\u01bb"+
+                    ";\3\2\2\2\u01bc\u01ba\3\2\2\2\u01bd\u01be\t\5\2\2\u01be=\3\2\2\2\u01bf"+
+                    "\u01c0\5\62\32\2\u01c0?\3\2\2\2\u01c1\u01c2\5\62\32\2\u01c2A\3\2\2\2\u01c3"+
+                    "\u01c4\t\6\2\2\u01c4C\3\2\2\2\64OR_t\u009d\u00a8\u00ac\u00b0\u00bc\u00c1"+
+                    "\u00c5\u00d1\u00d6\u00dc\u00df\u00e5\u00e8\u00eb\u00fb\u0109\u010b\u0113"+
+                    "\u0119\u0120\u012a\u0133\u0138\u013c\u0140\u014a\u014f\u0153\u0158\u015f"+
+                    "\u0164\u016d\u0179\u0181\u0185\u0189\u018d\u0191\u0195\u0199\u019d\u01a1"+
+                    "\u01a4\u01ab\u01b1\u01ba";
+    public static final ATN _ATN =
+            new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+    static {
+        _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
+        for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
+            _decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
+        }
+    }
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsVisitor.java
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LakeSoulSqlExtensionsVisitor.java
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.parser.extensions;
+
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
+
+public interface LakeSoulSqlExtensionsVisitor<T> extends ParseTreeVisitor<T> {
+    T visitSingleStatement(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SingleStatementContext ctx);
+
+    T visitCall(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.CallContext ctx);
+
+    T visitPositionalArgument(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.PositionalArgumentContext ctx);
+
+    T visitNamedArgument(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NamedArgumentContext ctx);
+
+    T visitExpression(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExpressionContext ctx);
+
+    T visitNumericLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NumericLiteralContext ctx);
+
+    T visitBooleanLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BooleanLiteralContext ctx);
+
+    T visitStringLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringLiteralContext ctx);
+
+    T visitTypeConstructor(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.TypeConstructorContext ctx);
+
+    T visitStringMap(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringMapContext ctx);
+
+    T visitStringArray(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.StringArrayContext ctx);
+
+    T visitBooleanValue(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BooleanValueContext ctx);
+
+    T visitExponentLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.ExponentLiteralContext ctx);
+
+    T visitDecimalLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.DecimalLiteralContext ctx);
+
+    T visitIntegerLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.IntegerLiteralContext ctx);
+
+    T visitBigIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BigIntLiteralContext ctx);
+
+    T visitSmallIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.SmallIntLiteralContext ctx);
+
+    T visitTinyIntLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.TinyIntLiteralContext ctx);
+
+    T visitDoubleLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.DoubleLiteralContext ctx);
+
+    T visitFloatLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.FloatLiteralContext ctx);
+    T visitBigDecimalLiteral(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.BigDecimalLiteralContext ctx);
+    T visitMultipartIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.MultipartIdentifierContext ctx);
+    T visitUnquotedIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.UnquotedIdentifierContext ctx);
+    T visitQuotedIdentifierAlternative(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.QuotedIdentifierAlternativeContext ctx);
+    T visitQuotedIdentifier(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.QuotedIdentifierContext ctx);
+    T visitNonReserved(org.apache.spark.sql.catalyst.parser.extensions.LakeSoulSqlExtensionsParser.NonReservedContext ctx);
+
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CallStatement.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CallStatement.scala
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+case class CallStatement(name: Seq[String], args: Seq[CallArgument]) extends LeafParsedStatement
+sealed trait CallArgument {
+  def expr: Expression
+}
+/**
+ * An argument in a CALL statement identified by name.
+ */
+case class NamedArgument(name: String, expr: Expression) extends CallArgument
+
+/**
+ * An argument in a CALL statement identified by position.
+ */
+case class PositionalArgument(expr: Expression) extends CallArgument

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/commands/CallExecCommand.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/commands/CallExecCommand.scala
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.lakesoul.commands
+
+import com.dmetasoul.lakesoul.tables.LakeSoulTable
+import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.{CallArgument, NamedArgument}
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.types.{IntegerType, LongType}
+
+case class CallExecCommand(action: String, args: Seq[CallArgument]) extends LeafRunnableCommand {
+  private val tableName = "tablename"
+  private val tableNamespace = "tablenamespace"
+  private val tablePath = "tablepath"
+  private val parValue = "partitionvalue"
+  private val toTime = "totime"
+  private val zoneId = "zoneid"
+  private val hiveTableName = "hivetablename"
+  private val cleanOld = "cleanold"
+  private val condition = "condition"
+  private val toVersion = "toversion"
+
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val argsMap = scala.collection.mutable.HashMap[String, Expression]()
+    for (item <- args) {
+      if (item.isInstanceOf[NamedArgument]) {
+        val argument = item.asInstanceOf[NamedArgument]
+        argsMap += argument.name.toLowerCase() -> argument.expr
+      }
+    }
+    if (argsMap.size == 0) {
+      throw new AnalysisException("no arguments")
+    }
+
+    action match {
+      case "rollback" => {
+        checkRollbackArgs(args)
+        val table = getLakeSoulTable(argsMap)
+        if (argsMap.contains(toVersion)) {
+          table.rollbackPartition(getPartitionVal(argsMap(parValue)), argsMap(toVersion).toString().toInt)
+        }else if (argsMap.contains(zoneId)) {
+          table.rollbackPartition(getPartitionVal(argsMap(parValue)), argsMap(toTime).toString(), argsMap(zoneId).toString())
+        } else {
+          table.rollbackPartition(getPartitionVal(argsMap(parValue)), argsMap(toTime).toString())
+        }
+      }
+      case "compaction" => {
+        checkCompactionArgs(args)
+        val table = getLakeSoulTable(argsMap)
+        val conditons = if (argsMap.contains(condition)) {
+          getContition(argsMap(condition))
+        } else {
+          ""
+        }
+        if (argsMap.contains(hiveTableName)) {
+          table.compaction(conditons, argsMap(hiveTableName).toString())
+        }
+        if (argsMap.contains(cleanOld)) {
+          table.compaction(argsMap(cleanOld).toString().toBoolean)
+        }
+        table.compaction(conditons)
+      }
+    }
+    Seq.empty
+  }
+
+  private def getLakeSoulTable(argsMap: scala.collection.mutable.HashMap[String, Expression]): LakeSoulTable = {
+    if (argsMap.contains(tableName)) {
+      val tName = argsMap(tableName).toString()
+      val tNameSpace = if (argsMap.contains(tableNamespace)) {
+        argsMap(tableNamespace).toString()
+      } else {
+        ""
+      }
+      if (tNameSpace.equals("")) {
+        toLakeSoulDFFromName(tName)
+      } else {
+        toLakeSoulDFFromNameAndNamespace(tName, tNameSpace)
+      }
+    } else {
+      val tPath = argsMap(tablePath).toString()
+      toLakeSoulDFFromPath(tPath)
+    }
+  }
+
+  private def getContition(contitons: Expression): String = {
+    if (contitons.isInstanceOf[Literal]) {
+      return contitons.asInstanceOf[Literal].toString()
+    }
+    if (!contitons.isInstanceOf[UnresolvedFunction]) {
+      throw new AnalysisException("conditions not support;for example condition='' or condition=map(a=>1,c=>'d')")
+    }
+    val parType = contitons.asInstanceOf[UnresolvedFunction].nameParts(0)
+    if (!"map".equalsIgnoreCase(parType)) {
+      throw new AnalysisException("condititon type is not map; for example map(a=>1,c=>'d')")
+    }
+    val parValue = contitons.asInstanceOf[UnresolvedFunction].arguments
+    if (parValue.size == 0) {
+      return ""
+    }
+    val content: StringBuilder = new StringBuilder()
+    for (i <- (1 to parValue.size by 2)) {
+      val parName = parValue(i - 1)
+      val parVal = parValue(i)
+      if (parVal.dataType.isInstanceOf[IntegerType] || parVal.dataType.isInstanceOf[LongType]) {
+        content.append(parName.toString() + "=" + parVal.toString() + " and ")
+      } else {
+        content.append(parName.toString() + "='" + parVal.toString() + "' and ")
+      }
+    }
+    content.toString().substring(0, content.toString().length - 5)
+  }
+
+
+  private def getPartitionVal(partition: Expression): String = {
+    val parType = partition.asInstanceOf[UnresolvedFunction].nameParts(0)
+    if (!"map".equalsIgnoreCase(parType)) {
+      throw new AnalysisException("partition type not map; for example map(a=>1,c=>'d')")
+    }
+    val parValue = partition.asInstanceOf[UnresolvedFunction].arguments
+    if (parValue.size == 2) {
+      if ("-5".equals(parValue(0).toString())) {
+        return "-5"
+      }
+    }
+    val content: StringBuilder = new StringBuilder()
+    for (i <- (1 to parValue.size by 2)) {
+      val parName = parValue(i - 1)
+      val parVal = parValue(i)
+      if (parVal.dataType.isInstanceOf[IntegerType] || parVal.dataType.isInstanceOf[LongType]) {
+        content.append(parName.toString() + "=" + parVal.toString() + ",")
+      } else {
+        content.append(parName.toString() + "='" + parVal.toString() + "',")
+      }
+    }
+    content.toString().substring(0, content.toString().length - 1)
+  }
+
+  private def toLakeSoulDFFromPath(tablePath: String): LakeSoulTable = {
+    LakeSoulTable.forPath(tablePath)
+  }
+
+  private def toLakeSoulDFFromName(tableName: String): LakeSoulTable = {
+    LakeSoulTable.forName(tableName)
+  }
+
+  private def toLakeSoulDFFromNameAndNamespace(tableName: String, nameSpace: String): LakeSoulTable = {
+    LakeSoulTable.forName(tableName, nameSpace)
+  }
+
+  private def checkRollbackArgs(rollbackArgs: Seq[CallArgument]): Boolean = {
+    val names = rollbackArgs.map(arg => if (arg.isInstanceOf[NamedArgument]) {
+      arg.asInstanceOf[NamedArgument].name.toLowerCase()
+    })
+    if (names.size > 0) {
+      if ((names.contains(tableName) || names.contains(tablePath)) && names.contains(parValue) && (names.contains(toTime) || names.contains(toVersion))) {
+        true
+      } else {
+        false
+      }
+    } else {
+      throw new AnalysisException("no rollback arguments")
+    }
+
+  }
+
+  private def checkCompactionArgs(compactionArgs: Seq[CallArgument]): Boolean = {
+    val names = compactionArgs.map(arg => if (arg.isInstanceOf[NamedArgument]) {
+      arg.asInstanceOf[NamedArgument].name.toLowerCase()
+    })
+    if (names.size > 0) {
+      if ((names.contains(tablePath) || names.contains(tableName))) {
+        true
+      } else {
+        false
+      }
+    } else {
+      throw new AnalysisException("no rollback arguments")
+    }
+  }
+}

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/rules/ProcessCall.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/rules/ProcessCall.scala
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.apache.spark.sql.lakesoul.rules
+
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.{CallArgument, CallStatement, LogicalPlan, NamedArgument}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.lakesoul.commands.CallExecCommand
+import java.util.Locale
+
+case class ProcessCall(spark: SparkSession) extends Rule[LogicalPlan] {
+  protected lazy val catalogManager: CatalogManager = spark.sessionState.catalogManager
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case CallStatement(ident, args) =>
+      if (!checkLakeSoulActions(ident)) {
+        throw new AnalysisException("Please check. Just support LakeSoulTable.rollback(xx) and LakeSoulTable.compaction(xx)")
+      }
+      val norArgs = normalizeArgs(args)
+      CallExecCommand(ident(1).toLowerCase(), norArgs)
+  }
+
+  private def checkLakeSoulActions(ident: Seq[String]): Boolean = {
+    if (ident.size != 2) {
+      return false
+    }
+    if (ident(0).equalsIgnoreCase("lakesoultable") && (ident(1).equalsIgnoreCase("rollback") || ident(1).equalsIgnoreCase("compaction"))) {
+      true
+    } else {
+      false
+    }
+  }
+
+  private def normalizeArgs(args: Seq[CallArgument]): Seq[CallArgument] = {
+    args.map {
+      case a@NamedArgument(name, _) => a.copy(name = name.toLowerCase(Locale.ROOT))
+      case other => other
+    }
+  }
+}

--- a/lakesoul-spark/src/test/scala/org/apache/spark/sql/lakesoul/DDLSuite.scala
+++ b/lakesoul-spark/src/test/scala/org/apache/spark/sql/lakesoul/DDLSuite.scala
@@ -8,6 +8,7 @@ import com.dmetasoul.lakesoul.meta.DBManager
 import com.dmetasoul.lakesoul.tables.LakeSoulTable
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.CallStatement
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.lakesoul.catalog.LakeSoulCatalog
 import org.apache.spark.sql.lakesoul.schema.InvariantViolationException
@@ -414,6 +415,14 @@ abstract class DDLTestBase extends QueryTest with SQLTestUtils {
     }
   }
 
+  test("Call Statement") {
+    withTable("lakesoul_test") {
+            val call = spark.sessionState.sqlParser.parsePlan("CALL cat.system.func(c1 => 'name=name1', c2 => map('2',3), c3 => true,c4 => TIMESTAMP '2013-01-01',c5=>3L,c6=>1.0D,c7=>ARRAY(1,3))")
+            val s = call.asInstanceOf[CallStatement]
+            assert(s.args.length == 7)
+    }
+  }
+
   test("DESCRIBE TABLE for partitioned table") {
     withTempDir { dir =>
       withTable("lakesoul_test") {
@@ -432,6 +441,7 @@ abstract class DDLTestBase extends QueryTest with SQLTestUtils {
       }
     }
   }
+
 
   test("ALTER TABLE with data CHANGE COLUMN from bigint to string") {
     withTempDir { dir =>

--- a/lakesoul-spark/src/test/scala/org/apache/spark/sql/lakesoul/commands/RollbackSuite.scala
+++ b/lakesoul-spark/src/test/scala/org/apache/spark/sql/lakesoul/commands/RollbackSuite.scala
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.apache.spark.sql.lakesoul.commands
+
+import com.dmetasoul.lakesoul.tables.LakeSoulTable
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.lakesoul.SnapshotManagement
+import org.apache.spark.sql.lakesoul.catalog.LakeSoulCatalog
+import org.apache.spark.sql.lakesoul.sources.LakeSoulSQLConf
+import org.apache.spark.sql.lakesoul.test.{LakeSoulSQLCommandTest, LakeSoulTestSparkSession, MergeOpInt}
+import org.apache.spark.sql.lakesoul.utils.SparkUtil
+import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SparkSession}
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class RollbackSuite extends QueryTest
+  with SharedSparkSession with BeforeAndAfterEach
+  with LakeSoulSQLCommandTest {
+
+  override protected def createSparkSession: TestSparkSession = {
+    SparkSession.cleanupAnyExistingSession()
+    val session = new LakeSoulTestSparkSession(sparkConf)
+    session.conf.set("spark.sql.catalog.lakesoul", classOf[LakeSoulCatalog].getName)
+    session.conf.set(SQLConf.DEFAULT_CATALOG.key, "lakesoul")
+    session.conf.set(LakeSoulSQLConf.NATIVE_IO_ENABLE.key, true)
+    session.sparkContext.setLogLevel("ERROR")
+
+    session
+  }
+
+  import testImplicits._
+
+
+  test("upsert then rollback") {
+    withTempDir(file => {
+      val tableName = file.getCanonicalPath
+
+      val df1 = Seq((1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4))
+        .toDF("range", "hash", "value")
+      val df2 = Seq((1, 1, 11), (1, 2, 22), (1, 3, 33))
+        .toDF("range", "hash", "value")
+
+      df1.write
+        .option("rangePartitions", "range")
+        .option("hashPartitions", "hash")
+        .option("hashBucketNum", "2")
+        .format("lakesoul")
+        .save(tableName)
+      LakeSoulTable.forPath(tableName).upsert(df2)
+      /*call rollback usage
+      * call LakeSoulTable.rollback(partitionvalue=>map('range',1),toVersion=>0,tablePath=>'file://path')
+      * call LakeSoulTable.rollback(partitionvalue=>map('range',1),toVersion=>0,tableName=>'lakesoul')
+      * call LakeSoulTable.rollback(partitionvalue=>map('range',1),toTime=>'2010-01-01 10:00:00',tableName=>'lakesoul')
+      * call LakeSoulTable.rollback(partitionvalue=>map('range',1),toTime=>'2010-01-01 10:00:00',zoneId=>'Asia/Shanghai',tableName=>'lakesoul')
+      * */
+      sql("call LakeSoulTable.rollback(partitionvalue=>map('range',1),toVersion=>0,tablePath=>'" + tableName + "')")
+      LakeSoulTable.uncached(tableName)
+      checkAnswer(LakeSoulTable.forPath(tableName).toDF.select("range", "hash", "value"),
+        Seq((1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4)).toDF("range", "hash", "value"))
+
+    })
+  }
+
+
+}
+


### PR DESCRIPTION
Spark Sql support call sql syntax for lakesoultable rollback and compaction
For example:
1) usage of call compaction
   call LakeSoulTable.compaction(condition=>map('range',1),tablePath=>'file://path/')
   call LakeSoulTable.compaction(condition=>map('range',1),tableName=>'lakesoul')
   call LakeSoulTable.compaction(tableName=>'lakesoul',hiveTableName=>'hive')
   call LakeSoulTable.compaction(tableName=>'lakesoul',cleanOld=>true)
2) usage of call rollback 
 call LakeSoulTable.rollback(partitionvalue=>map('range',1),toVersion=>0,tablePath=>'file://path/')
 call LakeSoulTable.rollback(partitionvalue=>map('range',1),toVersion=>0,tableName=>'lakesoul')
 call LakeSoulTable.rollback(partitionvalue=>map('range',1),toTime=>'2010-01-01 10:00:00',tableName=>'lakesoul')
 call LakeSoulTable.rollback(partitionvalue=>map('range',1),toTime=>'2010-01-01 10:00:00',zoneId=>'Asia/Shanghai',tableName=>'lakesoul')