### PR TITLE
[Flink] Allow disable auto schema change. Add batch size config

### DIFF
--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/Path.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/Path.java
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Modified from https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+// to avoid using Hadoop's Path class
+
+package com.dmetasoul.lakesoul.meta;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+public class Path implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The directory separator, a slash. */
+    public static final String SEPARATOR = "/";
+
+    /** Character denoting the current directory. */
+    public static final String CUR_DIR = ".";
+
+    /** A pre-compiled regex/state-machine to match the windows drive pattern. */
+    private static final Pattern WINDOWS_ROOT_DIR_REGEX = Pattern.compile("/\\p{Alpha}+:/");
+
+    /** The internal representation of the path, a hierarchical URI. */
+    private URI uri;
+
+    /** Constructs a new (empty) path object (used to reconstruct path object after RPC call). */
+    public Path() {}
+
+    /**
+     * Constructs a path object from a given URI.
+     *
+     * @param uri the URI to construct the path object from
+     */
+    public Path(URI uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * Resolve a child path against a parent path.
+     *
+     * @param parent the parent path
+     * @param child the child path
+     */
+    public Path(String parent, String child) {
+        this(new Path(parent), new Path(child));
+    }
+
+    /**
+     * Resolve a child path against a parent path.
+     *
+     * @param parent the parent path
+     * @param child the child path
+     */
+    public Path(Path parent, String child) {
+        this(parent, new Path(child));
+    }
+
+    /**
+     * Resolve a child path against a parent path.
+     *
+     * @param parent the parent path
+     * @param child the child path
+     */
+    public Path(String parent, Path child) {
+        this(new Path(parent), child);
+    }
+
+    /**
+     * Resolve a child path against a parent path.
+     *
+     * @param parent the parent path
+     * @param child the child path
+     */
+    public Path(Path parent, Path child) {
+        // Add a slash to parent's path so resolution is compatible with URI's
+        URI parentUri = parent.uri;
+        final String parentPath = parentUri.getPath();
+        if (!(parentPath.equals("/") || parentPath.equals(""))) {
+            try {
+                parentUri =
+                        new URI(
+                                parentUri.getScheme(),
+                                parentUri.getAuthority(),
+                                parentUri.getPath() + "/",
+                                null,
+                                null);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        if (child.uri.getPath().startsWith(Path.SEPARATOR)) {
+            child =
+                    new Path(
+                            child.uri.getScheme(),
+                            child.uri.getAuthority(),
+                            child.uri.getPath().substring(1));
+        }
+
+        final URI resolved = parentUri.resolve(child.uri);
+        initialize(resolved.getScheme(), resolved.getAuthority(), resolved.getPath());
+    }
+
+    /**
+     * Checks if the provided path string is either null or has zero length and throws a {@link
+     * IllegalArgumentException} if any of the two conditions apply.
+     *
+     * @param path the path string to be checked
+     * @return The checked path.
+     */
+    private String checkPathArg(String path) {
+        // disallow construction of a Path from an empty string
+        if (path == null) {
+            throw new IllegalArgumentException("Can not create a Path from a null string");
+        }
+        if (path.length() == 0) {
+            throw new IllegalArgumentException("Can not create a Path from an empty string");
+        }
+        return path;
+    }
+
+    /**
+     * Construct a path from a String. Path strings are URIs, but with unescaped elements and some
+     * additional normalization.
+     *
+     * @param pathString the string to construct a path from
+     */
+    public Path(String pathString) {
+        pathString = checkPathArg(pathString);
+
+        // We can't use 'new URI(String)' directly, since it assumes things are
+        // escaped, which we don't require of Paths.
+
+        // add a slash in front of paths with Windows drive letters
+        if (hasWindowsDrive(pathString, false)) {
+            pathString = "/" + pathString;
+        }
+
+        // parse uri components
+        String scheme = null;
+        String authority = null;
+
+        int start = 0;
+
+        // parse uri scheme, if any
+        final int colon = pathString.indexOf(':');
+        final int slash = pathString.indexOf('/');
+        if ((colon != -1) && ((slash == -1) || (colon < slash))) { // has a
+            // scheme
+            scheme = pathString.substring(0, colon);
+            start = colon + 1;
+        }
+
+        // parse uri authority, if any
+        if (pathString.startsWith("//", start)
+                && (pathString.length() - start > 2)) { // has authority
+            final int nextSlash = pathString.indexOf('/', start + 2);
+            final int authEnd = nextSlash > 0 ? nextSlash : pathString.length();
+            authority = pathString.substring(start + 2, authEnd);
+            start = authEnd;
+        }
+
+        // uri path is the rest of the string -- query & fragment not supported
+        final String path = pathString.substring(start, pathString.length());
+
+        initialize(scheme, authority, path);
+    }
+
+    /**
+     * Construct a Path from a scheme, an authority and a path string.
+     *
+     * @param scheme the scheme string
+     * @param authority the authority string
+     * @param path the path string
+     */
+    public Path(String scheme, String authority, String path) {
+        path = checkPathArg(path);
+        initialize(scheme, authority, path);
+    }
+
+    /**
+     * Initializes a path object given the scheme, authority and path string.
+     *
+     * @param scheme the scheme string.
+     * @param authority the authority string.
+     * @param path the path string.
+     */
+    private void initialize(String scheme, String authority, String path) {
+        try {
+            this.uri = new URI(scheme, authority, normalizePath(path), null, null).normalize();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Normalizes a path string.
+     *
+     * @param path the path string to normalize
+     * @return the normalized path string
+     */
+    private String normalizePath(String path) {
+        // remove consecutive slashes & backslashes
+        path = path.replace("\\", "/");
+        path = path.replaceAll("/+", "/");
+
+        // remove tailing separator
+        if (path.endsWith(SEPARATOR)
+                && !path.equals(SEPARATOR)
+                && // UNIX root path
+                !WINDOWS_ROOT_DIR_REGEX.matcher(path).matches()) { // Windows root path)
+
+            // remove tailing slash
+            path = path.substring(0, path.length() - SEPARATOR.length());
+        }
+
+        return path;
+    }
+
+    /**
+     * Converts the path object to a {@link URI}.
+     *
+     * @return the {@link URI} object converted from the path object
+     */
+    public URI toUri() {
+        return uri;
+    }
+
+    /**
+     * Checks if the directory of this path is absolute.
+     *
+     * @return <code>true</code> if the directory of this path is absolute, <code>false</code>
+     *     otherwise
+     */
+    public boolean isAbsolute() {
+        final int start = hasWindowsDrive(uri.getPath(), true) ? 3 : 0;
+        return uri.getPath().startsWith(SEPARATOR, start);
+    }
+
+    /**
+     * Returns the final component of this path, i.e., everything that follows the last separator.
+     *
+     * @return the final component of the path
+     */
+    public String getName() {
+        final String path = uri.getPath();
+        final int slash = path.lastIndexOf(SEPARATOR);
+        return path.substring(slash + 1);
+    }
+
+    /**
+     * Return full path.
+     *
+     * @return full path
+     */
+    public String getPath() {
+        return uri.getPath();
+    }
+
+    /**
+     * Returns the parent of a path, i.e., everything that precedes the last separator or <code>null
+     * </code> if at root.
+     *
+     * @return the parent of a path or <code>null</code> if at root.
+     */
+    public Path getParent() {
+        final String path = uri.getPath();
+        final int lastSlash = path.lastIndexOf('/');
+        final int start = hasWindowsDrive(path, true) ? 3 : 0;
+        if ((path.length() == start)
+                || // empty path
+                (lastSlash == start && path.length() == start + 1)) { // at root
+            return null;
+        }
+        String parent;
+        if (lastSlash == -1) {
+            parent = CUR_DIR;
+        } else {
+            final int end = hasWindowsDrive(path, true) ? 3 : 0;
+            parent = path.substring(0, lastSlash == end ? end + 1 : lastSlash);
+        }
+        return new Path(uri.getScheme(), uri.getAuthority(), parent);
+    }
+
+    /**
+     * Adds a suffix to the final name in the path.
+     *
+     * @param suffix The suffix to be added
+     * @return the new path including the suffix
+     */
+    public Path suffix(String suffix) {
+        return new Path(getParent(), getName() + suffix);
+    }
+
+    @Override
+    public String toString() {
+        // we can't use uri.toString(), which escapes everything, because we want
+        // illegal characters unescaped in the string, for glob processing, etc.
+        final StringBuilder buffer = new StringBuilder();
+        if (uri.getScheme() != null) {
+            buffer.append(uri.getScheme());
+            buffer.append(":");
+        }
+        if (uri.getAuthority() != null) {
+            buffer.append("//");
+            buffer.append(uri.getAuthority());
+        }
+        if (uri.getPath() != null) {
+            String path = uri.getPath();
+            if (path.indexOf('/') == 0
+                    && hasWindowsDrive(path, true)
+                    && // has windows drive
+                    uri.getScheme() == null
+                    && // but no scheme
+                    uri.getAuthority() == null) { // or authority
+                path = path.substring(1); // remove slash before drive
+            }
+            buffer.append(path);
+        }
+        return buffer.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Path)) {
+            return false;
+        }
+        Path that = (Path) o;
+        return this.uri.equals(that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return uri.hashCode();
+    }
+
+    public int compareTo(Object o) {
+        Path that = (Path) o;
+        return this.uri.compareTo(that.uri);
+    }
+
+    /**
+     * Returns the number of elements in this path.
+     *
+     * @return the number of elements in this path
+     */
+    public int depth() {
+        String path = uri.getPath();
+        int depth = 0;
+        int slash = path.length() == 1 && path.charAt(0) == '/' ? -1 : 0;
+        while (slash != -1) {
+            depth++;
+            slash = path.indexOf(SEPARATOR, slash + 1);
+        }
+        return depth;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Utilities
+    // ------------------------------------------------------------------------
+
+    /**
+     * Checks if the provided path string contains a windows drive letter.
+     *
+     * @return True, if the path string contains a windows drive letter, false otherwise.
+     */
+    public boolean hasWindowsDrive() {
+        return hasWindowsDrive(uri.getPath(), true);
+    }
+
+    /**
+     * Checks if the provided path string contains a windows drive letter.
+     *
+     * @param path the path to check
+     * @param slashed true to indicate the first character of the string is a slash, false otherwise
+     * @return <code>true</code> if the path string contains a windows drive letter, false otherwise
+     */
+    private boolean hasWindowsDrive(String path, boolean slashed) {
+        final int start = slashed ? 1 : 0;
+        return path.length() >= start + 2
+                && (!slashed || path.charAt(0) == '/')
+                && path.charAt(start + 1) == ':'
+                && ((path.charAt(start) >= 'A' && path.charAt(start) <= 'Z')
+                || (path.charAt(start) >= 'a' && path.charAt(start) <= 'z'));
+    }
+
+    // ------------------------------------------------------------------------
+    //  Utilities
+    // ------------------------------------------------------------------------
+
+    /**
+     * Creates a path for the given local file.
+     *
+     * <p>This method is useful to make sure the path creation for local files works seamlessly
+     * across different operating systems. Especially Windows has slightly different rules for
+     * slashes between schema and a local file path, making it sometimes tricky to produce
+     * cross-platform URIs for local files.
+     *
+     * @param file The file that the path should represent.
+     * @return A path representing the local file URI of the given file.
+     */
+    public static Path fromLocalFile(File file) {
+        return new Path(file.toURI());
+    }
+}

--- a/lakesoul-common/src/main/scala/com/dmetasoul/lakesoul/meta/DataOperation.scala
+++ b/lakesoul-common/src/main/scala/com/dmetasoul/lakesoul/meta/DataOperation.scala
@@ -5,7 +5,8 @@
 package com.dmetasoul.lakesoul.meta
 
 import com.dmetasoul.lakesoul.meta.entity.{DataCommitInfo, PartitionInfo}
-import org.apache.hadoop.fs.Path
+
+import java.net.URI
 
 import java.util
 import java.util.{Objects, UUID}
@@ -36,7 +37,14 @@ object BucketingUtils {
 case class DataFileInfo(range_partitions: String, path: String, file_op: String, size: Long,
                         modification_time: Long = -1L, file_exist_cols: String = "") {
 
-  lazy val file_bucket_id: Int = BucketingUtils.getBucketId(new Path(path).getName)
+  def getName(pathStr: String): String = {
+    val uri = new URI(pathStr)
+    val path = uri.getPath
+    val slash = path.lastIndexOf("/")
+    path.substring(slash + 1)
+  }
+
+  lazy val file_bucket_id: Int = BucketingUtils.getBucketId(getName(path))
     .getOrElse(sys.error(s"Invalid bucket file $path"))
 
   override def hashCode(): Int = {

--- a/lakesoul-common/src/main/scala/com/dmetasoul/lakesoul/meta/DataOperation.scala
+++ b/lakesoul-common/src/main/scala/com/dmetasoul/lakesoul/meta/DataOperation.scala
@@ -37,14 +37,7 @@ object BucketingUtils {
 case class DataFileInfo(range_partitions: String, path: String, file_op: String, size: Long,
                         modification_time: Long = -1L, file_exist_cols: String = "") {
 
-  def getName(pathStr: String): String = {
-    val uri = new URI(pathStr)
-    val path = uri.getPath
-    val slash = path.lastIndexOf("/")
-    path.substring(slash + 1)
-  }
-
-  lazy val file_bucket_id: Int = BucketingUtils.getBucketId(getName(path))
+  lazy val file_bucket_id: Int = BucketingUtils.getBucketId(new Path(path).getName)
     .getOrElse(sys.error(s"Invalid bucket file $path"))
 
   override def hashCode(): Int = {

--- a/lakesoul-common/src/main/scala/com/dmetasoul/lakesoul/meta/MetaVersion.scala
+++ b/lakesoul-common/src/main/scala/com/dmetasoul/lakesoul/meta/MetaVersion.scala
@@ -8,7 +8,6 @@ import com.alibaba.fastjson.JSONObject
 import com.dmetasoul.lakesoul.meta.entity.PartitionInfo
 
 import java.util
-import java.util.UUID
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/flink/FlinkSqlSubmitter.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/entry/sql/flink/FlinkSqlSubmitter.java
@@ -4,10 +4,8 @@
 
 package org.apache.flink.lakesoul.entry.sql.flink;
 
-
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.lakesoul.entry.sql.Submitter;
 import org.apache.flink.lakesoul.entry.sql.common.FlinkOption;
 import org.apache.flink.lakesoul.entry.sql.common.JobType;
@@ -15,20 +13,14 @@ import org.apache.flink.lakesoul.entry.sql.common.SubmitOption;
 import org.apache.flink.lakesoul.entry.sql.utils.FileUtil;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
 
 public class FlinkSqlSubmitter extends Submitter {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkSqlSubmitter.class);
@@ -87,5 +79,4 @@ public class FlinkSqlSubmitter extends Submitter {
                 Time.of(20, TimeUnit.SECONDS) // delay
         ));
     }
-
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/metadata/LakeSoulCatalog.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/metadata/LakeSoulCatalog.java
@@ -331,7 +331,7 @@ public class LakeSoulCatalog implements Catalog {
                 FileSystem fileSystem = new Path(path).getFileSystem();
                 Path qp = new Path(path).makeQualified(fileSystem);
                 FlinkUtil.createAndSetTableDirPermission(qp, false);
-                qualifiedPath = qp.toString();
+                qualifiedPath = qp.toUri().toString();
             } catch (IOException e) {
                 e.printStackTrace();
                 LOG.error("Set table dir {} permission failed.", path, e);

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/LakeSoulMultiTableSinkStreamBuilder.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/sink/LakeSoulMultiTableSinkStreamBuilder.java
@@ -21,11 +21,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
-import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.BUCKET_CHECK_INTERVAL;
-import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.BUCKET_PARALLELISM;
-import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.DYNAMIC_BUCKETING;
-import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.FILE_ROLLING_SIZE;
-import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.FILE_ROLLING_TIME;
+import static org.apache.flink.lakesoul.tool.LakeSoulSinkOptions.*;
 
 public class LakeSoulMultiTableSinkStreamBuilder {
 
@@ -60,6 +56,9 @@ public class LakeSoulMultiTableSinkStreamBuilder {
 
     public DataStreamSink<BinarySourceRecord> buildLakeSoulDMLSink(DataStream<BinarySourceRecord> stream) {
         context.conf.set(DYNAMIC_BUCKETING, false);
+        if (!context.conf.contains(AUTO_SCHEMA_CHANGE)) {
+            context.conf.set(AUTO_SCHEMA_CHANGE, true);
+        }
         LakeSoulRollingPolicyImpl<RowData> rollingPolicy = new LakeSoulRollingPolicyImpl<>(
                 context.conf.getLong(FILE_ROLLING_SIZE), context.conf.getLong(FILE_ROLLING_TIME));
         OutputFileConfig fileNameConfig = OutputFileConfig.builder()
@@ -78,6 +77,9 @@ public class LakeSoulMultiTableSinkStreamBuilder {
 
     public static DataStreamSink<LakeSoulArrowWrapper> buildArrowSink(Context context,
                                                                       DataStream<LakeSoulArrowWrapper> stream) {
+        if (!context.conf.contains(AUTO_SCHEMA_CHANGE)) {
+            context.conf.set(AUTO_SCHEMA_CHANGE, true);
+        }
         LakeSoulRollingPolicyImpl<LakeSoulArrowWrapper> rollingPolicy = new LakeSoulRollingPolicyImpl<>(
                 context.conf.getLong(FILE_ROLLING_SIZE), context.conf.getLong(FILE_ROLLING_TIME));
         OutputFileConfig fileNameConfig = OutputFileConfig.builder()

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulKeyGen.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulKeyGen.java
@@ -4,10 +4,14 @@
 
 package org.apache.flink.lakesoul.tool;
 
+import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.spark.sql.catalyst.expressions.Murmur3HashFunction;
+import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.io.Serializable;
@@ -18,75 +22,96 @@ import static org.apache.spark.sql.types.DataTypes.*;
 
 public class LakeSoulKeyGen implements Serializable {
 
-  private boolean simpleRecordKey = false;
-  private final int[] hashKeyIndex;
-  private final LogicalType[] hashKeyType;
+    private boolean simpleRecordKey = false;
+    private final int[] hashKeyIndex;
+    private final LogicalType[] hashKeyType;
 
-  public LakeSoulKeyGen(RowType rowType, String[] recordKeyFields) {
-    List<String> fieldNames = rowType.getFieldNames();
-    List<LogicalType> fieldTypes = rowType.getChildren();
-    if (recordKeyFields.length == 1) {
-      this.simpleRecordKey = true;
+    public LakeSoulKeyGen(RowType rowType, String[] recordKeyFields) {
+        List<String> fieldNames = rowType.getFieldNames();
+        List<LogicalType> fieldTypes = rowType.getChildren();
+        if (recordKeyFields.length == 1) {
+            this.simpleRecordKey = true;
+        }
+        this.hashKeyIndex = getFieldPositions(recordKeyFields, fieldNames);
+        this.hashKeyType = Arrays.stream(hashKeyIndex).mapToObj(fieldTypes::get).toArray(LogicalType[]::new);
     }
-    this.hashKeyIndex = getFieldPositions(recordKeyFields, fieldNames);
-    this.hashKeyType = Arrays.stream(hashKeyIndex).mapToObj(fieldTypes::get).toArray(LogicalType[]::new);
-  }
 
-  private static int[] getFieldPositions(String[] fields, List<String> allFields) {
-    return Arrays.stream(fields).mapToInt(allFields::indexOf).toArray();
-  }
-
-  public long getRePartitionHash(RowData rowData) {
-    long hash = 42;
-    if (hashKeyType.length == 0) {
-      return hash;
+    private static int[] getFieldPositions(String[] fields, List<String> allFields) {
+        return Arrays.stream(fields).mapToInt(allFields::indexOf).toArray();
     }
-    if (this.simpleRecordKey) {
-      Object fieldOrNull = RowData.createFieldGetter(hashKeyType[0], hashKeyIndex[0]).getFieldOrNull(rowData);
-      return getHash(hashKeyType[0], fieldOrNull, hash);
-    } else {
-      for (int i = 0; i < hashKeyType.length; i++) {
-        Object fieldOrNull = RowData.createFieldGetter(hashKeyType[i], hashKeyIndex[i]).getFieldOrNull(rowData);
-        hash = getHash(hashKeyType[i], fieldOrNull, hash);
-      }
-      return hash;
-    }
-  }
 
-  public static long getHash(LogicalType type, Object field, long seed) {
-
-    switch (type.getTypeRoot()) {
-      case VARCHAR:
-        UTF8String utf8String = UTF8String.fromString(java.lang.String.valueOf(field));
-        seed = Murmur3HashFunction.hash(utf8String, StringType, seed);
-        break;
-      case INTEGER:
-        seed = Murmur3HashFunction.hash(field, IntegerType, seed);
-        break;
-      case BIGINT:
-        seed = Murmur3HashFunction.hash(field, LongType, seed);
-        break;
-      case BINARY:
-        seed = Murmur3HashFunction.hash(field, ByteType, seed);
-        break;
-      case SMALLINT:
-        seed = Murmur3HashFunction.hash(field, ShortType, seed);
-        break;
-      case FLOAT:
-        seed = Murmur3HashFunction.hash(field, FloatType, seed);
-        break;
-      case DOUBLE:
-        seed = Murmur3HashFunction.hash(field, DoubleType, seed);
-        break;
-      case DATE:
-        seed = Murmur3HashFunction.hash(field,IntegerType, seed);
-        break;
-      case BOOLEAN:
-        seed = Murmur3HashFunction.hash(field, BooleanType, seed);
-        break;
-      default:
-        throw new RuntimeException("not support this partition type now :" + type.getTypeRoot().toString());
+    public long getRePartitionHash(RowData rowData) {
+        long hash = 42;
+        if (hashKeyType.length == 0) {
+            return hash;
+        }
+        if (this.simpleRecordKey) {
+            Object fieldOrNull = RowData.createFieldGetter(hashKeyType[0], hashKeyIndex[0]).getFieldOrNull(rowData);
+            return getHash(hashKeyType[0], fieldOrNull, hash);
+        } else {
+            for (int i = 0; i < hashKeyType.length; i++) {
+                Object fieldOrNull = RowData.createFieldGetter(hashKeyType[i], hashKeyIndex[i]).getFieldOrNull(rowData);
+                hash = getHash(hashKeyType[i], fieldOrNull, hash);
+            }
+            return hash;
+        }
     }
-    return seed;
-  }
+
+    public static long getHash(LogicalType type, Object field, long seed) {
+
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                UTF8String utf8String = UTF8String.fromString(java.lang.String.valueOf(field));
+                seed = Murmur3HashFunction.hash(utf8String, StringType, seed);
+                break;
+            case INTEGER:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case INTERVAL_YEAR_MONTH:
+                seed = Murmur3HashFunction.hash(field, IntegerType, seed);
+                break;
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                seed = Murmur3HashFunction.hash(field, LongType, seed);
+                break;
+            case TINYINT:
+                seed = Murmur3HashFunction.hash(field, ByteType, seed);
+                break;
+            case BINARY:
+            case VARBINARY:
+                seed = Murmur3HashFunction.hash(field, BinaryType, seed);
+                break;
+            case SMALLINT:
+                seed = Murmur3HashFunction.hash(field, ShortType, seed);
+                break;
+            case FLOAT:
+                seed = Murmur3HashFunction.hash(field, FloatType, seed);
+                break;
+            case DOUBLE:
+                seed = Murmur3HashFunction.hash(field, DoubleType, seed);
+                break;
+            case BOOLEAN:
+                seed = Murmur3HashFunction.hash(field, BooleanType, seed);
+                break;
+            case DECIMAL:
+                DecimalType decimalType = (DecimalType) type;
+                DecimalData decimalData = (DecimalData) field;
+                seed =
+                        Murmur3HashFunction.hash(Decimal.apply(decimalData.toBigDecimal(), decimalType.getPrecision(),
+                                        decimalType.getScale()),
+                                new org.apache.spark.sql.types.DecimalType(decimalType.getPrecision(),
+                                        decimalType.getScale()), seed);
+                break;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                TimestampData timestampData = (TimestampData) field;
+                long value = timestampData.getMillisecond() + timestampData.getNanoOfMillisecond() / 1000;
+                seed = Murmur3HashFunction.hash(value, LongType, seed);
+                break;
+            default:
+                throw new RuntimeException("not support this partition type now :" + type.getTypeRoot().toString());
+        }
+        return seed;
+    }
 }

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulSinkOptions.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulSinkOptions.java
@@ -217,7 +217,7 @@ public class LakeSoulSinkOptions {
     public static final ConfigOption<Boolean> AUTO_SCHEMA_CHANGE = ConfigOptions
             .key("lakesoul.sink.auto_schema_change")
             .booleanType()
-            .defaultValue(true)
+            .defaultValue(false)
             .withDescription("If true, lakesoul sink will auto change sink table's schema");
 }
 

--- a/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulSinkOptions.java
+++ b/lakesoul-flink/src/main/java/org/apache/flink/lakesoul/tool/LakeSoulSinkOptions.java
@@ -167,10 +167,10 @@ public class LakeSoulSinkOptions {
             .withDescription("mongodb database");
 
     public static final ConfigOption<Integer> BATCH_SIZE = ConfigOptions
-            .key("batchSize")
+            .key("lakesoul.io.batch.size")
             .intType()
             .defaultValue(1024)
-            .withDescription("The cursor batch size");
+            .withDescription("The batch size for lakesoul native io");
 
     public static final ConfigOption<Integer> MAX_ROW_GROUP_SIZE = ConfigOptions
             .key("lakesoul.file.max_row_group_size")
@@ -214,6 +214,11 @@ public class LakeSoulSinkOptions {
             .defaultValue(false)
             .withDescription("If true, lakesoul source will infer schema from files");
 
+    public static final ConfigOption<Boolean> AUTO_SCHEMA_CHANGE = ConfigOptions
+            .key("lakesoul.sink.auto_schema_change")
+            .booleanType()
+            .defaultValue(true)
+            .withDescription("If true, lakesoul sink will auto change sink table's schema");
 }
 
 

--- a/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/LakeSoulTestUtils.java
+++ b/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/LakeSoulTestUtils.java
@@ -5,7 +5,6 @@
 package org.apache.flink.lakesoul.test;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.lakesoul.metadata.LakeSoulCatalog;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -13,7 +12,6 @@ import org.apache.flink.table.api.*;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;

--- a/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/flinkSource/DMLSuite.java
+++ b/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/flinkSource/DMLSuite.java
@@ -12,7 +12,9 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 import org.junit.Test;
 
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.lakesoul.test.flinkSource.TestUtils.BATCH_TYPE;
@@ -325,6 +327,7 @@ public class DMLSuite extends AbstractTestBase {
     @Test
     public void testPKTypes() throws ExecutionException, InterruptedException {
         TableEnvironment tEnv = TestUtils.createTableEnv(BATCH_TYPE);
+        tEnv.getConfig().setLocalTimeZone(TimeZone.getTimeZone("Asia/Shanghai").toZoneId());
         String createUserSql = "create table test_pk_types (" +
                 "    id1 DECIMAL(10, 5)," +
                 "    id2 DATE," +

--- a/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/schema/SchemaMigrationTest.java
+++ b/lakesoul-flink/src/test/java/org/apache/flink/lakesoul/test/schema/SchemaMigrationTest.java
@@ -59,6 +59,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromIntToBigInt() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new IntType());
         RowType.RowField afterField = new RowType.RowField("a", new BigIntType());
 
@@ -79,6 +80,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromIntToBigIntWithoutAllowance() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new IntType());
         RowType.RowField afterField = new RowType.RowField("a", new BigIntType());
 
@@ -99,6 +101,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromBigIntToInt() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new BigIntType());
         RowType.RowField afterField = new RowType.RowField("a", new IntType());
 
@@ -119,6 +122,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromBigIntToTinyIntWithAllowance() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new BigIntType());
         RowType.RowField afterField = new RowType.RowField("a", new TinyIntType());
 
@@ -139,6 +143,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromFloatToDouble() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new FloatType());
         RowType.RowField afterField = new RowType.RowField("a", new DoubleType());
 
@@ -159,6 +164,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromFloatToDoubleWithoutAllowance() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new FloatType());
         RowType.RowField afterField = new RowType.RowField("a", new DoubleType());
 
@@ -179,6 +185,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testAddColumn() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new FloatType());
         RowType.RowField afterFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField afterFieldB = new RowType.RowField("b", new IntType());
@@ -208,6 +215,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testDropColumn() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField beforeFieldB = new RowType.RowField("b", new IntType());
         RowType.RowField afterField = new RowType.RowField("a", new FloatType());
@@ -238,6 +246,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
         Map<String, String> options = new HashMap<>();
         options.put(LakeSoulSinkOptions.CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
         options.put(LakeSoulSinkOptions.LOGICALLY_DROP_COLUM.key(), "true");
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField beforeFieldB = new RowType.RowField("b", new IntType());
         RowType.RowField afterField = new RowType.RowField("a", new FloatType());
@@ -269,6 +278,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromDoubleToFloat() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new DoubleType());
         RowType.RowField afterField = new RowType.RowField("a", new FloatType());
 
@@ -289,6 +299,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testFromDoubleToFloatWithAllowance() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeField = new RowType.RowField("a", new DoubleType());
         RowType.RowField afterField = new RowType.RowField("a", new FloatType());
 
@@ -309,6 +320,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testChangeDatatypeOfPartitionColumn() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField beforeFieldB = new RowType.RowField("b", new IntType());
         RowType.RowField afterFieldA = new RowType.RowField("a", new FloatType());
@@ -342,6 +354,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testChangeOfPartitionColumn() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField beforeFieldB = new RowType.RowField("b", new IntType());
         RowType.RowField afterFieldA = new RowType.RowField("a", new FloatType());
@@ -375,6 +388,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testChangeDatatypeOfPrimaryKeyColumn() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField beforeFieldB = new RowType.RowField("b", new IntType(false));
         RowType.RowField afterFieldA = new RowType.RowField("a", new FloatType());
@@ -410,6 +424,7 @@ public class SchemaMigrationTest extends AbstractTestBase {
     public void testChangeOfPrimaryKeyColumn() throws IOException, ExecutionException, InterruptedException {
         Map<String, String> options = new HashMap<>();
         options.put(CATALOG_PATH.key(), tempFolder.newFolder("test_sink").getAbsolutePath());
+        options.put(LakeSoulSinkOptions.AUTO_SCHEMA_CHANGE.key(), "true");
         RowType.RowField beforeFieldA = new RowType.RowField("a", new FloatType());
         RowType.RowField beforeFieldB = new RowType.RowField("b", new IntType(false));
         RowType.RowField afterFieldA = new RowType.RowField("a", new FloatType());


### PR DESCRIPTION
1. Added a new config AUTO_SCHEMA_CHANGE(lakesoul.sink.auto_schema_change), default false. It is only enabled in `buildLakeSoulDMLSink` and `buildArrowSink` for sink to multiple tables.
2. Set batch size for reader from config BATCH_SIZE