### PR TITLE
Add cache for s3 object store

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -443,6 +443,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2411,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +2468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2540,6 +2582,19 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2794,7 +2849,7 @@ checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -2959,7 +3014,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3351,14 +3406,19 @@ dependencies = [
  "datafusion-substrait",
  "derivative",
  "dhat",
+ "filetime",
+ "fs-err",
  "futures",
  "half",
  "hdfs-sys",
  "hdrs",
  "hex",
  "lazy_static",
+ "linked-hash-map",
+ "moka",
  "ndarray",
  "nohash",
+ "num_cpus",
  "object_store",
  "parking_lot",
  "parquet",
@@ -3369,6 +3429,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -3378,7 +3439,9 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "walkdir",
  "whoami",
+ "zipf",
 ]
 
 [[package]]
@@ -3558,6 +3621,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.5.3",
+]
+
+[[package]]
 name = "libz-ng-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3606,6 +3680,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -3806,6 +3893,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener",
+ "futures-util",
+ "loom",
+ "parking_lot",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3871,6 +3980,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3961,6 +4079,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
 ]
 
 [[package]]
@@ -4974,6 +5102,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "recursive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5385,6 +5533,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5869,6 +6023,26 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -6821,7 +6995,27 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6835,13 +7029,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -6860,7 +7132,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7168,6 +7440,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "zipf"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4e079d30939088cfc89b5318a5d3557d4a92890c917aa40475ea763bd473d5"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/rust/lakesoul-io/Cargo.toml
+++ b/rust/lakesoul-io/Cargo.toml
@@ -51,6 +51,15 @@ nohash = "0.2.0"
 uuid = { workspace = true }
 regex = "1.11.1"
 
+num_cpus = "1.16"
+filetime = "0.2.25"
+fs-err = "3.1.0"
+linked-hash-map = "0.5.6"
+moka = { version = "~0.12", features = ["future"] }
+tempfile = "3"
+sysinfo = "~0.32"
+walkdir = "2.5.0"
+zipf = "7.0.2"
 
 [features]
 hdfs = ["dep:hdrs", "dep:hdfs-sys"]

