### PR TITLE
[NativeIO] Use rust block api in file read

### DIFF
--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/connector/LakeSoulPartitionReader.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/connector/LakeSoulPartitionReader.java
@@ -98,9 +98,6 @@ public class LakeSoulPartitionReader implements PartitionReader<LakeSoulPartitio
         if (lakesoulArrowReader == null) return null;
 
         currentVSR = lakesoulArrowReader.nextResultVectorSchemaRoot();
-        if (this.currentVSR == null) {
-            throw new IOException("nextVectorSchemaRoot not ready");
-        }
         curRecordId = 0;
         return ArrowUtils.createArrowReader(currentVSR, this.schema);
     }

--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulRecordCursor.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulRecordCursor.java
@@ -109,7 +109,6 @@ public class LakeSoulRecordCursor implements RecordCursor {
             curRecordIdx = -1;
         } else {
             close();
-            return;
         }
     }
 

--- a/lakesoul-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/NativeVectorizedReader.java
+++ b/lakesoul-spark/src/main/java/org/apache/spark/sql/execution/datasources/parquet/NativeVectorizedReader.java
@@ -334,19 +334,15 @@ public class NativeVectorizedReader extends SpecificParquetRecordReaderBase<Obje
         closeCurrentBatch();
         if (nativeReader.hasNext()) {
             VectorSchemaRoot nextVectorSchemaRoot = nativeReader.nextResultVectorSchemaRoot();
-            if (nextVectorSchemaRoot == null) {
-                throw new IOException("nextVectorSchemaRoot not ready");
-            } else {
-                int rowCount = nextVectorSchemaRoot.getRowCount();
-                if (nextVectorSchemaRoot.getSchema().getFields().isEmpty()) {
-                    if (partitionColumnVectors == null) {
-                        throw new IOException("NativeVectorizedReader has not been initialized");
-                    }
-                    columnarBatch = new ColumnarBatch(partitionColumnVectors, rowCount);
-                } else {
-                    nativeColumnVector = NativeIOUtils.asArrayColumnVector(nextVectorSchemaRoot);
-                    columnarBatch = new ColumnarBatch(nativeColumnVector, rowCount);
+            int rowCount = nextVectorSchemaRoot.getRowCount();
+            if (nextVectorSchemaRoot.getSchema().getFields().isEmpty()) {
+                if (partitionColumnVectors == null) {
+                    throw new IOException("NativeVectorizedReader has not been initialized");
                 }
+                columnarBatch = new ColumnarBatch(partitionColumnVectors, rowCount);
+            } else {
+                nativeColumnVector = NativeIOUtils.asArrayColumnVector(nextVectorSchemaRoot);
+                columnarBatch = new ColumnarBatch(nativeColumnVector, rowCount);
             }
             return true;
         } else {
@@ -355,7 +351,6 @@ public class NativeVectorizedReader extends SpecificParquetRecordReaderBase<Obje
     }
 
     private void initializeInternal() throws IOException, UnsupportedOperationException {
-        recreateNativeReader();
         initBatch();
     }
 

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulSQLConf.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/lakesoul/sources/LakeSoulSQLConf.scala
@@ -121,7 +121,7 @@ object LakeSoulSQLConf {
           |If NATIVE_IO_ENABLE=true, NATIVE_IO_WRITE_MAX_ROW_GROUP_SIZE of rows will be used to write a new row group
       """.stripMargin)
       .intConf
-      .createWithDefault(250000)
+      .createWithDefault(1000000)
 
   val NATIVE_IO_THREAD_NUM: ConfigEntry[Int] =
     buildConf("native.io.thread.num")

--- a/lakesoul-spark/src/main/scala/org/apache/spark/sql/vectorized/GlutenUtils.scala
+++ b/lakesoul-spark/src/main/scala/org/apache/spark/sql/vectorized/GlutenUtils.scala
@@ -37,7 +37,7 @@ object GlutenUtils {
 
   def setArrowAllocator(io: NativeIOBase): Unit = {
     if (isGlutenEnabled) {
-      io.setExternalAllocator(getGlutenAllocator)
+      io.setExternalAllocator(getGlutenAllocator.newChildAllocator("gluten", 32 * 1024 * 1024, Long.MaxValue))
     }
   }
 

--- a/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/io/NativeIOReader.java
+++ b/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/io/NativeIOReader.java
@@ -6,6 +6,7 @@ package com.dmetasoul.lakesoul.lakesoul.io;
 
 import com.dmetasoul.lakesoul.lakesoul.io.jnr.LibLakeSoulIO;
 import jnr.ffi.Pointer;
+import jnr.ffi.byref.IntByReference;
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -17,7 +18,6 @@ import java.util.function.BiConsumer;
 
 public class NativeIOReader extends NativeIOBase implements AutoCloseable {
     private Pointer reader = null;
-
 
     private Schema readerSchema = null;
 
@@ -122,5 +122,14 @@ public class NativeIOReader extends NativeIOBase implements AutoCloseable {
             throw new RuntimeException(p.getString(0));
         }
         libLakeSoulIO.next_record_batch(reader, schemaAddr, arrayAddr, nativeIntegerCallback);
+    }
+
+    public int nextBatchBlocked(long arrayAddr) throws IOException {
+        IntByReference count = new IntByReference();
+        String err = libLakeSoulIO.next_record_batch_blocked(reader, arrayAddr, count);
+        if (err != null) {
+            throw new IOException(err);
+        }
+        return count.getValue();
     }
 }

--- a/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/io/jnr/JnrLoader.java
+++ b/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/io/jnr/JnrLoader.java
@@ -69,6 +69,7 @@ public class JnrLoader {
                 // so disable them
                 System.setProperty("arrow.enable_unsafe_memory_access", "true");
                 System.setProperty("arrow.enable_null_check_for_get", "false");
+                System.setProperty("arrow.allocation.manager.type", "Netty");
             }
         }
 

--- a/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/io/jnr/LibLakeSoulIO.java
+++ b/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/io/jnr/LibLakeSoulIO.java
@@ -9,6 +9,8 @@ import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import jnr.ffi.annotations.Delegate;
 import jnr.ffi.annotations.LongLong;
+import jnr.ffi.annotations.Out;
+import jnr.ffi.byref.IntByReference;
 
 public interface LibLakeSoulIO {
 
@@ -78,6 +80,8 @@ public interface LibLakeSoulIO {
     void start_reader(Pointer reader, BooleanCallback callback);
 
     void next_record_batch(Pointer reader, @LongLong long schemaAddr, @LongLong long arrayAddr, IntegerCallback callback);
+
+    String next_record_batch_blocked(Pointer reader, @LongLong long arrayAddr, @Out IntByReference count);
 
     void write_record_batch(Pointer writer, @LongLong long schemaAddr, @LongLong long arrayAddr, BooleanCallback callback);
 

--- a/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/memory/ArrowMemoryUtils.java
+++ b/native-io/lakesoul-io-java/src/main/java/com/dmetasoul/lakesoul/lakesoul/memory/ArrowMemoryUtils.java
@@ -9,5 +9,4 @@ import org.apache.arrow.memory.RootAllocator;
 
 public class ArrowMemoryUtils {
     public final static BufferAllocator rootAllocator = new RootAllocator();
-
 }

--- a/native-io/lakesoul-io-java/src/test/scala/com/dmetasoul/lakesoul/TestLakeSoulNativeReaderWriter.scala
+++ b/native-io/lakesoul-io-java/src/test/scala/com/dmetasoul/lakesoul/TestLakeSoulNativeReaderWriter.scala
@@ -5,39 +5,71 @@
 package com.dmetasoul.lakesoul
 
 import com.dmetasoul.lakesoul.lakesoul.io.{NativeIOReader, NativeIOWriter}
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, Schema}
+
+import scala.collection.JavaConverters.asJavaIterableConverter
 
 case class TestLakeSoulNativeReaderWriter() extends org.scalatest.funsuite.AnyFunSuite with org.scalatest.BeforeAndAfterAll with org.scalatest.BeforeAndAfterEach {
   val projectDir: String = System.getProperty("user.dir")
 
   test("test native reader writer with single file") {
 
-    val reader = new NativeIOReader()
-    val filePath = projectDir + "/native-io/lakesoul-io-java/src/test/resources/sample-parquet-files/part-00000-a9e77425-5fb4-456f-ba52-f821123bd193-c000.snappy.parquet"
-    reader.addFile(filePath)
-    reader.setThreadNum(2)
-    reader.setBatchSize(512)
-    reader.initializeReader()
+    for (i <- 1 to  10) {
+      val reader = new NativeIOReader()
+      //    val filePath = projectDir + "/native-io/lakesoul-io-java/src/test/resources/sample-parquet-files/part-00000-a9e77425-5fb4-456f-ba52-f821123bd193-c000.snappy.parquet"
+//      val filePath = "/data/presto-parquet/parquet/hive_data/tpch/orders/20231207_090334_00001_d3cs8_4bc28274-73fb-49eb-a3cc-389a3a4aed94.parquet"
+      val filePath = "/home/chenxu/program/data/lakesoul-test-orders/part-00000-00e25436-9e3a-483e-b0d6-74bc2f60a1bd-c000.parquet"
+      reader.addFile(filePath)
+      reader.setThreadNum(2)
+      reader.setBatchSize(20480)
+      reader.setBufferSize(4)
+      reader.addFilter("eq(orderpriority,String('2-HIGH'))")
+      val schema = new Schema(Seq(
+        Field.nullable("orderkey", new ArrowType.Int(64, true)),
+        Field.nullable("custkey", new ArrowType.Int(64, true)),
+        Field.nullable("orderstatus", ArrowType.Utf8.INSTANCE),
+        Field.nullable("totalprice", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+        Field.nullable("orderdate", ArrowType.Utf8.INSTANCE),
+        Field.nullable("orderpriority", ArrowType.Utf8.INSTANCE),
+        Field.nullable("clerk", ArrowType.Utf8.INSTANCE),
+        Field.nullable("shippriority", new ArrowType.Int(32, true)),
+        Field.nullable("comment", ArrowType.Utf8.INSTANCE),
+      ).asJava)
+      reader.setSchema(schema)
+      reader.initializeReader()
 
-    val schema = reader.getSchema
+//      val schema = reader.getSchema
 
-    val lakesoulReader = LakeSoulArrowReader(reader)
+      val lakesoulReader = LakeSoulArrowReader(reader)
 
-    val writer = new NativeIOWriter(schema)
-    writer.addFile(System.getProperty("java.io.tmpdir") + "/" + "temp.parquet")
-    writer.setPrimaryKeys(java.util.Arrays.asList("email", "first_name", "last_name"))
-    writer.setAuxSortColumns(java.util.Arrays.asList("country"))
-    writer.initializeWriter()
+      //    val writer = new NativeIOWriter(schema)
+      //    writer.addFile(System.getProperty("java.io.tmpdir") + "/" + "temp.parquet")
+      //    writer.setPrimaryKeys(java.util.Arrays.asList("email", "first_name", "last_name"))
+      //    writer.setAuxSortColumns(java.util.Arrays.asList("country"))
+      //    writer.initializeWriter()
 
-    while (lakesoulReader.hasNext) {
-      val batch = lakesoulReader.next()
-      println(batch.get.contentToTSVString())
-      writer.write(batch.get)
+      val t0 = System.nanoTime()
+      var rows: Long = 0
+      var batches: Long = 0
+      var cols: Long = 0
+      while (lakesoulReader.hasNext) {
+        val batch = lakesoulReader.next()
+        rows += batch.getRowCount
+        batches += 1
+        cols += batch.getFieldVectors.size()
+        //      println(batch.get.contentToTSVString())
+        //      writer.write(batch.get)
+      }
+      val t1 = System.nanoTime()
+      println("Elapsed time: " + (t1 - t0) + "ns")
+      println(rows, batches, cols)
+
+      //    writer.flush()
+      //    writer.close()
+
+      lakesoulReader.close()
     }
-
-    writer.flush()
-    writer.close()
-
-    lakesoulReader.close()
   }
 
 }

--- a/rust/lakesoul-io-c/lakesoul_c_bindings.h
+++ b/rust/lakesoul-io-c/lakesoul_c_bindings.h
@@ -121,6 +121,8 @@ void next_record_batch(CResult<Reader> *reader,
                        c_ptrdiff_t array_addr,
                        I32ResultCallback callback);
 
+const char *next_record_batch_blocked(CResult<Reader> *reader, c_ptrdiff_t array_addr, int *count);
+
 void next_record_batch_with_data(CResult<Reader> *reader,
                                  c_ptrdiff_t schema_addr,
                                  c_ptrdiff_t array_addr,

--- a/rust/lakesoul-io/src/lakesoul_reader.rs
+++ b/rust/lakesoul-io/src/lakesoul_reader.rs
@@ -66,7 +66,7 @@ impl LakeSoulReader {
                 self.config.batch_size,
             )
             .await?;
-            self.schema = Some(schema.clone());
+            self.schema = Some(stream.schema().clone());
             self.stream = Some(stream);
 
             Ok(())

--- a/rust/lakesoul-io/src/lakesoul_reader.rs
+++ b/rust/lakesoul-io/src/lakesoul_reader.rs
@@ -66,7 +66,7 @@ impl LakeSoulReader {
                 self.config.batch_size,
             )
             .await?;
-            self.schema = Some(stream.schema().clone());
+            self.schema = Some(stream.schema());
             self.stream = Some(stream);
 
             Ok(())


### PR DESCRIPTION
Address some perf issues found during profiling.
1. Table read in Java should use Rust side blocking API to avoid callback overhead in tokio's threads.
2. Reader's schema could be reused after initialization to save some allocations for each batch.
3. Arrow allocator in Java could reserve some memory.