### PR TITLE
[Flink/Rust] Adjust rolling file logic to reduce memory usage during write

### DIFF
--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/LakeSoulRollingPolicyImpl.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/LakeSoulRollingPolicyImpl.java
@@ -8,6 +8,8 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
 import org.apache.flink.table.data.RowData;
 
+import java.io.IOException;
+
 import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.DEFAULT_BUCKET_ROLLING_SIZE;
 import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.DEFAULT_BUCKET_ROLLING_TIME;
 
@@ -37,8 +39,8 @@ public class LakeSoulRollingPolicyImpl extends CheckpointRollingPolicy<RowData, 
   }
 
   @Override
-  public boolean shouldRollOnEvent(PartFileInfo<String> partFileState, RowData element) {
-    return false;
+  public boolean shouldRollOnEvent(PartFileInfo<String> partFileState, RowData element) throws IOException {
+    return partFileState.getSize() >= this.rollingSize;
   }
 
   @Override

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/state/LakeSoulMultiTableSinkCommittable.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/state/LakeSoulMultiTableSinkCommittable.java
@@ -110,6 +110,7 @@ public class LakeSoulMultiTableSinkCommittable implements Serializable, Comparab
                 ", bucketId='" + bucketId + '\'' +
                 ", identity=" + identity +
                 ", commitId='" + commitId + '\'' +
+                ", pendingFiles='" + pendingFiles + '\'' +
                 '}';
     }
 

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/table/LakeSoulDynamicTableFactory.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/table/LakeSoulDynamicTableFactory.java
@@ -8,6 +8,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.lakesoul.source.LakeSoulLookupTableSource;
 import org.apache.flink.lakesoul.tool.FlinkUtil;
 import org.apache.flink.lakesoul.types.TableId;
@@ -32,7 +33,8 @@ public class LakeSoulDynamicTableFactory implements DynamicTableSinkFactory, Dyn
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
-        Configuration options = (Configuration) FactoryUtil.createTableFactoryHelper(this, context).getOptions();
+        Configuration options = GlobalConfiguration.loadConfiguration();
+        options.addAll((Configuration) FactoryUtil.createTableFactoryHelper(this, context).getOptions());
         FlinkUtil.setLocalTimeZone(options,
                 FlinkUtil.getLocalTimeZone(((TableConfig) context.getConfiguration()).getConfiguration()));
 
@@ -71,7 +73,8 @@ public class LakeSoulDynamicTableFactory implements DynamicTableSinkFactory, Dyn
 
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
-        Configuration options = (Configuration) FactoryUtil.createTableFactoryHelper(this, context).getOptions();
+        Configuration options = GlobalConfiguration.loadConfiguration();
+        options.addAll((Configuration) FactoryUtil.createTableFactoryHelper(this, context).getOptions());
         FlinkUtil.setLocalTimeZone(options,
                 FlinkUtil.getLocalTimeZone(((TableConfig) context.getConfiguration()).getConfiguration()));
         ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