--- a/rust/lakesoul-io/src/lakesoul_cache/cache.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/cache.rs
@@ -1,0 +1,514 @@
+pub mod builder;
+pub mod lru_cache;
+pub mod lru_disk_cache;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use lru_disk_cache::LruDiskCache;
+use moka::future::Cache;
+use object_store::{path::Path, ObjectMeta};
+use std::{
+    collections::HashMap,
+    future::Future,
+    ops::Range,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+use tempfile::tempdir;
+use tokio::sync::RwLock;
+
+pub use self::builder::DiskCacheBuilder;
+use crate::lakesoul_cache::paging::PageCache;
+use object_store::Error;
+use object_store::Result;
+
+/// Default memory page size is 16 KB
+pub const DEFAULT_PAGE_SIZE: usize = 16 * 1024;
+const DEFAULT_TIME_TO_IDLE: Duration = Duration::from_secs(60 * 30); // 30 minutes
+const DEFAULT_METADATA_CACHE_SIZE: usize = 32 * 1024 * 1024;
+
+pub fn bytes_to_object_meta(bytes: &Bytes) -> Result<ObjectMeta> {
+    let str = String::from_utf8(bytes.to_vec()).unwrap();
+    from_json(&str)
+}
+
+pub fn object_meta_to_bytes(object_meta: &ObjectMeta) -> Bytes {
+    let str = to_json(object_meta);
+    Bytes::from(str)
+}
+
+/// 将 JSON 字符串反序列化为 ObjectMeta
+pub fn from_json(json: &str) -> Result<ObjectMeta> {
+    use serde_json::Value;
+    let value: Value = serde_json::from_str(json).unwrap();
+
+    let location = Path::from(value["location"].as_str().ok_or("Invalid location").unwrap());
+    let last_modified =
+        DateTime::parse_from_rfc3339(value["last_modified"].as_str().ok_or("Invalid last_modified").unwrap())
+            .unwrap()
+            .with_timezone(&Utc);
+    let size = value["size"].as_u64().ok_or("Invalid size").unwrap() as usize;
+    let e_tag = value["e_tag"].as_str().map(|s| s.to_string());
+    let version = value["version"].as_str().map(|s| s.to_string());
+
+    Ok(ObjectMeta {
+        location,
+        last_modified,
+        size,
+        e_tag,
+        version,
+    })
+}
+
+/// 将 ObjectMeta 序列化为 JSON 字符串
+pub fn to_json(object_meta: &ObjectMeta) -> String {
+    let mut json = String::new();
+    json.push('{');
+
+    // 序列化 location
+    json.push_str("\"location\":\"");
+    json.push_str(&object_meta.location.to_string());
+    json.push_str("\",");
+
+    // 序列化 last_modified
+    json.push_str("\"last_modified\":\"");
+    json.push_str(&object_meta.last_modified.to_rfc3339());
+    json.push_str("\",");
+
+    // 序列化 size
+    json.push_str("\"size\":");
+    json.push_str(&object_meta.size.to_string());
+    json.push_str(",");
+
+    // 序列化 e_tag
+    if let Some(e_tag) = &object_meta.e_tag {
+        json.push_str("\"e_tag\":\"");
+        json.push_str(e_tag);
+        json.push_str("\",");
+    } else {
+        json.push_str("\"e_tag\":null,");
+    }
+
+    // 序列化 version
+    if let Some(version) = &object_meta.version {
+        json.push_str("\"version\":\"");
+        json.push_str(version);
+        json.push_str("\"");
+    } else {
+        json.push_str("\"version\":null");
+    }
+
+    json.push('}');
+    json
+}
+
+pub fn concat_location_with_pagid(location: &Path, page_id: u32) -> String {
+    format!("{}_{}", location.to_string(), page_id)
+}
+
+/// In-memory [`PageCache`] implementation.
+///
+/// This is a LRU mapping of page IDs to page data, with TTL eviction.
+///
+#[derive(Debug)]
+pub struct DiskCache {
+    /// Disk Cache Capacity in bytes
+    disk_capacity: usize,
+
+    /// Size of each page
+    page_size: usize,
+
+    /// In memory page cache: a mapping from `(path id, offset)` to data / bytes.
+    // cache: Cache<(u64, u32), Bytes>,
+    // HybridCache<(u64, u32),
+    cache: LruDiskCache,
+
+    /// Metadata cache
+    // metadata_cache: Cache<u64, ObjectMeta>,
+    metadata_cache: Cache<u64, ObjectMeta>,
+
+    /// Provide fast lookup of path id
+    location_lookup: RwLock<HashMap<Path, u64>>,
+
+    /// Next location id to be assigned
+    next_location_id: AtomicU64,
+}
+
+impl DiskCache {
+    /// Create a [`Builder`](DiskCacheBuilder) to construct [`DiskCache`].
+    ///
+    /// # Parameters:
+    /// - *capacity*: capacity in bytes
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// use ocra::memory::DiskCache;
+    ///
+    /// let cache = DiskCache::builder(8*1024*1024)
+    ///     .page_size(4096)
+    ///     .time_to_idle(Duration::from_secs(60))
+    ///     .build();
+    /// ```
+    #[must_use]
+    pub fn builder(disk_capacity_bytes: usize) -> DiskCacheBuilder {
+        DiskCacheBuilder::new(disk_capacity_bytes)
+    }
+
+    /// Explicitly create a new [DiskCache] with a fixed capacity and page size.
+    ///
+    /// # Parameters:
+    /// - `capacity_bytes`: Max capacity in bytes.
+    /// - `page_size`: The maximum size of each page.
+    ///
+    pub fn new(disk_capacity: usize, page_size: usize) -> Self {
+        Self::with_params(disk_capacity, page_size, DEFAULT_TIME_TO_IDLE)
+    }
+
+    fn with_params(disk_capacity: usize, page_size: usize, _time_to_idle: Duration) -> Self {
+        let dir = tempdir().unwrap();
+        println!("tempdir: {}", dir.path().to_str().unwrap());
+        let cache = LruDiskCache::new("path", disk_capacity.try_into().unwrap()).unwrap();
+
+        let metadata_cache = Cache::builder()
+            .max_capacity(DEFAULT_METADATA_CACHE_SIZE as u64)
+            .build();
+        Self {
+            disk_capacity,
+            page_size,
+            cache,
+            metadata_cache,
+            location_lookup: RwLock::new(HashMap::new()),
+            next_location_id: AtomicU64::new(0),
+        }
+    }
+
+    /// Create a new [DiskCache] with a fixed capacity and page size.
+    async fn location_id(&self, location: &Path) -> u64 {
+        if let Some(&key) = self.location_lookup.read().await.get(location) {
+            return key;
+        }
+
+        let mut id_map = self.location_lookup.write().await;
+        // on lock-escalation, check if someone else has added it
+        if let Some(&id) = id_map.get(location) {
+            return id;
+        }
+
+        let id = self.next_location_id.fetch_add(1, Ordering::SeqCst);
+        id_map.insert(location.clone(), id);
+
+        id
+    }
+}
+
+#[async_trait::async_trait]
+impl PageCache for DiskCache {
+    /// The size of each page.
+    fn page_size(&self) -> usize {
+        self.page_size
+    }
+
+    /// Cache capacity in bytes.
+    fn capacity(&self) -> usize {
+        self.disk_capacity
+    }
+
+    /// Memory cache size in bytes.
+    fn size(&self) -> usize {
+        self.cache.size() as usize
+        // self.cache.memory().size() as usize
+        // self.cache.weighted_size() as usize
+    }
+
+    /// Get the page with the given page ID and location, and load it if not found.
+    async fn get_with(
+        &self,
+        location: &Path,
+        page_id: u32,
+        loader: impl Future<Output = Result<Bytes>> + Send,
+    ) -> Result<Bytes> {
+        let location_id = self.location_id(location).await;
+        let key = format!("{}_{}", location_id, page_id);
+        match self.cache.get(&key) {
+            Some(bytes) => Ok(Bytes::from(bytes)),
+            // _ => Err(format!("PageCache get_with Error:  get location {:?} ,page id {:?} ",location.to_string(),page_id).to_string())
+            _ => {
+                // When the page is not found in the cache, load it from the loader.
+                match loader.await {
+                    Ok(bytes) => {
+                        if bytes.len() == 0 {
+                            return Ok(bytes);
+                        }
+                        self.put(location, page_id, bytes.clone()).await?;
+                        return Ok(bytes);
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+    }
+
+    /// Get a range of the page with the given page ID and location, and load it if not found.
+    async fn get_range_with(
+        &self,
+        location: &Path,
+        page_id: u32,
+        range: Range<usize>,
+        loader: impl Future<Output = Result<Bytes>> + Send,
+    ) -> Result<Bytes> {
+        // Check if the range is within the page size.
+        assert!(range.start <= range.end && range.end <= self.page_size());
+        let bytes = self.get_with(location, page_id, loader).await?;
+        Ok(bytes.slice(range))
+    }
+
+    /// Get the page with the given page ID and location, and return `None` if not found.
+    async fn get(&self, location: &Path, page_id: u32) -> Result<Option<Bytes>> {
+        let location_id = self.location_id(location).await;
+        // construct key
+        let key = format!("{}_{}", location_id, page_id);
+        match self.cache.get(&key) {
+            Some(bytes) => {
+                Ok(Some(Bytes::from(bytes)))
+                // Ok(Some(bytes.value().clone())),
+            }
+            // When the page is not found in the cache, return None.
+            None => Ok(None),
+        }
+        // Ok(self.cache.get(&(location_id, page_id)).await.map(|bytes| bytes.unwrap().value().clone()).unwrap_or(None))
+    }
+
+    /// Get a range of the page with the given page ID and location, and return `None` if not found.
+    async fn get_range(&self, location: &Path, page_id: u32, range: Range<usize>) -> Result<Option<Bytes>> {
+        Ok(self.get(location, page_id).await?.map(|bytes| bytes.slice(range)))
+    }
+
+    /// Put the page with the given page ID and location.
+    async fn put(&self, location: &Path, page_id: u32, data: Bytes) -> Result<()> {
+        let location_id = self.location_id(location).await;
+        let key = format!("{}_{}", location_id, page_id);
+        self.cache.insert_bytes(key, &data).unwrap();
+        Ok(())
+    }
+
+    /// Get the metadata of the given location, and load it if not found.
+    async fn head(
+        &self,
+        location: &Path,
+        loader: impl Future<Output = Result<ObjectMeta>> + Send,
+    ) -> Result<ObjectMeta> {
+        let location_id = self.location_id(location).await;
+        match self.metadata_cache.try_get_with(location_id, loader).await {
+            Ok(meta) => Ok(meta),
+            Err(e) =>
+            //  Err(" self.metadata_cache.try_get_with err".to_string())
+            {
+                match e.as_ref() {
+                    // TODO: this adds an extra layer of error wrapping
+                    Error::NotFound { path, .. } => Err(Error::NotFound {
+                        path: path.to_string(),
+                        source: e.into(),
+                    }),
+                    _ => Err(Error::Generic {
+                        store: "DiskCache",
+                        source: Box::new(e),
+                    }),
+                }
+            }
+        }
+    }
+
+    async fn invalidate(&self, location: &Path) -> Result<()> {
+        // Remove the location from lookup table.
+        // This is cheaper (i.e., O(1)) instead of using O(n) to remove all entries from `self.cache`.
+        // The cache will be eventually cleared by the time-to-idle or LRU eviction.
+        let mut id_map = self.location_lookup.write().await;
+        id_map.remove(location);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{
+        io::Write,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    use bytes::{BufMut, BytesMut};
+    use chrono::TimeZone as _;
+    use object_store::{local::LocalFileSystem, ObjectStore};
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_get_range() {
+        let cache = DiskCache::new(1024 * 1024, 16 * 1024);
+        let local_fs = Arc::new(LocalFileSystem::new());
+
+        let tmp_dir = tempdir().unwrap();
+        let file_path = tmp_dir.path().join("test.bin");
+        std::fs::write(&file_path, "test data").unwrap();
+        let location = Path::from(file_path.as_path().to_str().unwrap());
+
+        let miss = Arc::new(AtomicUsize::new(0));
+
+        let data = cache
+            .get_with(&location, 0, {
+                let miss = miss.clone();
+                let local_fs = local_fs.clone();
+                let location = location.clone();
+                async move {
+                    miss.fetch_add(1, Ordering::SeqCst);
+                    local_fs.get(&location).await.unwrap().bytes().await
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(miss.load(Ordering::SeqCst), 1);
+        assert_eq!(data, Bytes::from("test data"));
+
+        let data = cache
+            .get_with(&location, 0, {
+                let miss = miss.clone();
+                let location = location.clone();
+                async move {
+                    miss.fetch_add(1, Ordering::SeqCst);
+                    local_fs.get(&location).await.unwrap().bytes().await
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(miss.load(Ordering::SeqCst), 1);
+        assert_eq!(data, Bytes::from("test data"));
+    }
+
+    #[tokio::test]
+    async fn test_eviction() {
+        const PAGE_SIZE: usize = 512;
+        let cache = DiskCache::new(1024, PAGE_SIZE);
+        let local_fs = Arc::new(LocalFileSystem::new());
+
+        let tmp_dir = tempdir().unwrap();
+        let file_path = tmp_dir.path().join("test.bin");
+        {
+            let mut file = std::fs::File::create(&file_path).unwrap();
+            for i in 0_u64..1024 {
+                file.write_all(&i.to_be_bytes()).unwrap();
+            }
+        }
+        let location = Path::from(file_path.as_path().to_str().unwrap());
+        // cache.cache.run_pending_tasks().await;
+
+        let miss = Arc::new(AtomicUsize::new(0));
+
+        for (page_id, expected_miss, expected_size) in [(0, 1, 1), (0, 1, 1), (1, 2, 2), (4, 3, 2), (5, 4, 2)].iter() {
+            println!("page_id: {}", page_id);
+            let data = cache
+                .get_with(&location, *page_id, {
+                    let miss = miss.clone();
+                    let local_fs = local_fs.clone();
+                    let location = location.clone();
+                    async move {
+                        miss.fetch_add(1, Ordering::SeqCst);
+                        local_fs
+                            .get_range(
+                                &location,
+                                PAGE_SIZE * (*page_id as usize)..PAGE_SIZE * (page_id + 1) as usize,
+                            )
+                            .await
+                    }
+                })
+                .await
+                .unwrap();
+            assert_eq!(miss.load(Ordering::SeqCst), *expected_miss);
+            assert_eq!(data.len(), PAGE_SIZE);
+
+            // cache.cache.run_pending_tasks().await;
+            assert_eq!(cache.cache.len(), *expected_size);
+
+            let mut buf = BytesMut::with_capacity(PAGE_SIZE);
+            for i in page_id * PAGE_SIZE as u32 / 8..(page_id + 1) * PAGE_SIZE as u32 / 8 {
+                buf.put_u64(i as u64);
+            }
+            assert_eq!(data, buf);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_head() {
+        const PAGE_SIZE: usize = 16 * 1024;
+        let cache = DiskCache::new(1024 * 1024, PAGE_SIZE);
+        let local_fs = Arc::new(LocalFileSystem::new());
+
+        let tmp_dir = tempdir().unwrap();
+        let file_path = tmp_dir.path().join("test.bin");
+        let path = Path::from(file_path.as_path().to_str().unwrap());
+
+        let r = cache
+            .head(&path, {
+                let local_fs = local_fs.clone();
+                let path = path.clone();
+                async move { local_fs.head(&path).await }
+            })
+            .await;
+        assert!(matches!(r, Err(Error::NotFound { .. })));
+        cache.metadata_cache.run_pending_tasks().await;
+        assert_eq!(cache.metadata_cache.entry_count(), 0);
+
+        std::fs::write(&file_path, "test data").unwrap();
+        let meta = cache
+            .head(&path, {
+                let local_fs = local_fs.clone();
+                let path = path.clone();
+                async move { local_fs.head(&path).await }
+            })
+            .await
+            .unwrap();
+        assert_eq!(meta.size, 9);
+    }
+
+    #[test]
+    fn test_to_json() {
+        let object_meta = ObjectMeta {
+            location: Path::from("test"),
+            last_modified: Utc.timestamp_nanos(100),
+            size: 100,
+            e_tag: Some("123".to_string()),
+            version: None,
+        };
+        let object_meta_to_str = to_json(&object_meta);
+        assert_eq!(
+            object_meta_to_str,
+            "{\"location\":\"test\",\"last_modified\":\"1970-01-01T00:00:00.000000100+00:00\",\"size\":100,\"e_tag\":\"123\",\"version\":null}"
+        );
+        let object_meta_from_str = from_json(&object_meta_to_str).unwrap();
+        assert_eq!(object_meta_from_str, object_meta);
+    }
+
+    #[test]
+    fn test_from_bytes() {
+        let object_meta = ObjectMeta {
+            location: Path::from("test"),
+            last_modified: Utc.timestamp_nanos(100),
+            size: 100,
+            e_tag: Some("123".to_string()),
+            version: None,
+        };
+        let bytes = object_meta_to_bytes(&object_meta);
+        let object_meta_from_bytes = bytes_to_object_meta(&bytes).unwrap();
+        assert_eq!(object_meta_from_bytes, object_meta);
+    }
+
+    #[test]
+    fn test_concat_location_with_pagid() {
+        let location = Path::from("test");
+        let page_id = 100;
+        let location_with_pagid = concat_location_with_pagid(&location, page_id);
+        assert_eq!(location_with_pagid, "test_100");
+    }
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/cache/builder.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/cache/builder.rs
@@ -1,0 +1,44 @@
+//! Disk cache Builder.
+//!
+
+use std::time::Duration;
+
+use super::{DiskCache, DEFAULT_PAGE_SIZE, DEFAULT_TIME_TO_IDLE};
+
+/// Builder for [`DiskCache`]
+pub struct DiskCacheBuilder {
+    capacity: usize,
+    page_size: usize,
+
+    time_to_idle: Duration,
+}
+
+impl DiskCacheBuilder {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            page_size: DEFAULT_PAGE_SIZE,
+            time_to_idle: DEFAULT_TIME_TO_IDLE,
+        }
+    }
+
+    /// Set the page size.
+    pub fn page_size(&mut self, size: usize) -> &mut Self {
+        self.page_size = size;
+        self
+    }
+
+    /// If an entry has been idle longer than `time_to_idle` seconds,
+    /// it will be evicted.
+    ///
+    /// Default is 30 minutes.
+    pub fn time_to_idle(&mut self, tti: Duration) -> &mut Self {
+        self.time_to_idle = tti;
+        self
+    }
+
+    #[must_use]
+    pub fn build(&self) -> DiskCache {
+        DiskCache::with_params(self.capacity, self.page_size, self.time_to_idle)
+    }
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/cache/lru_cache.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/cache/lru_cache.rs
@@ -1,0 +1,814 @@
+use std::borrow::Borrow;
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hash};
+
+use linked_hash_map::LinkedHashMap;
+
+// FIXME(conventions): implement indexing?
+
+/// A trait for measuring the size of a cache entry.
+///
+/// If you implement this trait, you should use `usize` as the `Measure` type, otherwise you will
+/// also have to implement [`CountableMeter`][countablemeter].
+///
+/// [countablemeter]: trait.Meter.html
+pub trait Meter<K, V> {
+    /// The type used to store measurements.
+    type Measure: Default + Copy;
+    /// Calculate the size of `key` and `value`.
+    fn measure<Q: ?Sized>(&self, key: &Q, value: &V) -> Self::Measure
+    where
+        K: Borrow<Q>;
+}
+
+/// Size limit based on a simple count of cache items.
+#[derive(Debug)]
+pub struct Count;
+
+impl<K, V> Meter<K, V> for Count {
+    /// Don't store anything, the measurement can be derived from the map.
+    type Measure = ();
+
+    /// Don't actually count anything either.
+    fn measure<Q: ?Sized>(&self, _: &Q, _: &V)
+    where
+        K: Borrow<Q>,
+    {
+    }
+}
+
+/// A trait to allow the default `Count` measurement to not store an
+/// extraneous counter.
+pub trait CountableMeter<K, V>: Meter<K, V> {
+    /// Add `amount` to `current` and return the sum.
+    fn add(&self, current: Self::Measure, amount: Self::Measure) -> Self::Measure;
+    /// Subtract `amount` from `current` and return the difference.
+    fn sub(&self, current: Self::Measure, amount: Self::Measure) -> Self::Measure;
+    /// Return `current` as a `usize` if possible, otherwise return `None`.
+    ///
+    /// If this method returns `None` the cache will use the number of cache entries as
+    /// its size.
+    fn size(&self, current: Self::Measure) -> Option<u64>;
+}
+
+/// `Count` is all no-ops, the number of entries in the map is the size.
+impl<K, V, T: Meter<K, V>> CountableMeter<K, V> for T
+where
+    T: CountableMeterWithMeasure<K, V, <T as Meter<K, V>>::Measure>,
+{
+    fn add(&self, current: Self::Measure, amount: Self::Measure) -> Self::Measure {
+        CountableMeterWithMeasure::meter_add(self, current, amount)
+    }
+    fn sub(&self, current: Self::Measure, amount: Self::Measure) -> Self::Measure {
+        CountableMeterWithMeasure::meter_sub(self, current, amount)
+    }
+    fn size(&self, current: Self::Measure) -> Option<u64> {
+        CountableMeterWithMeasure::meter_size(self, current)
+    }
+}
+
+pub trait CountableMeterWithMeasure<K, V, M> {
+    /// Add `amount` to `current` and return the sum.
+    fn meter_add(&self, current: M, amount: M) -> M;
+    /// Subtract `amount` from `current` and return the difference.
+    fn meter_sub(&self, current: M, amount: M) -> M;
+    /// Return `current` as a `usize` if possible, otherwise return `None`.
+    ///
+    /// If this method returns `None` the cache will use the number of cache entries as
+    /// its size.
+    fn meter_size(&self, current: M) -> Option<u64>;
+}
+
+/// For any other `Meter` with `Measure=usize`, just do the simple math.
+impl<K, V, T> CountableMeterWithMeasure<K, V, usize> for T
+where
+    T: Meter<K, V>,
+{
+    fn meter_add(&self, current: usize, amount: usize) -> usize {
+        current + amount
+    }
+    fn meter_sub(&self, current: usize, amount: usize) -> usize {
+        current - amount
+    }
+    fn meter_size(&self, current: usize) -> Option<u64> {
+        Some(current as u64)
+    }
+}
+
+impl<K, V> CountableMeterWithMeasure<K, V, ()> for Count {
+    fn meter_add(&self, _current: (), _amount: ()) {}
+    fn meter_sub(&self, _current: (), _amount: ()) {}
+    fn meter_size(&self, _current: ()) -> Option<u64> {
+        None
+    }
+}
+
+/// An LRU cache.
+#[derive(Clone, Debug)]
+pub struct LruCache<K: Eq + Hash, V, S: BuildHasher = RandomState, M: CountableMeter<K, V> = Count> {
+    map: LinkedHashMap<K, V, S>,
+    current_measure: M::Measure,
+    max_capacity: u64,
+    meter: M,
+}
+
+impl<K: Eq + Hash, V> LruCache<K, V> {
+    /// Creates an empty cache that can hold at most `capacity` items.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    /// let mut cache: LruCache<i32, &str> = LruCache::new(10);
+    /// ```
+    pub fn new(capacity: u64) -> Self {
+        LruCache {
+            map: LinkedHashMap::new(),
+            current_measure: (),
+            max_capacity: capacity,
+            meter: Count,
+        }
+    }
+}
+
+impl<K: Eq + Hash, V, M: CountableMeter<K, V>> LruCache<K, V, RandomState, M> {
+    /// Creates an empty cache that can hold at most `capacity` as measured by `meter`.
+    ///
+    /// You can implement the [`Meter`][meter] trait to allow custom metrics.
+    ///
+    /// [meter]: trait.Meter.html
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::{LruCache, Meter};
+    /// use std::borrow::Borrow;
+    ///
+    /// /// Measure Vec items by their length
+    /// struct VecLen;
+    ///
+    /// impl<K, T> Meter<K, Vec<T>> for VecLen {
+    ///     // Use `Measure = usize` or implement `CountableMeter` as well.
+    ///     type Measure = usize;
+    ///     fn measure<Q: ?Sized>(&self, _: &Q, v: &Vec<T>) -> usize
+    ///         where K: Borrow<Q>
+    ///     {
+    ///         v.len()
+    ///     }
+    /// }
+    ///
+    /// let mut cache = LruCache::with_meter(5, VecLen);
+    /// cache.insert(1, vec![1, 2]);
+    /// assert_eq!(cache.size(), 2);
+    /// cache.insert(2, vec![3, 4]);
+    /// cache.insert(3, vec![5, 6]);
+    /// assert_eq!(cache.size(), 4);
+    /// assert_eq!(cache.len(), 2);
+    /// ```
+    pub fn with_meter(capacity: u64, meter: M) -> LruCache<K, V, RandomState, M> {
+        LruCache {
+            map: LinkedHashMap::new(),
+            current_measure: Default::default(),
+            max_capacity: capacity,
+            meter,
+        }
+    }
+}
+
+impl<K: Eq + Hash, V, S: BuildHasher> LruCache<K, V, S, Count> {
+    /// Creates an empty cache that can hold at most `capacity` items with the given hash builder.
+    pub fn with_hasher(capacity: u64, hash_builder: S) -> LruCache<K, V, S, Count> {
+        LruCache {
+            map: LinkedHashMap::with_hasher(hash_builder),
+            current_measure: (),
+            max_capacity: capacity,
+            meter: Count,
+        }
+    }
+
+    /// Returns a mutable reference to the value corresponding to the given key in the cache, if
+    /// any.
+    ///
+    /// Note that this method is not available for cache objects using `Meter` implementations
+    /// other than `Count`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    /// cache.insert(2, "c");
+    /// cache.insert(3, "d");
+    ///
+    /// assert_eq!(cache.get_mut(&1), None);
+    /// assert_eq!(cache.get_mut(&2), Some(&mut "c"));
+    /// ```
+    pub fn get_mut<Q: Hash + Eq + ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+    {
+        self.map.get_refresh(k)
+    }
+
+    /// Returns an iterator over the cache's key-value pairs in least- to most-recently-used order,
+    /// with mutable references to the values.
+    ///
+    /// Accessing the cache through the iterator does _not_ affect the cache's LRU state.
+    /// Note that this method is not available for cache objects using `Meter` implementations.
+    /// other than `Count`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, 10);
+    /// cache.insert(2, 20);
+    /// cache.insert(3, 30);
+    ///
+    /// let mut n = 2;
+    ///
+    /// for (k, v) in cache.iter_mut() {
+    ///     assert_eq!(*k, n);
+    ///     assert_eq!(*v, n * 10);
+    ///     *v *= 10;
+    ///     n += 1;
+    /// }
+    ///
+    /// assert_eq!(n, 4);
+    /// assert_eq!(cache.get_mut(&2), Some(&mut 200));
+    /// assert_eq!(cache.get_mut(&3), Some(&mut 300));
+    /// ```
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        self.internal_iter_mut()
+    }
+}
+
+impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> LruCache<K, V, S, M> {
+    /// Creates an empty cache that can hold at most `capacity` as measured by `meter` with the
+    /// given hash builder.
+    pub fn with_meter_and_hasher(capacity: u64, meter: M, hash_builder: S) -> Self {
+        LruCache {
+            map: LinkedHashMap::with_hasher(hash_builder),
+            current_measure: Default::default(),
+            max_capacity: capacity,
+            meter,
+        }
+    }
+
+    /// Returns the maximum size of the key-value pairs the cache can hold, as measured by the
+    /// `Meter` used by the cache.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    /// let mut cache: LruCache<i32, &str> = LruCache::new(2);
+    /// assert_eq!(cache.capacity(), 2);
+    /// ```
+    pub fn capacity(&self) -> u64 {
+        self.max_capacity
+    }
+
+    /// Checks if the map contains the given key.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1);
+    ///
+    /// cache.insert(1, "a");
+    /// assert!(cache.contains_key(&1));
+    /// ```
+    pub fn contains_key<Q: Hash + Eq + ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+    {
+        self.map.contains_key(key)
+    }
+
+    pub fn get<Q: Hash + Eq + ?Sized>(&mut self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+    {
+        self.map.get_refresh(k).map(|v| v as &V)
+    }
+
+    /// Inserts a key-value pair into the cache. If the key already existed, the old value is
+    /// returned.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    /// assert_eq!(cache.get_mut(&1), Some(&mut "a"));
+    /// assert_eq!(cache.get_mut(&2), Some(&mut "b"));
+    /// ```
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        let new_size = self.meter.measure(&k, &v);
+        self.current_measure = self.meter.add(self.current_measure, new_size);
+        if let Some(old) = self.map.get(&k) {
+            self.current_measure = self.meter.sub(self.current_measure, self.meter.measure(&k, old));
+        }
+        let old_val = self.map.insert(k, v);
+        while self.size() > self.capacity() {
+            self.remove_lru();
+        }
+        old_val
+    }
+
+    /// Removes the given key from the cache and returns its corresponding value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(2, "a");
+    ///
+    /// assert_eq!(cache.remove(&1), None);
+    /// assert_eq!(cache.remove(&2), Some("a"));
+    /// assert_eq!(cache.remove(&2), None);
+    /// assert_eq!(cache.len(), 0);
+    /// ```
+    pub fn remove<Q: Hash + Eq + ?Sized>(&mut self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+    {
+        self.map.remove(k).map(|v| {
+            self.current_measure = self.meter.sub(self.current_measure, self.meter.measure(k, &v));
+            v
+        })
+    }
+
+    /// Sets the size of the key-value pairs the cache can hold, as measured by the `Meter` used by
+    /// the cache.
+    ///
+    /// Removes least-recently-used key-value pairs if necessary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    /// cache.insert(3, "c");
+    ///
+    /// assert_eq!(cache.get_mut(&1), None);
+    /// assert_eq!(cache.get_mut(&2), Some(&mut "b"));
+    /// assert_eq!(cache.get_mut(&3), Some(&mut "c"));
+    ///
+    /// cache.set_capacity(3);
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    ///
+    /// assert_eq!(cache.get_mut(&1), Some(&mut "a"));
+    /// assert_eq!(cache.get_mut(&2), Some(&mut "b"));
+    /// assert_eq!(cache.get_mut(&3), Some(&mut "c"));
+    ///
+    /// cache.set_capacity(1);
+    ///
+    /// assert_eq!(cache.get_mut(&1), None);
+    /// assert_eq!(cache.get_mut(&2), None);
+    /// assert_eq!(cache.get_mut(&3), Some(&mut "c"));
+    /// ```
+    pub fn set_capacity(&mut self, capacity: u64) {
+        while self.size() > capacity {
+            self.remove_lru();
+        }
+        self.max_capacity = capacity;
+    }
+
+    /// Removes and returns the least recently used key-value pair as a tuple.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    ///
+    /// assert_eq!(cache.remove_lru(), Some((1, "a")));
+    /// assert_eq!(cache.len(), 1);
+    /// ```
+    #[inline]
+    pub fn remove_lru(&mut self) -> Option<(K, V)> {
+        self.map.pop_front().map(|(k, v)| {
+            self.current_measure = self.meter.sub(self.current_measure, self.meter.measure(&k, &v));
+            (k, v)
+        })
+    }
+
+    /// Returns the number of key-value pairs in the cache.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns the size of all the key-value pairs in the cache, as measured by the `Meter` used
+    /// by the cache.
+    pub fn size(&self) -> u64 {
+        self.meter
+            .size(self.current_measure)
+            .unwrap_or_else(|| self.map.len() as u64)
+    }
+
+    /// Returns `true` if the cache contains no key-value pairs.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Removes all key-value pairs from the cache.
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.current_measure = Default::default();
+    }
+
+    /// Returns an iterator over the cache's key-value pairs in least- to most-recently-used order.
+    ///
+    /// Accessing the cache through the iterator does _not_ affect the cache's LRU state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, 10);
+    /// cache.insert(2, 20);
+    /// cache.insert(3, 30);
+    ///
+    /// let kvs: Vec<_> = cache.iter().collect();
+    /// assert_eq!(kvs, [(&2, &20), (&3, &30)]);
+    /// ```
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter(self.map.iter())
+    }
+
+    fn internal_iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IterMut(self.map.iter_mut())
+    }
+}
+
+impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> Extend<(K, V)> for LruCache<K, V, S, M> {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        for (k, v) in iter {
+            self.insert(k, v);
+        }
+    }
+}
+
+// impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, M: CountableMeter<K, V>> fmt::Debug
+//     for LruCache<K, V, S, M>
+// {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         f.debug_map().entries(self.iter().rev()).finish()
+//     }
+// }
+
+impl<K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> IntoIterator for LruCache<K, V, S, M> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> IntoIter<K, V> {
+        IntoIter(self.map.into_iter())
+    }
+}
+
+impl<'a, K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> IntoIterator for &'a LruCache<K, V, S, M> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
+impl<'a, K: Eq + Hash, V, S: BuildHasher, M: CountableMeter<K, V>> IntoIterator for &'a mut LruCache<K, V, S, M> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+    fn into_iter(self) -> IterMut<'a, K, V> {
+        self.internal_iter_mut()
+    }
+}
+
+/// An iterator over a cache's key-value pairs in least- to most-recently-used order.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use lru_cache::LruCache;
+///
+/// let mut cache = LruCache::new(2);
+///
+/// cache.insert(1, 10);
+/// cache.insert(2, 20);
+/// cache.insert(3, 30);
+///
+/// let mut n = 2;
+///
+/// for (k, v) in cache {
+///     assert_eq!(k, n);
+///     assert_eq!(v, n * 10);
+///     n += 1;
+/// }
+///
+/// assert_eq!(n, 4);
+/// ```
+#[derive(Clone)]
+pub struct IntoIter<K, V>(linked_hash_map::IntoIter<K, V>);
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<(K, V)> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
+    fn next_back(&mut self) -> Option<(K, V)> {
+        self.0.next_back()
+    }
+}
+
+impl<K, V> ExactSizeIterator for IntoIter<K, V> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// An iterator over a cache's key-value pairs in least- to most-recently-used order.
+///
+/// Accessing a cache through the iterator does _not_ affect the cache's LRU state.
+pub struct Iter<'a, K, V>(linked_hash_map::Iter<'a, K, V>);
+
+impl<'a, K, V> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Iter<'a, K, V> {
+        Iter(self.0.clone())
+    }
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<(&'a K, &'a V)> {
+        self.0.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
+    fn next_back(&mut self) -> Option<(&'a K, &'a V)> {
+        self.0.next_back()
+    }
+}
+
+impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// An iterator over a cache's key-value pairs in least- to most-recently-used order with mutable
+/// references to the values.
+///
+/// Accessing a cache through the iterator does _not_ affect the cache's LRU state.
+pub struct IterMut<'a, K, V>(linked_hash_map::IterMut<'a, K, V>);
+
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+    fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
+        self.0.next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
+    fn next_back(&mut self) -> Option<(&'a K, &'a mut V)> {
+        self.0.next_back()
+    }
+}
+
+impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LruCache, Meter};
+    use std::borrow::Borrow;
+
+    #[test]
+    fn test_put_and_get() {
+        let mut cache = LruCache::new(2);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        assert_eq!(cache.get_mut(&1), Some(&mut 10));
+        assert_eq!(cache.get_mut(&2), Some(&mut 20));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.size(), 2);
+    }
+
+    #[test]
+    fn test_put_update() {
+        let mut cache = LruCache::new(1);
+        cache.insert("1", 10);
+        cache.insert("1", 19);
+        assert_eq!(cache.get_mut("1"), Some(&mut 19));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_contains_key() {
+        let mut cache = LruCache::new(1);
+        cache.insert("1", 10);
+        assert!(cache.contains_key("1"));
+    }
+
+    #[test]
+    fn test_expire_lru() {
+        let mut cache = LruCache::new(2);
+        cache.insert("foo1", "bar1");
+        cache.insert("foo2", "bar2");
+        cache.insert("foo3", "bar3");
+        assert!(cache.get_mut("foo1").is_none());
+        cache.insert("foo2", "bar2update");
+        cache.insert("foo4", "bar4");
+        assert!(cache.get_mut("foo3").is_none());
+    }
+
+    #[test]
+    fn test_pop() {
+        let mut cache = LruCache::new(2);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        assert_eq!(cache.len(), 2);
+        let opt1 = cache.remove(&1);
+        assert!(opt1.is_some());
+        assert_eq!(opt1.unwrap(), 10);
+        assert!(cache.get_mut(&1).is_none());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_change_capacity() {
+        let mut cache = LruCache::new(2);
+        assert_eq!(cache.capacity(), 2);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.set_capacity(1);
+        assert!(cache.get_mut(&1).is_none());
+        assert_eq!(cache.capacity(), 1);
+    }
+
+    #[test]
+    fn test_debug() {
+        let mut cache = LruCache::new(3);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+        assert_eq!(format!("{:?}", cache), "{3: 30, 2: 20, 1: 10}");
+        cache.insert(2, 22);
+        assert_eq!(format!("{:?}", cache), "{2: 22, 3: 30, 1: 10}");
+        cache.insert(6, 60);
+        assert_eq!(format!("{:?}", cache), "{6: 60, 2: 22, 3: 30}");
+        cache.get_mut(&3);
+        assert_eq!(format!("{:?}", cache), "{3: 30, 6: 60, 2: 22}");
+        cache.set_capacity(2);
+        assert_eq!(format!("{:?}", cache), "{3: 30, 6: 60}");
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut cache = LruCache::new(3);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+        cache.insert(4, 40);
+        cache.insert(5, 50);
+        cache.remove(&3);
+        cache.remove(&4);
+        assert!(cache.get_mut(&3).is_none());
+        assert!(cache.get_mut(&4).is_none());
+        cache.insert(6, 60);
+        cache.insert(7, 70);
+        cache.insert(8, 80);
+        assert!(cache.get_mut(&5).is_none());
+        assert_eq!(cache.get_mut(&6), Some(&mut 60));
+        assert_eq!(cache.get_mut(&7), Some(&mut 70));
+        assert_eq!(cache.get_mut(&8), Some(&mut 80));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut cache = LruCache::new(2);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.clear();
+        assert!(cache.get_mut(&1).is_none());
+        assert!(cache.get_mut(&2).is_none());
+        assert_eq!(format!("{:?}", cache), "{}");
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut cache = LruCache::new(3);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
+        cache.insert(4, 40);
+        cache.insert(5, 50);
+        assert_eq!(cache.iter().collect::<Vec<_>>(), [(&3, &30), (&4, &40), (&5, &50)]);
+        assert_eq!(
+            cache.iter_mut().collect::<Vec<_>>(),
+            [(&3, &mut 30), (&4, &mut 40), (&5, &mut 50)]
+        );
+        assert_eq!(
+            cache.iter().rev().collect::<Vec<_>>(),
+            [(&5, &50), (&4, &40), (&3, &30)]
+        );
+        assert_eq!(
+            cache.iter_mut().rev().collect::<Vec<_>>(),
+            [(&5, &mut 50), (&4, &mut 40), (&3, &mut 30)]
+        );
+    }
+
+    struct VecLen;
+
+    impl<K, T> Meter<K, Vec<T>> for VecLen {
+        type Measure = usize;
+        fn measure<Q: ?Sized>(&self, _: &Q, v: &Vec<T>) -> usize
+        where
+            K: Borrow<Q>,
+        {
+            v.len()
+        }
+    }
+
+    #[test]
+    fn test_metered_cache() {
+        let mut cache = LruCache::with_meter(5, VecLen);
+        cache.insert("foo1", vec![1, 2]);
+        assert_eq!(cache.size(), 2);
+        cache.insert("foo2", vec![3, 4]);
+        cache.insert("foo3", vec![5, 6]);
+        assert_eq!(cache.size(), 4);
+        assert!(!cache.contains_key("foo1"));
+        cache.insert("foo2", vec![7, 8]);
+        cache.insert("foo4", vec![9, 10]);
+        assert_eq!(cache.size(), 4);
+        assert!(!cache.contains_key("foo3"));
+        assert_eq!(cache.get("foo2"), Some(&vec![7, 8]));
+    }
+
+    #[test]
+    fn test_metered_cache_reinsert_larger() {
+        let mut cache = LruCache::with_meter(5, VecLen);
+        cache.insert("foo1", vec![1, 2]);
+        cache.insert("foo2", vec![3, 4]);
+        assert_eq!(cache.size(), 4);
+        cache.insert("foo2", vec![5, 6, 7, 8]);
+        assert_eq!(cache.size(), 4);
+        assert!(!cache.contains_key("foo1"));
+    }
+
+    #[test]
+    fn test_metered_cache_oversize() {
+        let mut cache = LruCache::with_meter(2, VecLen);
+        cache.insert("foo1", vec![1, 2]);
+        cache.insert("foo2", vec![3, 4, 5, 6]);
+        assert_eq!(cache.size(), 0);
+        assert!(!cache.contains_key("foo1"));
+        assert!(!cache.contains_key("foo2"));
+    }
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/cache/lru_disk_cache.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/cache/lru_disk_cache.rs
@@ -1,0 +1,609 @@
+use fs::File;
+use fs_err as fs;
+use std::borrow::Borrow;
+use std::boxed::Box;
+use std::collections::hash_map::RandomState;
+use std::error::Error as StdError;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::hash::BuildHasher;
+use std::io;
+use std::io::prelude::*;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use tracing::{debug, error, warn};
+
+pub use super::lru_cache::{LruCache, Meter};
+use walkdir::WalkDir;
+
+#[derive(Debug)]
+struct FileSize;
+
+/// Given a tuple of (path, LruDiskCacheEntry), use the filesize for measurement.When key is path
+impl Meter<OsString, LruDiskCacheEntry> for FileSize {
+    type Measure = usize;
+    fn measure<Q: ?Sized>(&self, _: &Q, v: &LruDiskCacheEntry) -> usize
+    where
+        OsString: Borrow<Q>,
+    {
+        v.size as usize
+    }
+}
+
+/// Given a tuple of (file handle, filesize), use the filesize for measurement,when key is file handle.
+impl<K> Meter<K, u64> for FileSize {
+    type Measure = usize;
+    fn measure<Q: ?Sized>(&self, _: &Q, v: &u64) -> usize
+    where
+        K: Borrow<Q>,
+    {
+        *v as usize
+    }
+}
+
+#[derive(Debug)]
+pub struct LruDiskCacheEntry {
+    file: File,
+    size: u64,
+}
+
+/// An LRU cache of files on disk.
+#[derive(Debug)]
+pub struct LruDiskCache<S: BuildHasher = RandomState> {
+    lru: RwLock<LruCache<OsString, LruDiskCacheEntry, S, FileSize>>,
+    root: PathBuf,
+    pending_size: u64,
+}
+
+/// Return an iterator of `(path, size)` of files under `path` sorted by ascending last-modified
+/// time, such that the oldest modified file is returned first.
+fn get_all_files<P: AsRef<Path>>(path: P) -> Box<dyn Iterator<Item = (PathBuf, u64)>> {
+    let files: Vec<_> = WalkDir::new(path.as_ref())
+        .into_iter()
+        .filter_map(|e| {
+            e.ok().and_then(|f| {
+                // Only look at files
+                if f.file_type().is_file() {
+                    // Get the last-modified time, size, and the full path.
+                    f.metadata().ok().and_then(|m| {
+                        Some((f.path().to_owned(), m.len()))
+                        // m.modified()
+                        //     .ok()
+                        //     .map(|_| )
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+    // Sort by last-modified-time, so oldest file first.
+    // files.sort_by_key(|k| k.0);
+    Box::new(files.into_iter().map(|(path, size)| (path, size)))
+}
+
+impl<S: BuildHasher> Drop for LruDiskCache<S> {
+    fn drop(&mut self) {
+        let root = self.root.clone();
+        for (file, _) in get_all_files(root) {
+            fs::remove_file(file).unwrap();
+        }
+    }
+}
+
+/// Errors returned by this crate.
+#[derive(Debug)]
+pub enum Error {
+    /// The file was too large to fit in the cache.
+    FileTooLarge,
+    /// The file was not in the cache.
+    FileNotInCache,
+    /// An IO Error occurred.
+    Io(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::FileTooLarge => write!(f, "File too large"),
+            Error::FileNotInCache => write!(f, "File not in cache"),
+            // Error::Io(ref e) => write!(f, "{}", e),
+            Error::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::FileTooLarge => None,
+            Error::FileNotInCache => None,
+            // Error::Io(ref e) => Some(e),
+            Error::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Error {
+        Error::Io(e)
+    }
+}
+
+/// A convenience `Result` type
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Trait objects can't be bounded by more than one non-builtin trait.
+pub trait ReadSeek: Read + Seek + Send {}
+
+impl<T: Read + Seek + Send> ReadSeek for T {}
+
+enum AddFile<'a> {
+    _AbsPath(PathBuf),
+    RelPath(&'a OsStr),
+}
+
+impl LruDiskCache {
+    /// Create an `LruDiskCache` that stores files in `path`, limited to `size` bytes.
+    ///
+    /// Existing files in `path` will be stored with their last-modified time from the filesystem
+    /// used as the order for the recency of their use. Any files that are individually larger
+    /// than `size` bytes will be removed.
+    ///
+    /// The cache is not observant of changes to files under `path` from external sources, it
+    /// expects to have sole maintence of the contents.
+    pub fn new<T>(path: T, size: u64) -> Result<Self>
+    where
+        PathBuf: From<T>,
+    {
+        LruDiskCache {
+            lru: RwLock::new(LruCache::with_meter(size, FileSize)),
+            root: PathBuf::from(path),
+            pending_size: 0,
+        }
+        .init()
+    }
+
+    /// Return the current size of all the files in the cache.
+    pub fn size(&self) -> u64 {
+        self.lru.read().unwrap().size() + self.pending_size
+    }
+
+    /// Return the count of entries in the cache.
+    pub fn len(&self) -> usize {
+        self.lru.read().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.lru.read().unwrap().len() == 0
+    }
+
+    /// Return the maximum size of the cache.
+    pub fn capacity(&self) -> u64 {
+        self.lru.read().unwrap().capacity()
+    }
+
+    /// Return the path in which the cache is stored.
+    pub fn path(&self) -> &Path {
+        self.root.as_path()
+    }
+
+    /// Return the path that `key` would be stored at.
+    fn rel_to_abs_path<K: AsRef<Path>>(&self, rel_path: K) -> PathBuf {
+        self.root.join(rel_path)
+    }
+
+    /// Scan `self.root` for existing files and store them.
+    fn init(self) -> Result<Self> {
+        fs::create_dir_all(&self.root)?;
+        Ok(self)
+    }
+
+    /// Returns `true` if the disk cache can store a file of `size` bytes.
+    pub fn can_store(&self, size: u64) -> bool {
+        size <= self.lru.read().unwrap().capacity()
+    }
+
+    /// Make space for a file of `size` bytes.
+    fn make_space(&self, size: u64) -> Result<()> {
+        if !self.can_store(size) {
+            return Err(Error::FileTooLarge);
+        }
+        //TODO: ideally LRUCache::insert would give us back the entries it had to remove.
+        while self.size() + size > self.capacity() {
+            let (rel_path, _) = self
+                .lru
+                .write()
+                .unwrap()
+                .remove_lru()
+                .expect("Unexpectedly empty cache!");
+            let remove_path = self.rel_to_abs_path(rel_path);
+            //TODO: check that files are removable during `init`, so that this is only
+            // due to outside interference.
+            fs::remove_file(&remove_path).unwrap_or_else(|e| {
+                // Sometimes the file has already been removed
+                // this seems to happen when the max cache size has been reached
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    debug!(
+                        "Error removing file from cache as it was not found: `{:?}`",
+                        remove_path
+                    );
+                } else {
+                    panic!(
+                        "Error removing file from cache: `{:?}`: {}, {:?}",
+                        remove_path,
+                        e,
+                        e.kind()
+                    )
+                }
+            });
+        }
+        Ok(())
+    }
+
+    /// Add the file at `path` of size `size` to the cache.
+    fn add_file(&self, addfile_path: AddFile<'_>, size: u64) -> Result<()> {
+        let rel_path = match addfile_path {
+            AddFile::_AbsPath(ref p) => p.strip_prefix(&self.root).expect("Bad path?").as_os_str(),
+            AddFile::RelPath(p) => p,
+        };
+        self.make_space(size)?;
+        let path = self.rel_to_abs_path(rel_path);
+        // let file =  File::open(path);
+        let lru_disk_cache_entry = LruDiskCacheEntry {
+            file: File::open(path)?,
+            size,
+        };
+        self.lru
+            .write()
+            .unwrap()
+            .insert(rel_path.to_owned(), lru_disk_cache_entry);
+        Ok(())
+    }
+
+    /// Add a file by calling `by` with a `File` corresponding to the cache at path `key`.
+    fn insert_by<K: AsRef<OsStr>, F: FnOnce(&Path) -> io::Result<()>>(
+        &self,
+        key: K,
+        size: Option<u64>,
+        by: F,
+    ) -> Result<()> {
+        if let Some(size) = size {
+            if !self.can_store(size) {
+                return Err(Error::FileTooLarge);
+            }
+        }
+        let rel_path = key.as_ref();
+        let path = self.rel_to_abs_path(rel_path);
+        fs::create_dir_all(path.parent().expect("Bad path?"))?;
+        by(&path)?;
+        let size = match size {
+            Some(size) => size,
+            None => fs::metadata(path)?.len(),
+        };
+        self.add_file(AddFile::RelPath(rel_path), size).map_err(|e| {
+            error!("Failed to insert file `{}`: {}", rel_path.to_string_lossy(), e);
+            fs::remove_file(self.rel_to_abs_path(rel_path)).expect("Failed to remove file we just created!");
+            e
+        })
+    }
+
+    /// Add a file by calling `with` with the open `File` corresponding to the cache at path `key`.
+    pub fn insert_with<K: AsRef<OsStr>, F: FnOnce(File) -> io::Result<()>>(&self, key: K, with: F) -> Result<()> {
+        self.insert_by(key, None, |path| with(File::create(path)?))
+    }
+
+    /// Add a file with `bytes` as its contents to the cache at path `key`.
+    pub fn insert_bytes<K: AsRef<OsStr>>(&self, key: K, bytes: &[u8]) -> Result<()> {
+        self.insert_by(key, Some(bytes.len() as u64), |path| {
+            let mut f = File::create(path)?;
+            f.write_all(bytes)?;
+            Ok(())
+        })
+    }
+
+    /// Add an existing file at `path` to the cache at path `key`.
+    pub fn insert_file<K: AsRef<OsStr>, P: AsRef<OsStr>>(&self, key: K, path: P) -> Result<()> {
+        let size = fs::metadata(path.as_ref())?.len();
+        self.insert_by(key, Some(size), |new_path| {
+            fs::rename(path.as_ref(), new_path).or_else(|_| {
+                warn!("fs::rename failed, falling back to copy!");
+                fs::copy(path.as_ref(), new_path)?;
+                fs::remove_file(path.as_ref())
+                    .unwrap_or_else(|e| error!("Failed to remove original file in insert_file: {}", e));
+                Ok(())
+            })
+        })
+    }
+
+    /// Return `true` if a file with path `key` is in the cache.
+    pub fn contains_key<K: AsRef<OsStr>>(&self, key: K) -> bool {
+        self.lru.read().unwrap().contains_key(key.as_ref())
+    }
+
+    /// Get an opened `File` for `key`, if one exists and can be opened. Updates the LRU state
+    /// of the file if present. Avoid using this method if at all possible, prefer `.get`.
+    pub fn get_file<K: AsRef<OsStr>>(&self, key: K) -> Option<File> {
+        let rel_path = key.as_ref();
+        let mut guard = self.lru.write().unwrap();
+        let file = guard.get(rel_path);
+        Some(file?.file.try_clone().unwrap())
+    }
+
+    /// Get an opened readable and seekable handle to the file at `key`, if one exists and can
+    /// be opened. Updates the LRU state of the file if present.
+    pub fn get<K: AsRef<OsStr>>(&self, key: K) -> Option<Vec<u8>> {
+        match self.get_file(key).map(|f| Box::new(f) as Box<dyn ReadSeek>) {
+            Some(mut f) => {
+                let mut buf = vec![];
+                f.by_ref().read_to_end(&mut buf).unwrap();
+                // After reading, seek back to the beginning, so that the file can be read again.
+                f.seek(io::SeekFrom::Start(0)).unwrap();
+                return Some(buf);
+            }
+            None => None,
+        }
+    }
+
+    /// Remove the given key from the cache.
+    pub fn remove<K: AsRef<OsStr>>(&self, key: K) -> Result<()> {
+        match self.lru.write().unwrap().remove(key.as_ref()) {
+            Some(_) => {
+                let path = self.rel_to_abs_path(key.as_ref());
+                fs::remove_file(&path).map_err(|e| {
+                    error!("Error removing file from cache: `{:?}`: {}", path, e);
+                    Into::into(e)
+                })
+            }
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fs::{self, File};
+    use super::{Error, LruDiskCache};
+    use std::io::{self, Write};
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    struct TestFixture {
+        /// Temp directory.
+        pub tempdir: TempDir,
+    }
+
+    fn create_file<T: AsRef<Path>, F: FnOnce(File) -> io::Result<()>>(
+        dir: &Path,
+        path: T,
+        fill_contents: F,
+    ) -> io::Result<PathBuf> {
+        let b = dir.join(path);
+        fs::create_dir_all(b.parent().unwrap())?;
+        let f = fs::File::create(&b)?;
+        fill_contents(f)?;
+        b.canonicalize()
+    }
+
+    impl TestFixture {
+        pub fn new() -> TestFixture {
+            TestFixture {
+                tempdir: tempfile::Builder::new()
+                    .prefix("lru-disk-cache-test")
+                    .tempdir()
+                    .unwrap(),
+            }
+        }
+
+        pub fn tmp(&self) -> &Path {
+            self.tempdir.path()
+        }
+
+        pub fn create_file<T: AsRef<Path>>(&self, path: T, size: usize) -> PathBuf {
+            create_file(self.tempdir.path(), path, |mut f| f.write_all(&vec![0; size])).unwrap()
+        }
+    }
+
+    #[test]
+    fn test_empty_dir() {
+        let f = TestFixture::new();
+        LruDiskCache::new(f.tmp(), 1024).unwrap();
+    }
+
+    #[test]
+    fn test_missing_root() {
+        let f = TestFixture::new();
+        LruDiskCache::new(f.tmp().join("not-here"), 1024).unwrap();
+    }
+
+    #[test]
+    fn test_insert_bytes() {
+        let f = TestFixture::new();
+        let c = LruDiskCache::new(f.tmp(), 25).unwrap();
+        c.insert_bytes("a/b/c", &[0; 10]).unwrap();
+        assert!(c.contains_key("a/b/c"));
+        c.insert_bytes("a/b/d", &[0; 10]).unwrap();
+        assert_eq!(c.size(), 20);
+        // Adding this third file should put the cache above the limit.
+        c.insert_bytes("x/y/z", &[0; 10]).unwrap();
+        assert_eq!(c.size(), 20);
+        // The least-recently-used file should have been removed.
+        assert!(!c.contains_key("a/b/c"));
+        assert!(!f.tmp().join("a/b/c").exists());
+    }
+
+    #[test]
+    fn test_insert_bytes_exact() {
+        // Test that files adding up to exactly the size limit works.
+        let f = TestFixture::new();
+        let c = LruDiskCache::new(f.tmp(), 20).unwrap();
+        c.insert_bytes("file1", &[1; 10]).unwrap();
+        c.insert_bytes("file2", &[2; 10]).unwrap();
+        assert_eq!(c.size(), 20);
+        c.insert_bytes("file3", &[3; 10]).unwrap();
+        assert_eq!(c.size(), 20);
+        assert!(!c.contains_key("file1"));
+    }
+
+    #[test]
+    fn test_add_get_lru() {
+        let f = TestFixture::new();
+        {
+            let c = LruDiskCache::new(f.tmp(), 25).unwrap();
+            c.insert_bytes("file1", &[1; 10]).unwrap();
+            c.insert_bytes("file2", &[2; 10]).unwrap();
+            // Get the file to bump its LRU status.
+            c.get("file1").unwrap();
+
+            assert_eq!(c.get("file1").unwrap(), vec![1u8; 10]);
+            assert_eq!(c.get("file1").unwrap(), vec![1u8; 10]);
+            assert_eq!(c.get("file1").unwrap(), vec![1u8; 10]);
+            assert_eq!(c.get("file1").unwrap(), vec![1u8; 10]);
+            // Adding this third file should put the cache above the limit.
+            c.insert_bytes("file3", &[3; 10]).unwrap();
+            assert_eq!(c.size(), 20);
+            // The least-recently-used file should have been removed.
+            assert!(!c.contains_key("file2"));
+        }
+        // Get rid of the cache, to test that the LRU persists on-disk as mtimes.
+        // This is hacky, but mtime resolution on my mac with HFS+ is only 1 second, so we either
+        // need to have a 1 second sleep in the test (boo) or adjust the mtimes back a bit so
+        // that updating one file to the current time actually works to make it newer.
+        // set_mtime_back(f.tmp().join("file1"), 5);
+        // set_mtime_back(f.tmp().join("file3"), 5);
+        // {
+        //     let mut c = LruDiskCache::new(f.tmp(), 25).unwrap();
+        //     // Bump file1 again.
+        //     c.get("file1").unwrap();
+        // }
+        // // Now check that the on-disk mtimes were updated and used.
+        // {
+        //     let mut c = LruDiskCache::new(f.tmp(), 25).unwrap();
+        //     assert!(c.contains_key("file1"));
+        //     assert!(c.contains_key("file3"));
+        //     assert_eq!(c.size(), 20);
+        //     // Add another file to bump out the least-recently-used.
+        //     c.insert_bytes("file4", &[4; 10]).unwrap();
+        //     assert_eq!(c.size(), 20);
+        //     assert!(!c.contains_key("file3"));
+        //     assert!(c.contains_key("file1"));
+        // }
+    }
+
+    #[test]
+    fn test_insert_bytes_too_large() {
+        let f = TestFixture::new();
+        let c = LruDiskCache::new(f.tmp(), 1).unwrap();
+        match c.insert_bytes("a/b/c", &[0; 2]) {
+            Err(Error::FileTooLarge) => {}
+            x => panic!("Unexpected result: {:?}", x),
+        }
+    }
+
+    #[test]
+    fn test_insert_file() {
+        let f = TestFixture::new();
+        let p1 = f.create_file("file1", 10);
+        let p2 = f.create_file("file2", 10);
+        let p3 = f.create_file("file3", 10);
+        let c = LruDiskCache::new(f.tmp().join("cache"), 25).unwrap();
+        c.insert_file("file1", &p1).unwrap();
+        assert_eq!(c.len(), 1);
+        c.insert_file("file2", &p2).unwrap();
+        assert_eq!(c.len(), 2);
+        // Get the file to bump its LRU status.
+        assert_eq!(c.get("file1").unwrap(), vec![0u8; 10]);
+        // Adding this third file should put the cache above the limit.
+        c.insert_file("file3", &p3).unwrap();
+        assert_eq!(c.len(), 2);
+        assert_eq!(c.size(), 20);
+        // The least-recently-used file should have been removed.
+        assert!(!c.contains_key("file2"));
+        assert!(!p1.exists());
+        assert!(!p2.exists());
+        assert!(!p3.exists());
+    }
+
+    #[test]
+    fn test_remove() {
+        let f = TestFixture::new();
+        let p1 = f.create_file("file1", 10);
+        let p2 = f.create_file("file2", 10);
+        let p3 = f.create_file("file3", 10);
+        let c = LruDiskCache::new(f.tmp().join("cache"), 25).unwrap();
+        c.insert_file("file1", &p1).unwrap();
+        c.insert_file("file2", &p2).unwrap();
+        c.remove("file1").unwrap();
+        c.insert_file("file3", &p3).unwrap();
+        assert_eq!(c.len(), 2);
+        assert_eq!(c.size(), 20);
+
+        // file1 should have been removed.
+        assert!(!c.contains_key("file1"));
+        assert!(!f.tmp().join("cache").join("file1").exists());
+        assert!(f.tmp().join("cache").join("file2").exists());
+        assert!(f.tmp().join("cache").join("file3").exists());
+        assert!(!p1.exists());
+        assert!(!p2.exists());
+        assert!(!p3.exists());
+
+        let p4 = f.create_file("file1", 10);
+        c.insert_file("file1", &p4).unwrap();
+        assert_eq!(c.len(), 2);
+        // file2 should have been removed.
+        assert!(c.contains_key("file1"));
+        assert!(!c.contains_key("file2"));
+        assert!(!f.tmp().join("cache").join("file2").exists());
+        assert!(!p4.exists());
+    }
+
+    fn get_zipf() -> usize {
+        use rand::distributions::Distribution;
+
+        let mut rng = rand::thread_rng();
+        let zipf = zipf::ZipfDistribution::new(1024 * 1024, 1.03).unwrap();
+        zipf.sample(&mut rng)
+    }
+
+    /// page = 1 * 1024 hit percent 0.78448486328125
+    /// test lru disk cache hit percent from zipf
+    /// disk cache size: 64 * 1024 * 1024
+    /// page count: 1024 * 1024
+    /// page size: 4 * 1024
+    /// page hit percent: 0.78448486328125
+    /// page miss percent: 0.21551513671875
+    #[test]
+    fn test_lru_disk_cache_from_zipf() {
+        let f = TestFixture::new();
+        let mut cache_hit = 0;
+        let mut cache_miss = 0;
+        // let mut vec_p: Vec<PathBuf>;
+        {
+            let c = LruDiskCache::new(f.tmp(), 1024 * 1024 * 64).unwrap();
+            let file_prefix = "file";
+            for i in 0..(1024 * 16) as usize {
+                let file_name = format!("{}{}", file_prefix, i);
+                c.insert_bytes(file_name, &[i as u8; 1024 * 4]).unwrap();
+            }
+
+            for _ in 0..1024 * 1024 * 12 {
+                let object_id = get_zipf();
+                let file_name = format!("{}{}", file_prefix, object_id);
+                match c.get(&file_name) {
+                    Some(_) => cache_hit += 1,
+                    None => {
+                        cache_miss += 1;
+                        c.insert_bytes(file_name, &[object_id as u8; 1024 * 4]).unwrap();
+                    } // _ => panic!("Unexpected result"),
+                }
+            }
+            println!("cache hit: {}, cache miss: {}", cache_hit, cache_miss)
+        }
+    }
+
+    // #[test]
+    // fn test_create_file_performance() {
+    //     let file_handle = File::open("file1").unwrap();
+    //     file_handle.metadata().unwrap().len();
+    // }
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/mod.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/mod.rs
@@ -1,0 +1,135 @@
+pub mod cache;
+pub mod paging;
+pub mod read_through;
+pub mod stats;
+
+// We reuse `object_store` Error and Result to make this crate work well
+// with the rest of object_store implementations.
+pub use object_store::{Error, Result};
+
+pub use read_through::ReadThroughCache;
+
+
+#[cfg(test)]
+pub mod test {
+    use datafusion::error::DataFusionError;
+    // use datafusion::execution::context::SessionState;
+    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion::prelude::*;
+    use futures::StreamExt;
+    use object_store::aws;
+    use std::sync::Arc;
+    use std::time::Instant;
+    use url::Url;
+
+    // "--warehouse-prefix",
+    // "s3://lakesoul-bucket/flight-test",
+    // "--endpoint",
+    // "http://localhost:9000",
+    // "--s3-bucket",
+    // "lakesoul-test-bucket",
+    // "--s3-access-key",
+    // "minioadmin1",
+    // "--s3-secret-key",
+    // "minioadmin1",
+    // (flavor = "multi_thread", worker_threads = 10)
+    #[tokio::test]
+    async fn test_local_s3_cache() {
+        let config = SessionConfig::new()
+            .with_target_partitions(1) 
+            .set_bool("datafusion.execution.coalesce_batches", false)
+            .set_u64("datafusion.execution.batch_size", 4096)
+            .with_parquet_pruning(true)
+            .with_repartition_joins(false);
+        let runtime = Arc::new(RuntimeEnvBuilder::new().build().unwrap());
+        let state = SessionStateBuilder::new().with_config(config).with_runtime_env(runtime).build();
+        let ctx = SessionContext::new_with_state(state);
+
+        let s3 = aws::AmazonS3Builder::new()
+            .with_bucket_name("lakesoul-test-bucket")
+            .with_access_key_id("minioadmin1")
+            .with_secret_access_key("minioadmin1")
+            .with_allow_http(true)
+            .with_endpoint("http://localhost:9000")
+            .with_region("cn-southwest-2")
+            .build()
+            .unwrap();
+        let url = Url::parse("s3://lakesoul-test-bucket/")
+            .map_err(|e| DataFusionError::External(Box::new(e)))
+            .unwrap();
+
+        // 注册 S3 缓存存储
+        // let cache = Arc::new(DiskCache::new( 1 * 1024 * 1024 * 1024,4 * 1024 * 1024));
+        // let cache_s3_store = Arc::new(ReadThroughCache::new(Arc::new(s3), cache));
+        // ctx.runtime_env().register_object_store(&url, cache_s3_store);
+
+        ctx.runtime_env().register_object_store(&url, Arc::new(s3));
+
+        {
+            let df = ctx
+                .read_parquet(
+                    "s3://lakesoul-test-bucket/base-0.parquet",
+                    ParquetReadOptions::default(),
+                )
+                .await
+                .unwrap();
+
+            let start = Instant::now();
+            // let df = df.select_columns(&["uuid", "hostname", "requests"])?;
+
+            let mut stream = df.execute_stream().await.unwrap();
+            let mut total_rows = 0usize;
+            while let Some(batch) = stream.next().await {
+                    let batch = batch.unwrap();
+                    total_rows += batch.num_rows();
+            }
+
+            let duration = start.elapsed();
+            println!(
+                "Total rows {}, Time elapsed in expensive_function() is: {:?}",
+                total_rows, duration
+            );
+        }
+
+        {
+            let df = ctx
+                .read_parquet(
+                    "s3://lakesoul-test-bucket/base-0.parquet",
+                    ParquetReadOptions::default(),
+                )
+                .await
+                .unwrap();
+
+            let start = Instant::now();
+            // let df = df.select_columns(&["uuid", "hostname", "requests"])?;
+
+            let mut stream = df.execute_stream().await.unwrap();
+            let mut total_rows = 0usize;
+            while let Some(batch) = stream.next().await {
+                    let batch = batch.unwrap();
+                    total_rows += batch.num_rows();
+            }
+
+            let duration = start.elapsed();
+
+            println!(
+                "Total rows {}, Time elapsed in expensive_function() is: {:?}",
+                total_rows, duration
+            );
+        }
+    }
+
+    #[test]
+    fn test_env(){
+        use std::env;
+        // for (key, value) in env::vars_os() {
+        //     println!("{:?}: {:?}", key, value);
+        // }
+        let lakesoul_cache_env_value = env::var("LAKESOUL_CACHE").unwrap();
+        println!("LAKESOUL_CACHE: {:?}", lakesoul_cache_env_value);
+        let _lakesoul_cache_size_env_value = env::var("LAKESOUL_CACHE_SIZE").unwrap().parse::<usize>().unwrap();
+        // println!("LAKESOUL_CACHE_SIZE: {}", lakesoul_cache_size_env_value);
+    }
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/mod.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/mod.rs
@@ -9,7 +9,6 @@ pub use object_store::{Error, Result};
 
 pub use read_through::ReadThroughCache;
 
-
 #[cfg(test)]
 pub mod test {
     use datafusion::error::DataFusionError;
@@ -38,13 +37,16 @@ pub mod test {
     #[tokio::test]
     async fn test_local_s3_cache() {
         let config = SessionConfig::new()
-            .with_target_partitions(1) 
+            .with_target_partitions(1)
             .set_bool("datafusion.execution.coalesce_batches", false)
             .set_u64("datafusion.execution.batch_size", 4096)
             .with_parquet_pruning(true)
             .with_repartition_joins(false);
         let runtime = Arc::new(RuntimeEnvBuilder::new().build().unwrap());
-        let state = SessionStateBuilder::new().with_config(config).with_runtime_env(runtime).build();
+        let state = SessionStateBuilder::new()
+            .with_config(config)
+            .with_runtime_env(runtime)
+            .build();
         let ctx = SessionContext::new_with_state(state);
 
         let s3 = aws::AmazonS3Builder::new()
@@ -82,8 +84,8 @@ pub mod test {
             let mut stream = df.execute_stream().await.unwrap();
             let mut total_rows = 0usize;
             while let Some(batch) = stream.next().await {
-                    let batch = batch.unwrap();
-                    total_rows += batch.num_rows();
+                let batch = batch.unwrap();
+                total_rows += batch.num_rows();
             }
 
             let duration = start.elapsed();
@@ -108,8 +110,8 @@ pub mod test {
             let mut stream = df.execute_stream().await.unwrap();
             let mut total_rows = 0usize;
             while let Some(batch) = stream.next().await {
-                    let batch = batch.unwrap();
-                    total_rows += batch.num_rows();
+                let batch = batch.unwrap();
+                total_rows += batch.num_rows();
             }
 
             let duration = start.elapsed();
@@ -122,7 +124,7 @@ pub mod test {
     }
 
     #[test]
-    fn test_env(){
+    fn test_env() {
         use std::env;
         // for (key, value) in env::vars_os() {
         //     println!("{:?}: {:?}", key, value);

--- a/rust/lakesoul-io/src/lakesoul_cache/paging.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/paging.rs
@@ -1,0 +1,89 @@
+//! Trait for page cache
+//!
+//! A Page cache caches data in fixed-size pages.
+
+use std::fmt::Debug;
+use std::future::Future;
+use std::ops::Range;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use object_store::path::Path;
+use object_store::ObjectMeta;
+
+use object_store::Result;
+
+/// [PageCache] trait.
+///
+/// Caching fixed-size pages. Each page has a unique ID.
+#[async_trait]
+pub trait PageCache: Sync + Send + Debug + 'static {
+    /// The size of each page.
+    fn page_size(&self) -> usize;
+
+    /// Cache capacity, in number of pages.
+    fn capacity(&self) -> usize;
+
+    /// Total used cache size in bytes.
+    fn size(&self) -> usize;
+
+    /// Read data of a page.
+    ///
+    /// # Parameters
+    /// - `location`: the path of the object.
+    /// - `page_id`: the ID of the page.
+    ///
+    /// # Returns
+    /// - `Ok(Some(Bytes))` if the page exists and the data was read successfully.
+    /// - `Ok(None)` if the page does not exist.
+    /// - `Err(Error)` if an error occurred.
+    async fn get_with(
+        &self,
+        location: &Path,
+        page_id: u32,
+        loader: impl Future<Output = Result<Bytes>> + Send,
+    ) -> Result<Bytes>;
+
+    /// Read cached page.
+    ///
+    /// # Parameters
+    /// - `location`: the path of the object.
+    /// - `page_id`: the ID of the page.
+    ///
+    /// # Returns
+    /// - `Ok(Some(Bytes))` if the page exists and the data was read successfully.
+    /// - `Ok(None)` if the cached page does not exist.
+    /// - `Err(Error)` if an error occurred.
+    async fn get(&self, location: &Path, page_id: u32) -> Result<Option<Bytes>>;
+
+    /// Get range of data in the page.
+    ///
+    /// # Parameters
+    /// - `id`: The ID of the page.
+    /// - `range`: The range of data to read from the page. The range must be within the page size.
+    ///
+    /// # Returns
+    /// See [Self::get_with()].
+    async fn get_range_with(
+        &self,
+        location: &Path,
+        page_id: u32,
+        range: Range<usize>,
+        loader: impl Future<Output = Result<Bytes>> + Send,
+    ) -> Result<Bytes>;
+
+    async fn get_range(&self, location: &Path, page_id: u32, range: Range<usize>) -> Result<Option<Bytes>>;
+
+    /// Get metadata of the object.
+    async fn head(
+        &self,
+        location: &Path,
+        loader: impl Future<Output = Result<ObjectMeta>> + Send,
+    ) -> Result<ObjectMeta>;
+
+    /// Put data into the page.
+    async fn put(&self, location: &Path, page_id: u32, data: Bytes) -> Result<()>;
+
+    /// Remove all pages belong to the location.
+    async fn invalidate(&self, location: &Path) -> Result<()>;
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/read_through.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/read_through.rs
@@ -1,0 +1,223 @@
+use std::ops::Range;
+use std::sync::Arc;
+// use crate::cache;
+
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use futures::{stream, stream::BoxStream, StreamExt, TryStreamExt};
+use object_store::{
+    path::Path, Attributes, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
+};
+
+use crate::lakesoul_cache::{paging::PageCache, stats::CacheStats};
+use object_store::Result;
+
+/// Read-through Page Cache.
+#[derive(Debug, Clone)]
+pub struct ReadThroughCache<C: PageCache> {
+    inner: Arc<dyn ObjectStore>,
+    cache: Arc<C>,
+
+    parallelism: usize,
+
+    stats: Arc<dyn CacheStats>,
+}
+
+impl<C: PageCache> std::fmt::Display for ReadThroughCache<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ReadThroughCache(inner={}, cache={:?})", self.inner, self.cache)
+    }
+}
+
+impl<C: PageCache> ReadThroughCache<C> {
+    pub fn new(inner: Arc<dyn ObjectStore>, cache: Arc<C>) -> Self {
+        Self::new_with_stats(
+            inner,
+            cache,
+            Arc::new(crate::lakesoul_cache::stats::AtomicIntCacheStats::new()),
+        )
+    }
+
+    pub fn new_with_stats(inner: Arc<dyn ObjectStore>, cache: Arc<C>, stats: Arc<dyn CacheStats>) -> Self {
+        Self {
+            inner,
+            cache,
+            parallelism: num_cpus::get(),
+            stats,
+        }
+    }
+
+    async fn invalidate(&self, location: &Path) -> Result<()> {
+        self.cache.invalidate(location).await
+    }
+}
+
+/// Get a range of bytes from the DiskCache
+async fn get_range<C: PageCache>(
+    store: Arc<dyn ObjectStore>,
+    cache: Arc<C>,
+    stats: Arc<dyn CacheStats>,
+    location: &Path,
+    range: Range<usize>,
+    parallelism: usize,
+) -> Result<Bytes> {
+    let page_size = cache.page_size();
+    let start = (range.start / page_size) * page_size;
+    let meta = cache.head(location, store.head(location)).await?;
+
+    let pages = stream::iter((start..range.end).step_by(page_size))
+        .map(|offset| {
+            let page_cache = cache.clone();
+            let page_id = offset / page_size;
+            let intersection = std::cmp::max(offset, range.start)..std::cmp::min(offset + page_size, range.end);
+            let range_in_page = intersection.start - offset..intersection.end - offset;
+            let page_end = std::cmp::min(offset + page_size, meta.size);
+            let store = store.clone();
+            let stats = stats.clone();
+
+            stats.inc_total_reads();
+
+            async move {
+                // Actual range in the file.
+                page_cache
+                    .get_range_with(location, page_id as u32, range_in_page, async {
+                        stats.inc_total_misses();
+                        store.get_range(location, offset..page_end).await
+                    })
+                    .await
+            }
+        })
+        .buffered(parallelism)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    if pages.len() == 1 {
+        return Ok(pages.into_iter().next().unwrap());
+    }
+
+    // stick all bytes together.
+    let mut buf = BytesMut::with_capacity(range.len());
+    for page in pages {
+        buf.extend_from_slice(&page);
+    }
+    Ok(buf.into())
+}
+
+/// A ReadThroughCache is an ObjectStore that wraps another ObjectStore and
+/// caches the results of get_range calls.
+#[async_trait]
+impl<C: PageCache> ObjectStore for ReadThroughCache<C> {
+    async fn put_opts(&self, location: &Path, payload: PutPayload, options: PutOptions) -> Result<PutResult> {
+        self.cache.invalidate(location).await?;
+
+        self.inner.put_opts(location, payload, options).await
+    }
+
+    async fn put_multipart_opts(&self, location: &Path, _opts: PutMultipartOpts) -> Result<Box<dyn MultipartUpload>> {
+        self.invalidate(location).await?;
+
+        self.inner.put_multipart_opts(location, _opts).await
+    }
+
+    async fn get_opts(&self, _location: &Path, _options: GetOptions) -> Result<GetResult> {
+        todo!()
+    }
+
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        let meta = self.head(location).await?;
+        let file_size = meta.size;
+        let page_size = self.cache.page_size();
+        let inner = self.inner.clone();
+        let cache = self.cache.clone();
+        let stats = self.stats.clone();
+        let location = location.clone();
+        let parallelism = self.parallelism;
+
+        // TODO: This might yield too many small reads.
+        let s = stream::iter((0..file_size).step_by(page_size))
+            .map(move |offset| {
+                let loc = location.clone();
+                let store = inner.clone();
+                let stats = stats.clone();
+                let c = cache.clone();
+                let page_size = cache.page_size();
+
+                async move { get_range(store, c, stats, &loc, offset..offset + page_size, parallelism).await }
+            })
+            .buffered(self.parallelism)
+            .boxed();
+
+        let payload = GetResultPayload::Stream(s);
+        Ok(GetResult {
+            payload,
+            meta: meta.clone(),
+            range: 0..meta.size,
+            attributes: Attributes::default(),
+        })
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+        get_range(
+            self.inner.clone(),
+            self.cache.clone(),
+            self.stats.clone(),
+            location,
+            range,
+            self.parallelism,
+        )
+        .await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.cache.head(location, self.inner.head(location)).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.invalidate(location).await?;
+        self.inner.delete(location).await
+    }
+
+    fn list(&'_ self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.invalidate(to).await?;
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.invalidate(to).await?;
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lakesoul_cache::cache::DiskCache;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_end_of_file() {
+        let cache = Arc::new(DiskCache::new(64 * 1024 * 1024, 16 * 1024));
+        let store = Arc::new(object_store::local::LocalFileSystem::new());
+        let cache = Arc::new(ReadThroughCache::new(store, cache));
+
+        let temp_file = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        {
+            std::fs::write(temp_file.to_str().unwrap(), "this is a long text").unwrap();
+        }
+        let path = Path::from(temp_file.to_str().unwrap());
+        let meta = cache.head(&path).await.unwrap();
+
+        let data = cache.get_range(&path, 10..meta.size).await.unwrap();
+        assert_eq!(data.len(), 9);
+        assert_eq!(data, "long text".as_bytes());
+    }
+}

--- a/rust/lakesoul-io/src/lakesoul_cache/stats.rs
+++ b/rust/lakesoul-io/src/lakesoul_cache/stats.rs
@@ -1,0 +1,127 @@
+//! Cache stats
+
+use std::{
+    fmt::Debug,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use tracing::warn;
+
+/// Cache read stats.
+pub trait CacheReadStats: Sync + Send + Debug {
+    /// Total reads on the cache.
+    fn total_reads(&self) -> u64;
+
+    /// Total hits
+    fn total_misses(&self) -> u64;
+
+    /// Increase total reads by 1.
+    fn inc_total_reads(&self);
+
+    /// Increase total hits by 1.
+    fn inc_total_misses(&self);
+}
+
+/// Cache capacity stats.
+pub trait CacheCapacityStats {
+    fn max_capacity(&self) -> u64;
+
+    fn set_max_capacity(&self, val: u64);
+
+    fn usage(&self) -> u64;
+
+    fn set_usage(&self, val: u64);
+
+    fn inc_usage(&self, val: u64);
+
+    fn sub_usage(&self, val: u64);
+}
+
+pub trait CacheStats: CacheCapacityStats + CacheReadStats {}
+
+#[derive(Debug)]
+pub struct AtomicIntCacheStats {
+    total_reads: AtomicU64,
+    total_misses: AtomicU64,
+    max_capacity: AtomicU64,
+    capacity_usage: AtomicU64,
+}
+
+/// Atomic integer cache stats.
+impl AtomicIntCacheStats {
+    pub fn new() -> Self {
+        Self {
+            total_misses: AtomicU64::new(0),
+            total_reads: AtomicU64::new(0),
+            max_capacity: AtomicU64::new(0),
+            capacity_usage: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Default for AtomicIntCacheStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CacheReadStats for AtomicIntCacheStats {
+    fn total_misses(&self) -> u64 {
+        self.total_misses.load(Ordering::Acquire)
+    }
+
+    fn total_reads(&self) -> u64 {
+        self.total_reads.load(Ordering::Acquire)
+    }
+
+    fn inc_total_reads(&self) {
+        self.total_reads.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn inc_total_misses(&self) {
+        self.total_misses.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl CacheCapacityStats for AtomicIntCacheStats {
+    fn max_capacity(&self) -> u64 {
+        self.max_capacity.load(Ordering::Acquire)
+    }
+
+    fn set_max_capacity(&self, val: u64) {
+        self.max_capacity.store(val, Ordering::Relaxed);
+    }
+
+    fn usage(&self) -> u64 {
+        self.capacity_usage.load(Ordering::Acquire)
+    }
+
+    fn set_usage(&self, val: u64) {
+        self.capacity_usage.store(val, Ordering::Relaxed);
+    }
+
+    fn inc_usage(&self, val: u64) {
+        self.capacity_usage.fetch_add(val, Ordering::Relaxed);
+    }
+
+    fn sub_usage(&self, val: u64) {
+        let res = self
+            .capacity_usage
+            .fetch_update(Ordering::Acquire, Ordering::Relaxed, |current| {
+                if current < val {
+                    warn!(
+                        "cannot decrement cache usage. current val = {:?} and decrement = {:?}",
+                        current, val
+                    );
+                    None
+                } else {
+                    Some(current - val)
+                }
+            });
+        if let Err(e) = res {
+            warn!("error setting cache usage: {:?}", e);
+        }
+    }
+}
+
+impl CacheStats for AtomicIntCacheStats {}

--- a/rust/lakesoul-io/src/lakesoul_io_config.rs
+++ b/rust/lakesoul-io/src/lakesoul_io_config.rs
@@ -703,18 +703,14 @@ pub fn register_s3_object_store(url: &Url, config: &LakeSoulIOConfig, runtime: &
         s3_store_builder = s3_store_builder.with_endpoint(ep);
     }
     let s3_store = Arc::new(s3_store_builder.build().map_err(|e| DataFusionError::ObjectStore(e))?);
-    
+
     // add cache if env LAKESOUL_CACHE is set
     if std::env::var("LAKESOUL_CACHE").is_ok() {
         // cache size in bytes, default to 1GB
         let cache_size = {
             match std::env::var("LAKESOUL_CACHE_SIZE") {
-                Ok(s) => {
-                    s.parse::<usize>().unwrap_or(1024) * 1024 * 1024
-                }
-                _ => {
-                    1024 * 1024 * 1024
-                }
+                Ok(s) => s.parse::<usize>().unwrap_or(1024) * 1024 * 1024,
+                _ => 1024 * 1024 * 1024,
             }
         };
         let cache = Arc::new(DiskCache::new(cache_size, 4 * 1024));

--- a/rust/lakesoul-io/src/lib.rs
+++ b/rust/lakesoul-io/src/lib.rs
@@ -67,6 +67,7 @@ pub mod datasource;
 pub mod filter;
 pub mod hash_utils;
 pub mod helpers;
+pub mod lakesoul_cache;
 pub mod lakesoul_io_config;
 pub mod lakesoul_reader;
 pub mod lakesoul_writer;


### PR DESCRIPTION
Add disk cache for s3 object store, use the LRU algorithm to cache S3 object store on the local disk to accelerate read efficiency.