### PR TITLE
[Rust]: replace rust version number with stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "stable"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Change-Id: I6a6a6964c135d998b53ce6b7df5eef0278094637