@@ -97,7 +100,11 @@ public class LakeSoulDynamicTableFactory implements DynamicTableSinkFactory, Dyn
 
         return new LakeSoulLookupTableSource(
                 new TableId(io.debezium.relational.TableId.parse(objectIdentifier.asSummaryString())),
-                (RowType) catalogTable.getResolvedSchema().toSourceRowDataType().notNull().getLogicalType(), isStreaming, pkColumns, catalogTable, options.toMap()
+                (RowType) catalogTable.getResolvedSchema().toSourceRowDataType().notNull().getLogicalType(),
+                isStreaming,
+                pkColumns,
+                catalogTable,
+                options.toMap()
         );
     }
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/table/LakeSoulTableSource.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/table/LakeSoulTableSource.java
@@ -38,7 +38,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class LakeSoulTableSource
-        implements SupportsFilterPushDown, SupportsPartitionPushDown, SupportsProjectionPushDown, ScanTableSource, SupportsRowLevelModificationScan {
+        implements SupportsFilterPushDown, SupportsPartitionPushDown, SupportsProjectionPushDown, ScanTableSource,
+        SupportsRowLevelModificationScan {
 
     private static final Logger LOG = LoggerFactory.getLogger(LakeSoulTableSource.class);
 
@@ -232,7 +233,10 @@ public class LakeSoulTableSource
     }
 
     @Override
-    public RowLevelModificationScanContext applyRowLevelModificationScan(RowLevelModificationType rowLevelModificationType, @Nullable RowLevelModificationScanContext previousContext) {
+    public RowLevelModificationScanContext applyRowLevelModificationScan(
+            RowLevelModificationType rowLevelModificationType,
+            @Nullable
+            RowLevelModificationScanContext previousContext) {
         return null;
     }
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/FlinkUtil.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/FlinkUtil.java
@@ -294,7 +294,6 @@ public class FlinkUtil {
         JSONObject properties = JSON.parseObject(tableInfo.getProperties());
 
         org.apache.arrow.vector.types.pojo.Schema arrowSchema = null;
-        System.out.println(tableSchema);
         if (TableInfoDao.isArrowKindSchema(tableSchema)) {
             try {
                 arrowSchema = org.apache.arrow.vector.types.pojo.Schema.fromJSON(tableSchema);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulSinkOptions.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulSinkOptions.java
@@ -28,9 +28,9 @@ public class LakeSoulSinkOptions {
 
     public static final String SORT_FIELD = "__sort_filed__";
 
-    public static final Long DEFAULT_BUCKET_ROLLING_SIZE = 20000L;
+    public static final Long DEFAULT_BUCKET_ROLLING_SIZE = 5000000L;
 
-    public static final Long DEFAULT_BUCKET_ROLLING_TIME = 2000000L;
+    public static final Long DEFAULT_BUCKET_ROLLING_TIME = 5 * 60 * 1000L;
 
     public static final String DELETE = "delete";
 
@@ -66,7 +66,7 @@ public class LakeSoulSinkOptions {
             .key("warehouse_path")
             .stringType()
             .defaultValue(new Path(System.getProperty("java.io.tmpdir"), "lakesoul").toString())
-            .withDescription("warehouse path for LakeSoul");
+            .withDescription("warehouse path for LakeSoul for command line tools");
 
     public static final ConfigOption<Integer> BUCKET_PARALLELISM = ConfigOptions
             .key("sink.parallelism")
@@ -81,22 +81,22 @@ public class LakeSoulSinkOptions {
             .withDescription("bucket number for table");
 
     public static final ConfigOption<Long> FILE_ROLLING_SIZE = ConfigOptions
-            .key("file_rolling_size")
+            .key("lakesoul.file.rolling.rows")
             .longType()
-            .defaultValue(20000L)
-            .withDescription("file rolling size ");
+            .defaultValue(DEFAULT_BUCKET_ROLLING_SIZE)
+            .withDescription("file rolling max rows");
 
     public static final ConfigOption<Long> FILE_ROLLING_TIME = ConfigOptions
-            .key("file_rolling_time")
+            .key("lakesoul.file.rolling.time.ms")
             .longType()
-            .defaultValue(Duration.ofMinutes(10).toMillis())
-            .withDescription("file rolling time ");
+            .defaultValue(DEFAULT_BUCKET_ROLLING_TIME)
+            .withDescription("file rolling time in milliseconds");
 
     public static final ConfigOption<Long> BUCKET_CHECK_INTERVAL = ConfigOptions
-            .key("bucket_check_interval")
+            .key("lakesoul.rolling.check.interval")
             .longType()
             .defaultValue(Duration.ofMinutes(1).toMillis())
-            .withDescription("file rolling time ");
+            .withDescription("file rolling check interval in milliseconds");
 
     public static final ConfigOption<Boolean> USE_CDC = ConfigOptions
             .key("use_cdc")

--- a/rust/lakesoul-io/src/lakesoul_io_config.rs
+++ b/rust/lakesoul-io/src/lakesoul_io_config.rs
@@ -419,10 +419,9 @@ pub fn create_session_context_with_planner(
     sess_conf.options_mut().optimizer.enable_round_robin_repartition = false; // if true, the record_batches poll from stream become unordered
     sess_conf.options_mut().optimizer.prefer_hash_join = false; //if true, panicked at 'range end out of bounds'
     sess_conf.options_mut().execution.parquet.pushdown_filters = config.parquet_filter_pushdown;
-    // sess_conf.options_mut().execution.parquet.enable_page_index = true;
+    sess_conf.options_mut().execution.target_partitions = 1;
 
-    // limit memory for sort writer
-    let runtime = RuntimeEnv::new(RuntimeConfig::new().with_memory_limit(128 * 1024 * 1024, 1.0))?;
+    let runtime = RuntimeEnv::new(RuntimeConfig::new())?;
 
     // firstly parse default fs if exist
     let default_fs = config

--- a/rust/lakesoul-io/src/lakesoul_reader.rs
+++ b/rust/lakesoul-io/src/lakesoul_reader.rs
@@ -52,8 +52,6 @@ impl LakeSoulReader {
                 "LakeSoulReader has wrong number of file".to_string(),
             ))
         } else {
-            // let source = LakeSoulParquetProvider::from_config(self.config.clone());
-            // let source = source.build_with_context(&self.sess_ctx).await.unwrap();
             let file_format = Arc::new(LakeSoulParquetFormat::new(
                 Arc::new(ParquetFormat::new()),
                 self.config.clone(),

--- a/rust/lakesoul-io/src/lakesoul_writer.rs
+++ b/rust/lakesoul-io/src/lakesoul_writer.rs
@@ -730,7 +730,7 @@ mod tests {
             let read_conf = common_conf_builder
                 .clone()
                 .with_files(vec![
-                    "/home/chenxu/program/data/base-0/part-00000-ccbfddad-30ec-40c6-9fbd-86acc53dfeb9-c000.snappy.parquet".to_string()
+                    "large_file.snappy.parquet".to_string()
                 ])
                 .with_schema(Arc::new(Schema::new(vec![
                     Arc::new(Field::new("uuid", DataType::Utf8, false)),

--- a/rust/lakesoul-io/src/lakesoul_writer.rs
+++ b/rust/lakesoul-io/src/lakesoul_writer.rs
@@ -76,7 +76,8 @@ pub struct MultiPartAsyncWriter {
 pub struct SortAsyncWriter {
     sorter_sender: Sender<Result<RecordBatch>>,
     _sort_exec: Arc<dyn ExecutionPlan>,
-    join_handle: JoinHandle<Result<()>>,
+    join_handle: Option<JoinHandle<Result<()>>>,
+    err: Option<DataFusionError>,
 }
 
 /// A VecDeque which is both std::io::Write and bytes::Buf
@@ -344,23 +345,42 @@ impl SortAsyncWriter {
 
         let mut async_writer = Box::new(async_writer);
         let join_handle = tokio::task::spawn(async move {
+            let mut err = None;
             while let Some(batch) = sorted_stream.next().await {
+
                 match batch {
                     Ok(batch) => {
                         async_writer.write_record_batch(batch).await?;
                     }
                     // received abort signal
-                    Err(_) => return async_writer.abort_and_close().await,
+                    Err(e) => {
+                        err = Some(e);
+                        break
+                    }
                 }
             }
-            async_writer.flush_and_close().await?;
-            Ok(())
+            if let Some(e) = err {
+                let result = async_writer.abort_and_close().await;
+                match result {
+                    Ok(_) => match e {
+                        Internal(ref err_msg) if err_msg == "external abort" => Ok(()),
+                        _ => Err(e)
+                    },
+                    Err(abort_err) => {
+                        Err(Internal(format!("Abort failed {:?}, previous error {:?}", abort_err, e)))
+                    }
+                }
+            } else {
+                async_writer.flush_and_close().await?;
+                Ok(())
+            }
         });
 
         Ok(SortAsyncWriter {
             sorter_sender: tx,
             _sort_exec: exec_plan,
-            join_handle,
+            join_handle: Some(join_handle),
+            err: None,
         })
     }
 }
@@ -368,31 +388,58 @@ impl SortAsyncWriter {
 #[async_trait]
 impl AsyncBatchWriter for SortAsyncWriter {
     async fn write_record_batch(&mut self, batch: RecordBatch) -> Result<()> {
-        self.sorter_sender
+        if let Some(err) = &self.err {
+            return Err(Internal(format!("SortAsyncWriter alread failed with error {:?}", err)));
+        }
+        let send_result = self.sorter_sender
             .send(Ok(batch))
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))
+            .await;
+        match send_result {
+            Ok(_) => Ok(()),
+            // channel has been closed, indicating error happened during sort write
+            Err(e) => {
+                if let Some(join_handle) = self.join_handle.take() {
+                    let result = join_handle
+                        .await
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                    self.err = result.err();
+                    Err(Internal(format!("Write to SortAsyncWriter failed: {:?}", self.err)))
+                } else {
+                    self.err = Some(DataFusionError::External(Box::new(e)));
+                    Err(Internal(format!("Write to SortAsyncWriter failed: {:?}", self.err)))
+                }
+            }
+        }
     }
 
     async fn flush_and_close(self: Box<Self>) -> Result<()> {
-        let sender = self.sorter_sender;
-        drop(sender);
-        self.join_handle
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
+        if let Some(join_handle) = self.join_handle {
+            let sender = self.sorter_sender;
+            drop(sender);
+            join_handle
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        } else {
+            Err(Internal("SortAsyncWriter has been aborted, cannot flush".to_string()))
+        }
     }
 
     async fn abort_and_close(self: Box<Self>) -> Result<()> {
-        let sender = self.sorter_sender;
-        // send abort signal to the task
-        sender
-            .send(Err(Internal("abort".to_string())))
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        drop(sender);
-        self.join_handle
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
+        if let Some(join_handle) = self.join_handle {
+            let sender = self.sorter_sender;
+            // send abort signal to the task
+            sender
+                .send(Err(Internal("external abort".to_string())))
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            drop(sender);
+            join_handle
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+        } else {
+            // previouse error has already aborted writer
+            Ok(())
+        }
     }
 }
 
@@ -498,6 +545,7 @@ mod tests {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReader;
     use std::fs::File;
     use std::sync::Arc;
+    use arrow_schema::{DataType, Field, Schema};
     use tokio::runtime::Builder;
 
     #[test]
@@ -669,6 +717,58 @@ mod tests {
         drop(reader);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_sort_spill_write() -> Result<()> {
+        let runtime = Arc::new(Builder::new_multi_thread().enable_all().build().unwrap());
+        runtime.clone().block_on(async move {
+            let common_conf_builder = LakeSoulIOConfigBuilder::new()
+                .with_thread_num(2)
+                .with_batch_size(8192)
+                .with_max_row_group_size(250000);
+            let read_conf = common_conf_builder
+                .clone()
+                .with_files(vec![
+                    "/home/chenxu/program/data/base-0/part-00000-ccbfddad-30ec-40c6-9fbd-86acc53dfeb9-c000.snappy.parquet".to_string()
+                ])
+                .with_schema(Arc::new(Schema::new(vec![
+                    Arc::new(Field::new("uuid", DataType::Utf8, false)),
+                    Arc::new(Field::new("ip", DataType::Utf8, false)),
+                    Arc::new(Field::new("hostname", DataType::Utf8, false)),
+                    Arc::new(Field::new("requests", DataType::Int64, false)),
+                    Arc::new(Field::new("name", DataType::Utf8, false)),
+                    Arc::new(Field::new("city", DataType::Utf8, false)),
+                    Arc::new(Field::new("job", DataType::Utf8, false)),
+                    Arc::new(Field::new("phonenum", DataType::Utf8, false)),
+                ])))
+                .build();
+            let mut reader = LakeSoulReader::new(read_conf)?;
+            reader.start().await?;
+
+            let schema = reader.schema.clone().unwrap();
+
+            let write_conf = common_conf_builder
+                .clone()
+                .with_files(vec![
+                    "/home/chenxu/program/data/large_file_written.parquet".to_string(),
+                ])
+                .with_primary_key("uuid".to_string())
+                .with_schema(schema)
+                .build();
+            let async_writer = MultiPartAsyncWriter::try_new(write_conf.clone()).await?;
+            let mut async_writer = SortAsyncWriter::try_new(async_writer, write_conf, runtime.clone())?;
+
+            while let Some(rb) = reader.next_rb().await {
+                let rb = rb?;
+                async_writer.write_record_batch(rb).await?;
+            }
+
+            Box::new(async_writer).flush_and_close().await?;
+            drop(reader);
+
+            Ok(())
+        })
     }
 
     #[test]

--- a/rust/lakesoul-io/src/sorted_merge/sorted_stream_merger.rs
+++ b/rust/lakesoul-io/src/sorted_merge/sorted_stream_merger.rs
@@ -867,7 +867,7 @@ mod tests {
             2,
             vec![
                 MergeOperator::UseLast,
-                MergeOperator::Sum,
+                MergeOperator::SumAll,
                 MergeOperator::UseLastNotNull,
                 MergeOperator::UseLast,
                 MergeOperator::UseLast,

--- a/website/docs/03-Usage Docs/06-flink-lakesoul-connector.md
+++ b/website/docs/03-Usage Docs/06-flink-lakesoul-connector.md
@@ -288,3 +288,12 @@ JOIN `lakesoul`.`default`.customers FOR SYSTEM_TIME AS OF o.proctime
 ON c_id = o_cid;
 ```
 In the example above, the Orders table is enriched with data from the Customers table. The FOR SYSTEM_TIME AS OF clause with the subsequent processing time attribute ensures that each row of the Orders table is joined with those Customers rows that match the join predicate at the point in time when the Orders row is processed by the join operator. It also prevents that the join result is updated when a joined Customer row is updated in the future. The lookup join also requires a mandatory equality join predicate, in the example above o.oc_id = c.id.
+
+## 5. Configurations
+The following configuration items can be placed in `$FLINK_HOME/conf/flink-conf.yaml` and take effect globally. You can also add it to the properties of the table creation statement. If there are the same configuration items in the configuration file and table creation properties, the table creation properties have a higher priority.
+
+| Configuration item              | Default value | Meaning                                                                                        |
+|---------------------------------|---------------|------------------------------------------------------------------------------------------------|
+| lakesoul.file.rolling.rows      | 5000000       | Sink Writer maximum number of rows in a single file                                            |
+| lakesoul.file.rolling.time.ms   | 300000        | Sink Writer interval for creating new files (milliseconds)                                     |
+| lakesoul.rolling.check.interval | 60000         | The interval at which Sink Writer checks whether a new file needs to be created (milliseconds) |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/03-Usage Docs/06-flink-lakesoul-connector.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/03-Usage Docs/06-flink-lakesoul-connector.md
@@ -294,3 +294,12 @@ JOIN `lakesoul`.`default`.customers FOR SYSTEM_TIME AS OF o.proctime
 ON c_id = o_cid;
 ```
 在上面的示例中，Orders 表需要与 Customers 表的数据进行 Lookup Join。带有后续 process time 属性的 FOR SYSTEM_TIME AS OF 子句确保在联接运算符处理 Orders 行时，Orders 的每一行都与 join 条件匹配的 Customer 行连接。它还防止连接的 Customer 表在未来发生更新时变更连接结果。lookup join 还需要一个强制的相等连接条件，在上面的示例中是 o_c_id = c_id
+
+## 5. 配置项说明
+以下配置项可以放在 `$FLINK_HOME/conf/flink-conf.yaml` 中，全局生效。也可以添加在建表语句的参数中。如果配置文件和建表参数中有相同的配置项，则建表语句参数的优先级更高。
+
+| 配置项                             | 默认值     | 含义                            |
+|---------------------------------|---------|-------------------------------|
+| lakesoul.file.rolling.rows      | 5000000 | Sink Writer 单个文件行数上限          |
+| lakesoul.file.rolling.time.ms   | 300000  | Sink Writer 新建文件的间隔(毫秒)       |
+| lakesoul.rolling.check.interval | 60000   | Sink Writer 检查是否需要新建文件的间隔(毫秒) |


### PR DESCRIPTION
1. Roll part file for every 5 million rows by default;
2. Fix error not returned when sorting writer failed.