### PR TITLE
[Rust] Fix Vortex catalog scans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,8 @@ cargo -q test --package lakesoul-io
 cargo -q test --package lakesoul-metadata
 
 # Lint
+cargo fmt --all --check
 cargo clippy
-cargo fmt --check
 
 # Build the C FFI libraries (used by Java JNI)
 cargo -q build --release -p lakesoul-io-c

--- a/rust/lakesoul-console/src/exec.rs
+++ b/rust/lakesoul-console/src/exec.rs
@@ -4,7 +4,7 @@
 
 use std::io::BufRead;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 use std::{fs::File, io::BufReader};
 
@@ -231,6 +231,14 @@ async fn exec(
     Ok((row_count, res, schema))
 }
 
+fn history_path() -> &'static str {
+    static HISTORY_PATH: OnceLock<String> = OnceLock::new();
+    HISTORY_PATH.get_or_init(|| {
+        std::env::var("LAKESOUL_CONSOLE_HISTORY_PATH")
+            .unwrap_or(String::from("/tmp/console.history"))
+    })
+}
+
 #[tracing::instrument(skip(ctx, printer))]
 async fn exec_and_print(
     ctx: &SessionContext,
@@ -246,7 +254,7 @@ async fn exec_and_print(
 
 pub async fn exec_from_repl(ctx: &SessionContext, printer: &Printer) -> Result<()> {
     let mut rl = rustyline::DefaultEditor::new()?;
-    rl.load_history("console.history").ok();
+    rl.load_history(history_path()).ok();
     loop {
         match rl.readline("lakesoul >> ") {
             Ok(line) => {
@@ -277,9 +285,6 @@ pub async fn exec_from_repl(ctx: &SessionContext, printer: &Printer) -> Result<(
         }
     }
 
-    let histry_path = std::env::var("LAKESOUL_CONSOLE_HISTORY_PATH")
-        .unwrap_or(String::from("/tmp/console.history"));
-
-    rl.save_history(&histry_path)?;
+    rl.save_history(history_path())?;
     Ok(())
 }

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -16,7 +16,7 @@ use arrow::error::ArrowError;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::catalog::memory::DataSourceExec;
-use datafusion::common::{Constraint, Statistics, ToDFSchema, project_schema};
+use datafusion::common::{Constraint, DFSchema, Statistics, ToDFSchema, project_schema};
 use datafusion::datasource::TableProvider;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
@@ -36,8 +36,10 @@ use datafusion::logical_expr::{
 use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, create_physical_expr};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
+use datafusion::prelude::{ident, lit};
 use datafusion::scalar::ScalarValue;
 use datafusion::{
     execution::{context::SessionState, object_store::ObjectStoreUrl},
@@ -547,39 +549,98 @@ impl LakeSoulTableProvider {
         let mut groups: Vec<FormatScanGroup> = vec![];
 
         for partitioned_files in partitioned_file_lists {
-            let mut files_by_format: Vec<(PhysicalFormat, Vec<PartitionedFile>)> = vec![];
+            let mut current_format = None;
+            let mut current_files = vec![];
 
             for file in partitioned_files {
                 let physical_format = format_registry
                     .physical_format_for_path(file.object_meta.location.as_ref())?;
 
-                if let Some((_, files)) = files_by_format
-                    .iter_mut()
-                    .find(|(format, _)| *format == physical_format)
-                {
-                    files.push(file);
-                } else {
-                    files_by_format.push((physical_format, vec![file]));
+                match current_format {
+                    Some(format) if format == physical_format => {
+                        current_files.push(file);
+                    }
+                    Some(format) => {
+                        Self::push_format_scan_group(
+                            &mut groups,
+                            object_store_url.clone(),
+                            format,
+                            std::mem::take(&mut current_files),
+                        );
+                        current_format = Some(physical_format);
+                        current_files.push(file);
+                    }
+                    None => {
+                        current_format = Some(physical_format);
+                        current_files.push(file);
+                    }
                 }
             }
 
-            for (physical_format, files) in files_by_format {
-                if let Some(group) = groups.iter_mut().find(|group| {
-                    group.object_store_url == object_store_url
-                        && group.physical_format == physical_format
-                }) {
-                    group.partitioned_file_lists.push(files);
-                } else {
-                    groups.push(FormatScanGroup {
-                        object_store_url: object_store_url.clone(),
-                        physical_format,
-                        partitioned_file_lists: vec![files],
-                    });
-                }
+            if let Some(physical_format) = current_format {
+                Self::push_format_scan_group(
+                    &mut groups,
+                    object_store_url.clone(),
+                    physical_format,
+                    current_files,
+                );
             }
         }
 
         Ok(groups)
+    }
+
+    fn push_format_scan_group(
+        groups: &mut Vec<FormatScanGroup>,
+        object_store_url: ObjectStoreUrl,
+        physical_format: PhysicalFormat,
+        files: Vec<PartitionedFile>,
+    ) {
+        if files.is_empty() {
+            return;
+        }
+
+        if let Some(group) = groups.last_mut().filter(|group| {
+            group.object_store_url == object_store_url
+                && group.physical_format == physical_format
+        }) {
+            group.partitioned_file_lists.push(files);
+        } else {
+            groups.push(FormatScanGroup {
+                object_store_url,
+                physical_format,
+                partitioned_file_lists: vec![files],
+            });
+        }
+    }
+
+    fn classify_filter_pushdown(
+        pushdown_filters: bool,
+        primary_keys: &[String],
+        filters: &[&Expr],
+    ) -> DFResult<Vec<TableProviderFilterPushDown>> {
+        if !pushdown_filters {
+            return Ok(vec![
+                TableProviderFilterPushDown::Unsupported;
+                filters.len()
+            ]);
+        }
+
+        if primary_keys.is_empty() {
+            return Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()]);
+        }
+
+        filters
+            .iter()
+            .map(|f| {
+                let cols = f.column_refs();
+                if cols.iter().all(|col| primary_keys.contains(&col.name)) {
+                    Ok(TableProviderFilterPushDown::Inexact)
+                } else {
+                    Ok(TableProviderFilterPushDown::Unsupported)
+                }
+            })
+            .collect()
     }
 }
 
@@ -804,10 +865,25 @@ impl TableProvider for LakeSoulTableProvider {
             partitioned_execs.push(merge_exec);
         }
 
-        let merge_exec = if partitioned_execs.len() > 1 {
+        let exec = if partitioned_execs.len() > 1 {
             UnionExec::try_new(partitioned_execs)?
         } else {
             partitioned_execs.first().unwrap().clone()
+        };
+
+        let cdc_column = self.io_config.cdc_column();
+        let exec = if !cdc_column.is_empty() {
+            let dfschema = DFSchema::try_from(exec.schema().as_ref().clone())?;
+            let cdc_filter = ident(cdc_column).not_eq(lit("delete"));
+            let expr = create_physical_expr(
+                &cdc_filter,
+                &dfschema,
+                session_state.execution_props(),
+            )?;
+
+            Arc::new(FilterExec::try_new(expr, exec)?) as Arc<dyn ExecutionPlan>
+        } else {
+            exec
         };
 
         if Self::needs_output_projection(&scan_schema, &merged_schema) {
@@ -816,17 +892,14 @@ impl TableProvider for LakeSoulTableProvider {
                 projection_expr.push((
                     datafusion::physical_expr::expressions::col(
                         field.name(),
-                        &merged_schema,
+                        exec.schema().as_ref(),
                     )?,
                     field.name().clone(),
                 ));
             }
-            Ok(Arc::new(ProjectionExec::try_new(
-                projection_expr,
-                merge_exec,
-            )?))
+            Ok(Arc::new(ProjectionExec::try_new(projection_expr, exec)?))
         } else {
-            Ok(merge_exec)
+            Ok(exec)
         }
     }
 
@@ -835,32 +908,7 @@ impl TableProvider for LakeSoulTableProvider {
         filters: &[&Expr],
     ) -> DFResult<Vec<TableProviderFilterPushDown>> {
         info!("supports_filters_pushdown: {:?}", filters);
-
-        if !self.pushdown_filters {
-            return Ok(vec![
-                TableProviderFilterPushDown::Unsupported;
-                filters.len()
-            ]);
-        }
-
-        if self.primary_keys.is_empty() {
-            // TODO session config -> io_config / config.parquet support filter pushdown
-            Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
-        } else {
-            // O(nml), n = number of filters, m = number of primary keys, l = number of columns
-            filters
-                .iter()
-                .map(|f| {
-                    let cols = f.column_refs();
-                    if cols.iter().all(|col| self.primary_keys.contains(&col.name)) {
-                        // use primary key
-                        Ok(TableProviderFilterPushDown::Inexact)
-                    } else {
-                        Ok(TableProviderFilterPushDown::Unsupported)
-                    }
-                })
-                .collect()
-        }
+        Self::classify_filter_pushdown(self.pushdown_filters, &self.primary_keys, filters)
     }
 
     #[instrument(skip(self, state))]
@@ -955,6 +1003,49 @@ mod tests {
     }
 
     #[test]
+    fn filter_pushdown_classification_never_returns_exact() {
+        let id_filter = Expr::Column(datafusion::common::Column::from_name("id"));
+        let score_filter = Expr::Column(datafusion::common::Column::from_name("score"));
+        let filters = vec![&id_filter, &score_filter];
+
+        let disabled =
+            LakeSoulTableProvider::classify_filter_pushdown(false, &[], &filters)
+                .unwrap();
+        assert_eq!(
+            disabled,
+            vec![
+                TableProviderFilterPushDown::Unsupported,
+                TableProviderFilterPushDown::Unsupported,
+            ]
+        );
+
+        let without_primary_keys =
+            LakeSoulTableProvider::classify_filter_pushdown(true, &[], &filters).unwrap();
+        assert_eq!(
+            without_primary_keys,
+            vec![
+                TableProviderFilterPushDown::Inexact,
+                TableProviderFilterPushDown::Inexact,
+            ]
+        );
+
+        let primary_keys = vec![String::from("id")];
+        let with_primary_keys = LakeSoulTableProvider::classify_filter_pushdown(
+            true,
+            &primary_keys,
+            &filters,
+        )
+        .unwrap();
+        assert_eq!(
+            with_primary_keys,
+            vec![
+                TableProviderFilterPushDown::Inexact,
+                TableProviderFilterPushDown::Unsupported,
+            ]
+        );
+    }
+
+    #[test]
     fn format_scan_groups_split_mixed_physical_formats() {
         let registry =
             LakeSoulFormatRegistry::new(LakeSoulIOConfig::default(), false).unwrap();
@@ -987,6 +1078,35 @@ mod tests {
                 .partitioned_file_lists[0]
                 .len(),
             1
+        );
+    }
+
+    #[test]
+    fn format_scan_groups_preserve_non_adjacent_format_order() {
+        let registry =
+            LakeSoulFormatRegistry::new(LakeSoulIOConfig::default(), false).unwrap();
+        let object_store_url = ObjectStoreUrl::parse("file://").unwrap();
+        let groups = LakeSoulTableProvider::format_scan_groups(
+            &registry,
+            object_store_url,
+            vec![vec![
+                PartitionedFile::from(object_meta("part-000.parquet")),
+                PartitionedFile::from(object_meta("part-001.vortex")),
+                PartitionedFile::from(object_meta("part-002.parquet")),
+            ]],
+        )
+        .unwrap();
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].physical_format, PhysicalFormat::Parquet);
+        assert_eq!(groups[1].physical_format, PhysicalFormat::Vortex);
+        assert_eq!(groups[2].physical_format, PhysicalFormat::Parquet);
+        assert_eq!(
+            groups[2].partitioned_file_lists[0][0]
+                .object_meta
+                .location
+                .as_ref(),
+            "part-002.parquet"
         );
     }
 }

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -5,7 +5,7 @@
 //! The [`datafusion::datasource::TableProvider`] implementation for LakeSoul table.
 
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -660,6 +660,30 @@ impl LakeSoulTableProvider {
     ) -> SchemaRef {
         merged_schema
     }
+
+    fn merged_schema_with_input_nullability(
+        merged_schema: SchemaRef,
+        inputs: &[Arc<dyn ExecutionPlan>],
+    ) -> SchemaRef {
+        Arc::new(Schema::new(
+            merged_schema
+                .fields()
+                .iter()
+                .map(|field| {
+                    Field::new(
+                        field.name(),
+                        field.data_type().clone(),
+                        field.is_nullable()
+                            | inputs.iter().any(|input| {
+                                input.schema().column_with_name(field.name()).is_none_or(
+                                    |(_, input_field)| input_field.is_nullable(),
+                                )
+                            }),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        ))
+    }
 }
 
 #[async_trait]
@@ -826,7 +850,7 @@ impl TableProvider for LakeSoulTableProvider {
                 (Vec<Arc<dyn ExecutionPlan>>, Vec<String>),
             ),
         > = HashMap::new();
-        let mut column_nullable = HashSet::<String>::new();
+        let mut all_inputs = Vec::<Arc<dyn ExecutionPlan>>::new();
 
         for config in flatten_configs {
             let (partition_desc, partition_values) =
@@ -836,11 +860,7 @@ impl TableProvider for LakeSoulTableProvider {
             let partition_values = Arc::new(partition_values);
             let file_path = config.file_groups[0].files()[0].path().to_string();
             let input = DataSourceExec::from_data_source(config);
-            for field in input.schema().fields() {
-                if field.is_nullable() {
-                    column_nullable.insert(field.name().clone());
-                }
-            }
+            all_inputs.push(input.clone());
 
             if let Some((_, inputs)) = inputs_map.get_mut(&partition_desc) {
                 inputs.0.push(input);
@@ -853,19 +873,8 @@ impl TableProvider for LakeSoulTableProvider {
             }
         }
 
-        let merged_schema = Arc::new(Schema::new(
-            merged_schema
-                .fields()
-                .iter()
-                .map(|field| {
-                    Field::new(
-                        field.name(),
-                        field.data_type().clone(),
-                        field.is_nullable() | column_nullable.contains(field.name()),
-                    )
-                })
-                .collect::<Vec<_>>(),
-        ));
+        let merged_schema =
+            Self::merged_schema_with_input_nullability(merged_schema, &all_inputs);
 
         let mut partitioned_execs = Vec::new();
         for (_, (partition_values, (inputs, file_paths))) in inputs_map {
@@ -1157,5 +1166,63 @@ mod tests {
 
         assert!(exec.schema().field_with_name("op").is_ok());
         assert_eq!(exec.schema(), merged_schema);
+    }
+
+    #[test]
+    fn partitioned_merge_execs_share_nullable_schema_after_evolution() {
+        let merged_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("evolved", DataType::Utf8, false),
+        ]));
+        let old_file_schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let new_file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("evolved", DataType::Utf8, false),
+        ]));
+        let old_input =
+            Arc::new(EmptyExec::new(old_file_schema)) as Arc<dyn ExecutionPlan>;
+        let new_input =
+            Arc::new(EmptyExec::new(new_file_schema)) as Arc<dyn ExecutionPlan>;
+        let merged_schema = LakeSoulTableProvider::merged_schema_with_input_nullability(
+            merged_schema,
+            &[old_input.clone(), new_input.clone()],
+        );
+
+        let old_partition = Arc::new(
+            lakesoul_io::physical_plan::MergeParquetExec::new_with_inputs(
+                merged_schema.clone(),
+                vec![old_input],
+                LakeSoulIOConfig::default(),
+                Arc::new(HashMap::new()),
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+        let new_partition = Arc::new(
+            lakesoul_io::physical_plan::MergeParquetExec::new_with_inputs(
+                merged_schema,
+                vec![new_input],
+                LakeSoulIOConfig::default(),
+                Arc::new(HashMap::new()),
+            )
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
+
+        assert!(
+            old_partition
+                .schema()
+                .field_with_name("evolved")
+                .unwrap()
+                .is_nullable()
+        );
+        assert!(
+            new_partition
+                .schema()
+                .field_with_name("evolved")
+                .unwrap()
+                .is_nullable(),
+            "all partition execs must advertise the globally nullable schema"
+        );
+        assert_eq!(old_partition.schema(), new_partition.schema());
     }
 }

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -5,7 +5,7 @@
 //! The [`datafusion::datasource::TableProvider`] implementation for LakeSoul table.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -15,6 +15,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaBuilder, SchemaRef};
 use arrow::error::ArrowError;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
+use datafusion::catalog::memory::DataSourceExec;
 use datafusion::common::{Constraint, Statistics, ToDFSchema, project_schema};
 use datafusion::datasource::TableProvider;
 use datafusion::datasource::file_format::FileFormat;
@@ -36,6 +37,7 @@ use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, create_physical_e
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::union::UnionExec;
 use datafusion::scalar::ScalarValue;
 use datafusion::{
     execution::{context::SessionState, object_store::ObjectStoreUrl},
@@ -50,7 +52,9 @@ use lakesoul_io::file_format::{
     LakeSoulFormatRegistry, PhysicalFormat, compute_project_column_indices,
     flatten_file_scan_config_for_format,
 };
-use lakesoul_io::helpers::listing_table_from_lakesoul_io_config;
+use lakesoul_io::helpers::{
+    listing_table_from_lakesoul_io_config, partition_desc_from_file_scan_config,
+};
 use lakesoul_metadata::MetaDataClientRef;
 use lakesoul_metadata::utils::qualify_path;
 use proto::proto::entity::TableInfo;
@@ -736,14 +740,75 @@ impl TableProvider for LakeSoulTableProvider {
             flatten_configs.extend(group_flatten_configs);
         }
 
-        let merge_exec = Arc::new(
-            lakesoul_io::physical_plan::MergeParquetExec::new(
-                merged_schema.clone(),
-                flatten_configs,
-                self.io_config.clone(),
-            )
-            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?,
-        );
+        let mut inputs_map: HashMap<
+            String,
+            (
+                Arc<HashMap<String, String>>,
+                (Vec<Arc<dyn ExecutionPlan>>, Vec<String>),
+            ),
+        > = HashMap::new();
+        let mut column_nullable = HashSet::<String>::new();
+
+        for config in flatten_configs {
+            let (partition_desc, partition_values) =
+                partition_desc_from_file_scan_config(&config).map_err(|report| {
+                    DataFusionError::External(report.into_boxed_error())
+                })?;
+            let partition_values = Arc::new(partition_values);
+            let file_path = config.file_groups[0].files()[0].path().to_string();
+            let input = DataSourceExec::from_data_source(config);
+            for field in input.schema().fields() {
+                if field.is_nullable() {
+                    column_nullable.insert(field.name().clone());
+                }
+            }
+
+            if let Some((_, inputs)) = inputs_map.get_mut(&partition_desc) {
+                inputs.0.push(input);
+                inputs.1.push(file_path);
+            } else {
+                inputs_map.insert(
+                    partition_desc,
+                    (partition_values, (vec![input], vec![file_path])),
+                );
+            }
+        }
+
+        let merged_schema = Arc::new(Schema::new(
+            merged_schema
+                .fields()
+                .iter()
+                .map(|field| {
+                    Field::new(
+                        field.name(),
+                        field.data_type().clone(),
+                        field.is_nullable() | column_nullable.contains(field.name()),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        ));
+
+        let mut partitioned_execs = Vec::new();
+        for (_, (partition_values, (inputs, file_paths))) in inputs_map {
+            let mut io_config = self.io_config.clone();
+            io_config.set_files(file_paths);
+            let merge_exec = Arc::new(
+                lakesoul_io::physical_plan::MergeParquetExec::new_with_inputs(
+                    merged_schema.clone(),
+                    inputs,
+                    io_config,
+                    partition_values,
+                )
+                .map_err(|report| DataFusionError::External(report.into_boxed_error()))?,
+            ) as Arc<dyn ExecutionPlan>;
+            partitioned_execs.push(merge_exec);
+        }
+
+        let merge_exec = if partitioned_execs.len() > 1 {
+            UnionExec::try_new(partitioned_execs)?
+        } else {
+            partitioned_execs.first().unwrap().clone()
+        };
 
         if Self::needs_output_projection(&scan_schema, &merged_schema) {
             let mut projection_expr = vec![];

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -642,6 +642,17 @@ impl LakeSoulTableProvider {
             })
             .collect()
     }
+
+    fn build_partitioned_exec(
+        partitioned_execs: Vec<Arc<dyn ExecutionPlan>>,
+        empty_schema: SchemaRef,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        match partitioned_execs.len() {
+            0 => Ok(Arc::new(EmptyExec::new(empty_schema))),
+            1 => Ok(partitioned_execs[0].clone()),
+            _ => UnionExec::try_new(partitioned_execs),
+        }
+    }
 }
 
 #[async_trait]
@@ -865,11 +876,7 @@ impl TableProvider for LakeSoulTableProvider {
             partitioned_execs.push(merge_exec);
         }
 
-        let exec = if partitioned_execs.len() > 1 {
-            UnionExec::try_new(partitioned_execs)?
-        } else {
-            partitioned_execs.first().unwrap().clone()
-        };
+        let exec = Self::build_partitioned_exec(partitioned_execs, scan_schema.clone())?;
 
         let cdc_column = self.io_config.cdc_column();
         let exec = if !cdc_column.is_empty() {
@@ -1108,5 +1115,16 @@ mod tests {
                 .as_ref(),
             "part-002.parquet"
         );
+    }
+
+    #[test]
+    fn build_partitioned_exec_returns_empty_exec_for_empty_partitions() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, true)]));
+
+        let exec = LakeSoulTableProvider::build_partitioned_exec(vec![], schema.clone())
+            .unwrap();
+
+        assert!(exec.as_any().is::<EmptyExec>());
+        assert_eq!(exec.schema(), schema);
     }
 }

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -653,6 +653,13 @@ impl LakeSoulTableProvider {
             _ => UnionExec::try_new(partitioned_execs),
         }
     }
+
+    fn empty_partitioned_exec_schema(
+        _scan_schema: SchemaRef,
+        merged_schema: SchemaRef,
+    ) -> SchemaRef {
+        merged_schema
+    }
 }
 
 #[async_trait]
@@ -876,7 +883,11 @@ impl TableProvider for LakeSoulTableProvider {
             partitioned_execs.push(merge_exec);
         }
 
-        let exec = Self::build_partitioned_exec(partitioned_execs, scan_schema.clone())?;
+        let empty_exec_schema = Self::empty_partitioned_exec_schema(
+            scan_schema.clone(),
+            merged_schema.clone(),
+        );
+        let exec = Self::build_partitioned_exec(partitioned_execs, empty_exec_schema)?;
 
         let cdc_column = self.io_config.cdc_column();
         let exec = if !cdc_column.is_empty() {
@@ -1126,5 +1137,25 @@ mod tests {
 
         assert!(exec.as_any().is::<EmptyExec>());
         assert_eq!(exec.schema(), schema);
+    }
+
+    #[test]
+    fn build_empty_partitioned_exec_preserves_cdc_column_for_filtering() {
+        let scan_schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, true)]));
+        let merged_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("op", DataType::Utf8, true),
+        ]));
+
+        let empty_schema = LakeSoulTableProvider::empty_partitioned_exec_schema(
+            scan_schema,
+            merged_schema.clone(),
+        );
+        let exec =
+            LakeSoulTableProvider::build_partitioned_exec(vec![], empty_schema).unwrap();
+
+        assert!(exec.schema().field_with_name("op").is_ok());
+        assert_eq!(exec.schema(), merged_schema);
     }
 }

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -5,6 +5,7 @@
 //! The [`datafusion::datasource::TableProvider`] implementation for LakeSoul table.
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::env;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -17,7 +18,6 @@ use datafusion::catalog::Session;
 use datafusion::common::{Constraint, Statistics, ToDFSchema, project_schema};
 use datafusion::datasource::TableProvider;
 use datafusion::datasource::file_format::FileFormat;
-use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{ListingOptions, ListingTableUrl, PartitionedFile};
 use datafusion::datasource::physical_plan::{
@@ -35,13 +35,21 @@ use datafusion::logical_expr::{
 use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr, create_physical_expr};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::scalar::ScalarValue;
-use datafusion::{execution::context::SessionState, logical_expr::Expr};
+use datafusion::{
+    execution::{context::SessionState, object_store::ObjectStoreUrl},
+    logical_expr::Expr,
+};
 use datafusion_datasource::file_sink_config::FileOutputMode;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 
 use lakesoul_io::config::LakeSoulIOConfig;
+use lakesoul_io::file_format::{
+    LakeSoulFormatRegistry, PhysicalFormat, compute_project_column_indices,
+    flatten_file_scan_config_for_format,
+};
 use lakesoul_io::helpers::listing_table_from_lakesoul_io_config;
 use lakesoul_metadata::MetaDataClientRef;
 use lakesoul_metadata::utils::qualify_path;
@@ -55,12 +63,19 @@ use crate::catalog::{
     LakeSoulTableProperty, format_table_info_partitions, parse_table_info_partitions,
 };
 use crate::lakesoul_table::helpers::{
-    case_fold_column_name, case_fold_table_name, listing_partition_info,
+    case_fold_column_name, case_fold_table_name,
+    create_io_config_builder_from_table_info, listing_partition_info,
     parse_partitions_for_partition_desc, prune_partitions,
 };
 use crate::serialize::arrow_java::{ArrowJavaSchema, schema_from_metadata_str};
 
 use super::file_format::LakeSoulMetaDataParquetFormat;
+
+struct FormatScanGroup {
+    object_store_url: ObjectStoreUrl,
+    physical_format: PhysicalFormat,
+    partitioned_file_lists: Vec<Vec<PartitionedFile>>,
+}
 
 /// Reads data from LakeSoul
 ///
@@ -87,8 +102,25 @@ pub struct LakeSoulTableProvider {
     pub(crate) primary_keys: Vec<String>,
     pub(crate) range_partitions: Vec<String>,
     pub(crate) pushdown_filters: bool,
+    pub(crate) io_config: LakeSoulIOConfig,
+    pub(crate) format_registry: Arc<LakeSoulFormatRegistry>,
 }
 impl LakeSoulTableProvider {
+    fn needs_output_projection(
+        target_schema: &SchemaRef,
+        merged_schema: &SchemaRef,
+    ) -> bool {
+        if target_schema.fields().len() != merged_schema.fields().len() {
+            return true;
+        }
+
+        target_schema
+            .fields()
+            .iter()
+            .zip(merged_schema.fields().iter())
+            .any(|(target, merged)| target.name() != merged.name())
+    }
+
     fn split_schemas(
         logical_schema: SchemaRef,
         range_partitions: &[String],
@@ -162,17 +194,20 @@ impl LakeSoulTableProvider {
         let (file_schema, scan_schema) =
             Self::split_schemas(logical_schema.clone(), &range_partitions)?;
 
+        let parquet_force_view_types = session_state
+            .config_options()
+            .execution
+            .parquet
+            .schema_force_view_types;
+        let format_registry = Arc::new(LakeSoulFormatRegistry::new(
+            lakesoul_io_config.clone(),
+            parquet_force_view_types,
+        )?);
         let file_format: Arc<dyn FileFormat> = Arc::new(
             LakeSoulMetaDataParquetFormat::new(
                 client.clone(),
                 Arc::new(
-                    ParquetFormat::new().with_force_view_types(
-                        session_state
-                            .config_options()
-                            .execution
-                            .parquet
-                            .schema_force_view_types,
-                    ),
+                    ParquetFormat::new().with_force_view_types(parquet_force_view_types),
                 ),
                 table_info.clone(),
                 lakesoul_io_config.clone(),
@@ -201,6 +236,8 @@ impl LakeSoulTableProvider {
             primary_keys: hash_partitions,
             range_partitions,
             pushdown_filters: lakesoul_io_config.file_filter_pushdown(),
+            io_config: lakesoul_io_config,
+            format_registry,
         })
     }
 
@@ -298,6 +335,20 @@ impl LakeSoulTableProvider {
             },
             domain: "public".to_string(),
         });
+        let io_config = create_io_config_builder_from_table_info(
+            table_info.clone(),
+            cmd.options.clone(),
+            HashMap::new(),
+        )?
+        .build();
+        let format_registry = Arc::new(LakeSoulFormatRegistry::new(
+            io_config.clone(),
+            session_state
+                .config_options()
+                .execution
+                .parquet
+                .schema_force_view_types,
+        )?);
         Ok(Self {
             listing_options: LakeSoulMetaDataParquetFormat::default_listing_options()
                 .await?,
@@ -314,6 +365,8 @@ impl LakeSoulTableProvider {
                 .execution
                 .parquet
                 .pushdown_filters, // TODO after more format
+            io_config,
+            format_registry,
         })
     }
 
@@ -481,6 +534,49 @@ impl LakeSoulTableProvider {
 
         Ok((file_groups, Statistics::new_unknown(self.schema().deref())))
     }
+
+    fn format_scan_groups(
+        format_registry: &LakeSoulFormatRegistry,
+        object_store_url: ObjectStoreUrl,
+        partitioned_file_lists: Vec<Vec<PartitionedFile>>,
+    ) -> Result<Vec<FormatScanGroup>> {
+        let mut groups: Vec<FormatScanGroup> = vec![];
+
+        for partitioned_files in partitioned_file_lists {
+            let mut files_by_format: Vec<(PhysicalFormat, Vec<PartitionedFile>)> = vec![];
+
+            for file in partitioned_files {
+                let physical_format = format_registry
+                    .physical_format_for_path(file.object_meta.location.as_ref())?;
+
+                if let Some((_, files)) = files_by_format
+                    .iter_mut()
+                    .find(|(format, _)| *format == physical_format)
+                {
+                    files.push(file);
+                } else {
+                    files_by_format.push((physical_format, vec![file]));
+                }
+            }
+
+            for (physical_format, files) in files_by_format {
+                if let Some(group) = groups.iter_mut().find(|group| {
+                    group.object_store_url == object_store_url
+                        && group.physical_format == physical_format
+                }) {
+                    group.partitioned_file_lists.push(files);
+                } else {
+                    groups.push(FormatScanGroup {
+                        object_store_url: object_store_url.clone(),
+                        physical_format,
+                        partitioned_file_lists: vec![files],
+                    });
+                }
+            }
+        }
+
+        Ok(groups)
+    }
 }
 
 #[async_trait]
@@ -536,7 +632,6 @@ impl TableProvider for LakeSoulTableProvider {
         let table_schema =
             TableSchema::new(self.file_schema.clone(), table_partition_cols.clone());
         let statistics = Arc::new(statistics);
-        let file_source = self.options().format.file_source(table_schema);
 
         let object_store_url = if let Some(url) = self.table_paths().first() {
             url.object_store()
@@ -544,60 +639,130 @@ impl TableProvider for LakeSoulTableProvider {
             return Ok(Arc::new(EmptyExec::new(Arc::new(Schema::empty()))));
         };
 
-        let mut scan_config =
-            FileScanConfigBuilder::new(object_store_url, file_source)
-                .with_file_groups(
-                    partitioned_file_lists
-                        .into_iter()
-                        .map(|files| {
-                            FileGroup::new(files).with_statistics(statistics.clone())
-                        })
-                        .collect(),
-                )
-                .with_statistics((*statistics).clone())
-                .with_projection_indices(self.scan_projection(projection)?)?
-                .with_limit(limit)
-                .with_output_ordering(self.try_create_output_ordering().map_err(
-                    |report| DataFusionError::External(report.into_boxed_error()),
-                )?)
-                .with_file_compression_type(FileCompressionType::ZSTD) // TODO CONF;
-                .build();
+        let projection_indices = self.scan_projection(projection)?;
+        let scan_schema =
+            project_schema(table_schema.table_schema(), projection_indices.as_ref())?;
+        let merged_projection = compute_project_column_indices(
+            table_schema.table_schema().clone(),
+            scan_schema.clone(),
+            self.primary_keys.as_slice(),
+            &self.io_config.cdc_column(),
+        );
+        let merged_schema =
+            project_schema(table_schema.table_schema(), merged_projection.as_ref())?;
 
-        if let Some(expr) = conjunction(filters.to_vec()) {
+        let filter = if let Some(expr) = conjunction(filters.to_vec()) {
             // NOTE: Use the table schema (NOT file schema) here because `expr` may contain references to partition columns.
             let table_df_schema = self.schema().as_ref().clone().to_dfschema()?;
-            let filter = create_physical_expr(
+            Some(create_physical_expr(
                 &expr,
                 &table_df_schema,
                 session_state.execution_props(),
-            )?;
+            )?)
+        } else {
+            None
+        };
 
-            let res = scan_config
-                .try_pushdown_filters(vec![filter], session_state.config_options())?;
-            match res.updated_node {
-                Some(sc) => {
-                    debug!("apply new scan config");
-                    debug!("filters: {:?}", res.filters);
-                    scan_config = sc
-                        .as_any()
-                        .downcast_ref::<FileScanConfig>()
-                        .ok_or(DataFusionError::Internal(
-                            "Failed to downcast FileScanConfig".into(),
-                        ))?
-                        .clone();
-                }
-                None => {
-                    debug!("no updated node")
+        let partition_schema = Arc::new(Schema::new(table_partition_cols));
+        let output_ordering = self
+            .try_create_output_ordering()
+            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?;
+        let format_groups = Self::format_scan_groups(
+            self.format_registry.as_ref(),
+            object_store_url,
+            partitioned_file_lists,
+        )
+        .map_err(|report| DataFusionError::External(report.into_boxed_error()))?;
+
+        let mut flatten_configs = vec![];
+        for group in format_groups {
+            let file_format = self.format_registry.file_format(group.physical_format);
+            let file_source = file_format.file_source(table_schema.clone());
+            let mut scan_config =
+                FileScanConfigBuilder::new(group.object_store_url, file_source)
+                    .with_file_groups(
+                        group
+                            .partitioned_file_lists
+                            .into_iter()
+                            .map(|files| {
+                                FileGroup::new(files).with_statistics(statistics.clone())
+                            })
+                            .collect(),
+                    )
+                    .with_statistics((*statistics).clone())
+                    .with_projection_indices(projection_indices.clone())?
+                    .with_limit(limit)
+                    .with_output_ordering(output_ordering.clone())
+                    .with_file_compression_type(
+                        self.format_registry
+                            .file_compression_type(group.physical_format),
+                    )
+                    .build();
+
+            if let Some(filter) = &filter {
+                let res = scan_config.try_pushdown_filters(
+                    vec![filter.clone()],
+                    session_state.config_options(),
+                )?;
+                match res.updated_node {
+                    Some(sc) => {
+                        debug!("apply new scan config");
+                        debug!("filters: {:?}", res.filters);
+                        scan_config = sc
+                            .as_any()
+                            .downcast_ref::<FileScanConfig>()
+                            .ok_or(DataFusionError::Internal(
+                                "Failed to downcast FileScanConfig".into(),
+                            ))?
+                            .clone();
+                    }
+                    None => {
+                        debug!("no updated node")
+                    }
                 }
             }
+
+            let group_flatten_configs = flatten_file_scan_config_for_format(
+                session_state,
+                file_format,
+                scan_config,
+                self.primary_keys.as_slice(),
+                &self.io_config.cdc_column(),
+                partition_schema.clone(),
+                scan_schema.clone(),
+            )
+            .await
+            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?;
+            flatten_configs.extend(group_flatten_configs);
         }
-        // create the execution plan
-        let plan = self
-            .options()
-            .format
-            .create_physical_plan(session_state, scan_config)
-            .await?;
-        Ok(plan)
+
+        let merge_exec = Arc::new(
+            lakesoul_io::physical_plan::MergeParquetExec::new(
+                merged_schema.clone(),
+                flatten_configs,
+                self.io_config.clone(),
+            )
+            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?,
+        );
+
+        if Self::needs_output_projection(&scan_schema, &merged_schema) {
+            let mut projection_expr = vec![];
+            for field in scan_schema.fields() {
+                projection_expr.push((
+                    datafusion::physical_expr::expressions::col(
+                        field.name(),
+                        &merged_schema,
+                    )?,
+                    field.name().clone(),
+                ));
+            }
+            Ok(Arc::new(ProjectionExec::try_new(
+                projection_expr,
+                merge_exec,
+            )?))
+        } else {
+            Ok(merge_exec)
+        }
     }
 
     fn supports_filters_pushdown(
@@ -669,6 +834,18 @@ impl TableProvider for LakeSoulTableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
+    use object_store::{ObjectMeta, path::Path};
+
+    fn object_meta(location: &str) -> ObjectMeta {
+        ObjectMeta {
+            location: Path::from(location),
+            last_modified: chrono::Utc.timestamp_nanos(0),
+            size: 100,
+            e_tag: None,
+            version: None,
+        }
+    }
 
     #[test]
     fn logical_projection_maps_to_scan_schema_order() {
@@ -693,5 +870,58 @@ mod tests {
         .unwrap();
 
         assert_eq!(mapped, Some(vec![0, 2, 1]));
+    }
+
+    #[test]
+    fn output_projection_is_needed_when_schema_order_differs() {
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("c1", DataType::Int32, true),
+            Field::new("c2", DataType::Int32, true),
+        ]));
+        let merged_schema = Arc::new(Schema::new(vec![
+            Field::new("c2", DataType::Int32, true),
+            Field::new("c1", DataType::Int32, true),
+        ]));
+
+        assert!(LakeSoulTableProvider::needs_output_projection(
+            &target_schema,
+            &merged_schema
+        ));
+    }
+
+    #[test]
+    fn format_scan_groups_split_mixed_physical_formats() {
+        let registry =
+            LakeSoulFormatRegistry::new(LakeSoulIOConfig::default(), false).unwrap();
+        let object_store_url = ObjectStoreUrl::parse("file://").unwrap();
+        let groups = LakeSoulTableProvider::format_scan_groups(
+            &registry,
+            object_store_url,
+            vec![vec![
+                PartitionedFile::from(object_meta("part-000.parquet")),
+                PartitionedFile::from(object_meta("part-001.vortex")),
+            ]],
+        )
+        .unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(
+            groups
+                .iter()
+                .find(|group| group.physical_format == PhysicalFormat::Parquet)
+                .unwrap()
+                .partitioned_file_lists[0]
+                .len(),
+            1
+        );
+        assert_eq!(
+            groups
+                .iter()
+                .find(|group| group.physical_format == PhysicalFormat::Vortex)
+                .unwrap()
+                .partitioned_file_lists[0]
+                .len(),
+            1
+        );
     }
 }

--- a/rust/lakesoul-datafusion/src/lakesoul_table/mod.rs
+++ b/rust/lakesoul-datafusion/src/lakesoul_table/mod.rs
@@ -19,8 +19,9 @@ use datafusion::{
     execution::context::{SessionContext, SessionState},
     logical_expr::LogicalPlanBuilder,
 };
-use helpers::case_fold_table_name;
+use helpers::{case_fold_table_name, create_io_config_builder_from_table_info};
 use lakesoul_io::config::OPTION_KEY_MEM_LIMIT;
+use lakesoul_io::file_format::LakeSoulFormatRegistry;
 use lakesoul_io::session::create_session_context_with_planner;
 use lakesoul_io::writer::async_writer::{
     AsyncBatchWriter, AsyncSendableMutableLakeSoulWriter, FlushOutput,
@@ -298,6 +299,15 @@ impl LakeSoulTable {
         &self,
         pushdown_filters: bool,
     ) -> Result<Arc<dyn TableProvider>> {
+        let io_config = create_io_config_builder_from_table_info(
+            self.table_info(),
+            HashMap::new(),
+            HashMap::new(),
+        )?
+        .build();
+        let format_registry =
+            Arc::new(LakeSoulFormatRegistry::new(io_config.clone(), false)?);
+
         Ok(Arc::new(LakeSoulTableProvider {
             listing_options: LakeSoulMetaDataParquetFormat::default_listing_options()
                 .await?,
@@ -310,6 +320,8 @@ impl LakeSoulTable {
             primary_keys: self.primary_keys().to_vec(),
             range_partitions: self.range_partitions().to_vec(),
             pushdown_filters,
+            io_config,
+            format_registry,
         }))
     }
 

--- a/rust/lakesoul-datafusion/src/tests/mod.rs
+++ b/rust/lakesoul-datafusion/src/tests/mod.rs
@@ -24,6 +24,8 @@ mod benchmarks;
 
 #[cfg(test)]
 mod catalog_tests;
+#[cfg(test)]
+mod vortex_catalog_tests;
 
 // in cargo test, this executed only once
 #[ctor::ctor]

--- a/rust/lakesoul-datafusion/src/tests/vortex_catalog_tests.rs
+++ b/rust/lakesoul-datafusion/src/tests/vortex_catalog_tests.rs
@@ -4,21 +4,28 @@
 
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, Int32Array, RecordBatch};
+use arrow::array::{ArrayRef, Int32Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::assert_batches_eq;
-use lakesoul_io::config::LakeSoulIOConfigBuilder;
+use lakesoul_io::config::{
+    LakeSoulIOConfigBuilder, OPTION_KEY_CDC_COLUMN, OPTION_KEY_STABLE_SORT,
+};
 use lakesoul_io::file_format::PhysicalFormat;
 use lakesoul_io::writer::async_writer::{
     AsyncBatchWriter, AsyncSendableMutableLakeSoulWriter,
 };
 use lakesoul_metadata::{MetaDataClient, MetaDataClientRef};
+use proto::proto::entity::TableInfo;
 
 use crate::Result;
-use crate::catalog::{create_io_config_builder, create_table};
+use crate::catalog::{
+    LakeSoulTableProperty, create_io_config_builder, create_table,
+    format_table_info_partitions,
+};
 use crate::cli::CoreArgs;
 use crate::create_lakesoul_session_ctx;
 use crate::lakesoul_table::LakeSoulTable;
+use crate::serialize::arrow_java::ArrowJavaSchema;
 
 fn test_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
@@ -33,6 +40,26 @@ fn batch(ids: &[i32], scores: &[i32]) -> RecordBatch {
         vec![
             Arc::new(Int32Array::from(ids.to_vec())) as ArrayRef,
             Arc::new(Int32Array::from(scores.to_vec())) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
+
+fn cdc_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("score", DataType::Int32, false),
+        Field::new("op", DataType::Utf8, true),
+    ]))
+}
+
+fn cdc_batch(ids: &[i32], scores: &[i32], ops: &[&str]) -> RecordBatch {
+    RecordBatch::try_new(
+        cdc_schema(),
+        vec![
+            Arc::new(Int32Array::from(ids.to_vec())) as ArrayRef,
+            Arc::new(Int32Array::from(scores.to_vec())) as ArrayRef,
+            Arc::new(StringArray::from(ops.to_vec())) as ArrayRef,
         ],
     )
     .unwrap()
@@ -81,6 +108,61 @@ async fn create_table_with_batches(
     for (physical_format, batch) in batches {
         write_batch_to_table(client.clone(), &table, physical_format, batch).await?;
     }
+
+    Ok(())
+}
+
+async fn create_primary_key_table_with_batches(
+    client: MetaDataClientRef,
+    table_name: &str,
+    batches: Vec<(PhysicalFormat, RecordBatch)>,
+) -> Result<()> {
+    let io_config = LakeSoulIOConfigBuilder::new()
+        .with_schema(test_schema())
+        .with_primary_keys(vec![String::from("id")])
+        .build();
+    create_table(client.clone(), table_name, io_config).await?;
+
+    let table = LakeSoulTable::for_name(table_name).await?;
+    for (physical_format, batch) in batches {
+        write_batch_to_table(client.clone(), &table, physical_format, batch).await?;
+    }
+
+    Ok(())
+}
+
+async fn create_cdc_table(client: MetaDataClientRef, table_name: &str) -> Result<()> {
+    let primary_keys = vec!["id".to_string()];
+    let io_config = LakeSoulIOConfigBuilder::new()
+        .with_schema(cdc_schema())
+        .with_primary_keys(primary_keys.clone())
+        .with_option(OPTION_KEY_CDC_COLUMN, "op")
+        .with_option(OPTION_KEY_STABLE_SORT, "true")
+        .build();
+
+    client
+        .create_table(TableInfo {
+            table_id: format!("table_{}", uuid::Uuid::new_v4()),
+            table_name: table_name.to_string(),
+            table_path: format!(
+                "file://{}/default/{}",
+                std::env::current_dir()?.to_string_lossy(),
+                table_name
+            ),
+            table_schema: serde_json::to_string::<ArrowJavaSchema>(
+                &io_config.target_schema().into(),
+            )?,
+            table_namespace: "default".to_string(),
+            properties: serde_json::to_string(&LakeSoulTableProperty {
+                hash_bucket_num: Some(String::from("4")),
+                cdc_change_column: Some(String::from("op")),
+                use_cdc: Some(String::from("true")),
+                ..Default::default()
+            })?,
+            partitions: format_table_info_partitions(&[], &primary_keys),
+            domain: "public".to_string(),
+        })
+        .await?;
 
     Ok(())
 }
@@ -158,6 +240,37 @@ async fn catalog_select_reads_mixed_parquet_and_vortex_table() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn catalog_mixed_format_scan_preserves_commit_order_for_use_last() -> Result<()> {
+    let client = Arc::new(MetaDataClient::from_env().await?);
+    let table_name = unique_table_name("catalog_mixed_order");
+    create_primary_key_table_with_batches(
+        client,
+        &table_name,
+        vec![
+            (PhysicalFormat::Parquet, batch(&[1], &[10])),
+            (PhysicalFormat::Vortex, batch(&[1], &[20])),
+            (PhysicalFormat::Parquet, batch(&[1], &[30])),
+        ],
+    )
+    .await?;
+
+    let results =
+        collect_sql(&table_name, "SELECT id, score FROM {table} ORDER BY id").await?;
+
+    assert_batches_eq!(
+        &[
+            "+----+-------+",
+            "| id | score |",
+            "+----+-------+",
+            "| 1  | 30    |",
+            "+----+-------+",
+        ],
+        &results
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn catalog_vortex_filter_can_reference_non_projected_column() -> Result<()> {
     let client = Arc::new(MetaDataClient::from_env().await?);
     let table_name = unique_table_name("catalog_vortex_filter_projection");
@@ -182,6 +295,44 @@ async fn catalog_vortex_filter_can_reference_non_projected_column() -> Result<()
         "| 2  |",
         "| 3  |",
         "+----+",],
+        &results
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_cdc_scan_filters_delete_tombstones_before_projection() -> Result<()> {
+    let client = Arc::new(MetaDataClient::from_env().await?);
+    let table_name = unique_table_name("catalog_cdc_delete_filter");
+    create_cdc_table(client.clone(), &table_name).await?;
+
+    let table = LakeSoulTable::for_name(&table_name).await?;
+    write_batch_to_table(
+        client.clone(),
+        &table,
+        PhysicalFormat::Parquet,
+        cdc_batch(&[1, 2], &[10, 30], &["insert", "insert"]),
+    )
+    .await?;
+    write_batch_to_table(
+        client,
+        &table,
+        PhysicalFormat::Parquet,
+        cdc_batch(&[1], &[20], &["delete"]),
+    )
+    .await?;
+
+    let results =
+        collect_sql(&table_name, "SELECT id, score FROM {table} ORDER BY id").await?;
+
+    assert_batches_eq!(
+        &[
+            "+----+-------+",
+            "| id | score |",
+            "+----+-------+",
+            "| 2  | 30    |",
+            "+----+-------+",
+        ],
         &results
     );
     Ok(())

--- a/rust/lakesoul-datafusion/src/tests/vortex_catalog_tests.rs
+++ b/rust/lakesoul-datafusion/src/tests/vortex_catalog_tests.rs
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::assert_batches_eq;
+use lakesoul_io::config::LakeSoulIOConfigBuilder;
+use lakesoul_io::file_format::PhysicalFormat;
+use lakesoul_io::writer::async_writer::{
+    AsyncBatchWriter, AsyncSendableMutableLakeSoulWriter,
+};
+use lakesoul_metadata::{MetaDataClient, MetaDataClientRef};
+
+use crate::Result;
+use crate::catalog::{create_io_config_builder, create_table};
+use crate::cli::CoreArgs;
+use crate::create_lakesoul_session_ctx;
+use crate::lakesoul_table::LakeSoulTable;
+
+fn test_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("score", DataType::Int32, false),
+    ]))
+}
+
+fn batch(ids: &[i32], scores: &[i32]) -> RecordBatch {
+    RecordBatch::try_new(
+        test_schema(),
+        vec![
+            Arc::new(Int32Array::from(ids.to_vec())) as ArrayRef,
+            Arc::new(Int32Array::from(scores.to_vec())) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
+
+fn unique_table_name(prefix: &str) -> String {
+    format!("{}_{}", prefix, uuid::Uuid::new_v4().simple())
+}
+
+async fn write_batch_to_table(
+    client: MetaDataClientRef,
+    table: &LakeSoulTable,
+    physical_format: PhysicalFormat,
+    batch: RecordBatch,
+) -> Result<()> {
+    let io_config = create_io_config_builder(
+        client,
+        Some(table.table_name()),
+        false,
+        table.table_namespace(),
+        Default::default(),
+        Default::default(),
+    )
+    .await?
+    .with_physical_format(physical_format)
+    .build();
+
+    let mut writer =
+        AsyncSendableMutableLakeSoulWriter::from_io_config(io_config).await?;
+    writer.write_record_batch(batch).await?;
+    let outputs = Box::new(writer).flush_and_close().await?;
+    table.commit_flush_result(outputs).await
+}
+
+async fn create_table_with_batches(
+    client: MetaDataClientRef,
+    table_name: &str,
+    batches: Vec<(PhysicalFormat, RecordBatch)>,
+) -> Result<()> {
+    let io_config = LakeSoulIOConfigBuilder::new()
+        .with_schema(test_schema())
+        .build();
+    create_table(client.clone(), table_name, io_config).await?;
+
+    let table = LakeSoulTable::for_name(table_name).await?;
+    for (physical_format, batch) in batches {
+        write_batch_to_table(client.clone(), &table, physical_format, batch).await?;
+    }
+
+    Ok(())
+}
+
+async fn collect_sql(table_name: &str, sql: &str) -> Result<Vec<RecordBatch>> {
+    let client = Arc::new(MetaDataClient::from_env().await?);
+    let ctx = create_lakesoul_session_ctx(client, &CoreArgs::default())?;
+    Ok(ctx
+        .sql(sql.replace("{table}", table_name).as_str())
+        .await?
+        .collect()
+        .await?)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_select_reads_vortex_table() -> Result<()> {
+    let client = Arc::new(MetaDataClient::from_env().await?);
+    let table_name = unique_table_name("catalog_vortex_select");
+    create_table_with_batches(
+        client,
+        &table_name,
+        vec![(PhysicalFormat::Vortex, batch(&[3, 1, 2], &[30, 10, 20]))],
+    )
+    .await?;
+
+    let results =
+        collect_sql(&table_name, "SELECT id, score FROM {table} ORDER BY id").await?;
+
+    assert_batches_eq!(
+        &[
+            "+----+-------+",
+            "| id | score |",
+            "+----+-------+",
+            "| 1  | 10    |",
+            "| 2  | 20    |",
+            "| 3  | 30    |",
+            "+----+-------+",
+        ],
+        &results
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_select_reads_mixed_parquet_and_vortex_table() -> Result<()> {
+    let client = Arc::new(MetaDataClient::from_env().await?);
+    let table_name = unique_table_name("catalog_mixed_select");
+    create_table_with_batches(
+        client,
+        &table_name,
+        vec![
+            (PhysicalFormat::Parquet, batch(&[2, 1], &[20, 10])),
+            (PhysicalFormat::Vortex, batch(&[4, 3], &[40, 30])),
+        ],
+    )
+    .await?;
+
+    let results =
+        collect_sql(&table_name, "SELECT id, score FROM {table} ORDER BY id").await?;
+
+    assert_batches_eq!(
+        &[
+            "+----+-------+",
+            "| id | score |",
+            "+----+-------+",
+            "| 1  | 10    |",
+            "| 2  | 20    |",
+            "| 3  | 30    |",
+            "| 4  | 40    |",
+            "+----+-------+",
+        ],
+        &results
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_vortex_filter_can_reference_non_projected_column() -> Result<()> {
+    let client = Arc::new(MetaDataClient::from_env().await?);
+    let table_name = unique_table_name("catalog_vortex_filter_projection");
+    create_table_with_batches(
+        client,
+        &table_name,
+        vec![(PhysicalFormat::Vortex, batch(&[1, 2, 3], &[5, 15, 25]))],
+    )
+    .await?;
+
+    let results = collect_sql(
+        &table_name,
+        "SELECT id FROM {table} WHERE score > 10 ORDER BY id",
+    )
+    .await?;
+
+    #[rustfmt::skip]
+    assert_batches_eq!(
+      &["+----+",
+        "| id |",
+        "+----+",
+        "| 2  |",
+        "| 3  |",
+        "+----+",],
+        &results
+    );
+    Ok(())
+}

--- a/rust/lakesoul-io/src/file_format.rs
+++ b/rust/lakesoul-io/src/file_format.rs
@@ -490,9 +490,13 @@ pub async fn flatten_file_scan_config(
                                 .await?;
                             let statistics =
                                 table_statistics(file_statistics, &table_schema);
-                            let projection_indices = compute_project_column_indices(
-                                table_schema.table_schema().clone(),
+                            let physical_target_schema = strip_partition_columns(
                                 target_schema.clone(),
+                                partition_schema.clone(),
+                            );
+                            let projection_indices = compute_project_column_indices(
+                                table_schema.file_schema().clone(),
+                                physical_target_schema,
                                 primary_keys,
                                 cdc_column,
                             );
@@ -599,9 +603,13 @@ pub async fn flatten_file_scan_config_for_format(
                                 .await?;
                             let statistics =
                                 table_statistics(file_statistics, &table_schema);
-                            let projection_indices = compute_project_column_indices(
-                                table_schema.table_schema().clone(),
+                            let physical_target_schema = strip_partition_columns(
                                 target_schema.clone(),
+                                partition_schema.clone(),
+                            );
+                            let projection_indices = compute_project_column_indices(
+                                table_schema.file_schema().clone(),
+                                physical_target_schema,
                                 primary_keys,
                                 cdc_column,
                             );

--- a/rust/lakesoul-io/src/file_format.rs
+++ b/rust/lakesoul-io/src/file_format.rs
@@ -474,7 +474,13 @@ pub async fn flatten_file_scan_config(
                                 SchemaRef::new(builder.finish())
                             };
                             debug!("file schema:{}", file_schema);
-                            let statistics = format
+                            let cols = conf.table_partition_cols().clone();
+                            debug!("partition cols: {:?}", cols);
+                            debug!("flatten: file_schema: {}", file_schema);
+                            // only file schema
+                            let table_schema =
+                                TableSchema::new(file_schema.clone(), cols);
+                            let file_statistics = format
                                 .infer_stats(
                                     state,
                                     &store,
@@ -482,17 +488,14 @@ pub async fn flatten_file_scan_config(
                                     &file.object_meta,
                                 )
                                 .await?;
+                            let statistics =
+                                table_statistics(file_statistics, &table_schema);
                             let projection_indices = compute_project_column_indices(
-                                file_schema.clone(),
+                                table_schema.table_schema().clone(),
                                 target_schema.clone(),
                                 primary_keys,
                                 cdc_column,
                             );
-                            let cols = conf.table_partition_cols().clone();
-                            debug!("partition cols: {:?}", cols);
-                            debug!("flatten: file_schema: {}", file_schema);
-                            // only file schema
-                            let table_schema = TableSchema::new(file_schema, cols);
                             let mut parquet_source = format
                                 .file_source(table_schema)
                                 .as_any()
@@ -582,24 +585,26 @@ pub async fn flatten_file_scan_config_for_format(
                                 partition_schema.clone(),
                             );
                             debug!("file schema:{}", file_schema);
-                            let statistics = format
-                                .infer_stats(
-                                    state,
-                                    &store,
-                                    file_schema.clone(),
-                                    &file.object_meta,
-                                )
-                                .await?;
-                            let projection_indices = compute_project_column_indices(
-                                file_schema.clone(),
-                                target_schema.clone(),
-                                primary_keys,
-                                cdc_column,
-                            );
                             let cols = conf.table_partition_cols().clone();
                             debug!("partition cols: {:?}", cols);
                             debug!("flatten: file_schema: {}", file_schema);
                             let table_schema = TableSchema::new(file_schema, cols);
+                            let file_statistics = format
+                                .infer_stats(
+                                    state,
+                                    &store,
+                                    table_schema.file_schema().clone(),
+                                    &file.object_meta,
+                                )
+                                .await?;
+                            let statistics =
+                                table_statistics(file_statistics, &table_schema);
+                            let projection_indices = compute_project_column_indices(
+                                table_schema.table_schema().clone(),
+                                target_schema.clone(),
+                                primary_keys,
+                                cdc_column,
+                            );
                             let mut source = format.file_source(table_schema);
                             source = adapt_file_source_for_single_file(
                                 source, &format, &conf,
@@ -663,6 +668,23 @@ fn strip_partition_columns(
         }
     }
     SchemaRef::new(builder.finish())
+}
+
+fn table_statistics(
+    file_statistics: Statistics,
+    table_schema: &TableSchema,
+) -> Statistics {
+    let mut statistics = Statistics::new_unknown(table_schema.table_schema());
+    statistics.num_rows = file_statistics.num_rows;
+    statistics.total_byte_size = file_statistics.total_byte_size;
+    for (idx, column_statistics) in
+        file_statistics.column_statistics.into_iter().enumerate()
+    {
+        if idx < statistics.column_statistics.len() {
+            statistics.column_statistics[idx] = column_statistics;
+        }
+    }
+    statistics
 }
 
 fn adapt_file_source_for_single_file(

--- a/rust/lakesoul-io/src/lib.rs
+++ b/rust/lakesoul-io/src/lib.rs
@@ -10,14 +10,14 @@
 //!
 //! # Examples
 //!
-//! ```rust
+//! ```no_run
+//! # fn main() -> lakesoul_io::Result<()> {
 //! # tokio_test::block_on(async {
-//! use lakesoul_io::lakesoul_reader::LakeSoulReader;
-//! use lakesoul_io::lakesoul_io_config::LakeSoulIOConfigBuilder;
+//! use lakesoul_io::config::LakeSoulIOConfig;
+//! use lakesoul_io::reader::LakeSoulReader;
 //!
-//! // Configure and create a reader
-//! let config = LakeSoulIOConfigBuilder::new()
-//!     .with_files(vec!["path/to/file.parquet"])
+//! let config = LakeSoulIOConfig::builder()
+//!     .with_file("path/to/file.parquet")
 //!     .with_thread_num(1)
 //!     .with_batch_size(256)
 //!     .build();
@@ -25,12 +25,14 @@
 //! let mut reader = LakeSoulReader::new(config)?;
 //! reader.start().await?;
 //!
-//! // Read data
 //! while let Some(batch) = reader.next_rb().await {
 //!     let record_batch = batch?;
-//!     // Process the record batch
+//!     let _row_count = record_batch.num_rows();
 //! }
-//!})
+//! # Ok::<(), rootcause::Report>(())
+//! # })?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Features

--- a/rust/lakesoul-io/src/physical_plan/merge/mod.rs
+++ b/rust/lakesoul-io/src/physical_plan/merge/mod.rs
@@ -57,6 +57,37 @@ pub struct MergeParquetExec {
 }
 
 impl MergeParquetExec {
+    /// Align the advertised merged schema with the values this plan can emit.
+    ///
+    /// Schema evolution can leave older files without a newly requested column.
+    /// Default-column projection fills those missing fields with defaults or nulls,
+    /// so any field missing from any input must be reported as nullable.
+    fn merged_schema_with_input_nullability(
+        merged_schema: SchemaRef,
+        inputs: &[Arc<dyn ExecutionPlan>],
+    ) -> SchemaRef {
+        SchemaRef::new(Schema::new(
+            merged_schema
+                .fields()
+                .iter()
+                .map(|field| {
+                    Field::new(
+                        field.name(),
+                        field.data_type().clone(),
+                        field.is_nullable()
+                            | inputs.iter().any(|plan| {
+                                // If an input is missing a requested field, the default-column
+                                // projection will synthesize nulls for that input.
+                                plan.schema().column_with_name(field.name()).is_none_or(
+                                    |(_, plan_field)| plan_field.is_nullable(),
+                                )
+                            }),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        ))
+    }
+
     /// Create a new Parquet reader execution plan provided file list and schema.
     pub fn new(
         merged_schema: SchemaRef,
@@ -72,29 +103,8 @@ impl MergeParquetExec {
         }
         // Compute Nullability
         // O(nml), n = number of schema fields, m = number of file schema fields, l = number of files
-        let merged_schema = SchemaRef::new(Schema::new(
-            merged_schema
-                .fields()
-                .iter()
-                .map(|field| {
-                    Field::new(
-                        field.name(),
-                        field.data_type().clone(),
-                        field.is_nullable()
-                            | inputs.iter().any(|plan| {
-                                // see all inputs
-                                if let Some((_, plan_field)) =
-                                    plan.schema().column_with_name(field.name())
-                                {
-                                    plan_field.is_nullable()
-                                } else {
-                                    true
-                                }
-                            }),
-                    )
-                })
-                .collect::<Vec<_>>(),
-        ));
+        let merged_schema =
+            Self::merged_schema_with_input_nullability(merged_schema, &inputs);
 
         let config = io_config.clone();
         let primary_keys = Arc::new(io_config.primary_keys);
@@ -129,6 +139,7 @@ impl MergeParquetExec {
             "MergeParquetExec::new_with_inputs: {:?}, {:?}, {:?}",
             schema, io_config, default_column_value
         );
+        let schema = Self::merged_schema_with_input_nullability(schema, &inputs);
         let config = io_config.clone();
         let primary_keys = Arc::new(io_config.primary_keys);
         let merge_operators = Arc::new(io_config.merge_operators);
@@ -430,4 +441,54 @@ pub async fn prune_filter_and_execute(
     let df = df.select(cols)?;
     // return a stream
     Ok(df.execute_stream().await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    use crate::config::LakeSoulIOConfigBuilder;
+
+    #[test]
+    fn new_with_inputs_marks_missing_requested_fields_nullable() {
+        // Simulate schema evolution: the old file was written before `evolved`
+        // existed, while the table/requested schema now includes it.
+        let merged_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("evolved", DataType::Utf8, false),
+        ]));
+        let old_file_schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let new_file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("evolved", DataType::Utf8, false),
+        ]));
+        let inputs = vec![
+            Arc::new(EmptyExec::new(old_file_schema)) as Arc<dyn ExecutionPlan>,
+            Arc::new(EmptyExec::new(new_file_schema)) as Arc<dyn ExecutionPlan>,
+        ];
+
+        let exec = MergeParquetExec::new_with_inputs(
+            merged_schema,
+            inputs,
+            LakeSoulIOConfigBuilder::new().build(),
+            Arc::new(HashMap::new()),
+        )
+        .unwrap();
+
+        assert!(
+            exec.schema()
+                .field_with_name("evolved")
+                .unwrap()
+                .is_nullable(),
+            "fields missing from any input schema must be nullable because default-column projection synthesizes nulls"
+        );
+        assert!(
+            !exec.schema().field_with_name("id").unwrap().is_nullable(),
+            "fields present and non-nullable in every input should keep their nullability"
+        );
+    }
 }

--- a/rust/lakesoul-io/src/reader.rs
+++ b/rust/lakesoul-io/src/reader.rs
@@ -9,12 +9,14 @@
 //! features like filtering, partitioning, and optimized reading with primary keys.
 //!
 //! # Examples
-//! ```rust
-//! use lakesoul_io::lakesoul_reader::LakeSoulReader;
-//! use lakesoul_io::lakesoul_io_config::LakeSoulIOConfigBuilder;
+//! ```no_run
+//! # fn main() -> lakesoul_io::Result<()> {
+//! # tokio_test::block_on(async {
+//! use lakesoul_io::config::LakeSoulIOConfig;
+//! use lakesoul_io::reader::LakeSoulReader;
 //!
-//! let config = LakeSoulIOConfigBuilder::new()
-//!     .with_files(vec!["path/to/file.parquet"])
+//! let config = LakeSoulIOConfig::builder()
+//!     .with_file("path/to/file.parquet")
 //!     .with_thread_num(1)
 //!     .with_batch_size(256)
 //!     .build();
@@ -24,8 +26,12 @@
 //!
 //! while let Some(batch) = reader.next_rb().await {
 //!     let record_batch = batch?;
-//!     // Process the record batch
+//!     let _row_count = record_batch.num_rows();
 //! }
+//! # Ok::<(), rootcause::Report>(())
+//! # })?;
+//! # Ok(())
+//! # }
 //! ```
 
 use std::sync::Arc;
@@ -66,13 +72,14 @@ use crate::{
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```no_run
+/// # fn main() -> lakesoul_io::Result<()> {
 /// # tokio_test::block_on(async {
-/// use lakesoul_io::lakesoul_reader::LakeSoulReader;
-/// use lakesoul_io::lakesoul_io_config::LakeSoulIOConfigBuilder;
+/// use lakesoul_io::config::LakeSoulIOConfig;
+/// use lakesoul_io::reader::LakeSoulReader;
 ///
-/// let config = LakeSoulIOConfigBuilder::new()
-///     .with_files(vec!["path/to/file.parquet"])
+/// let config = LakeSoulIOConfig::builder()
+///     .with_file("path/to/file.parquet")
 ///     .with_thread_num(1)
 ///     .with_batch_size(256)
 ///     .build();
@@ -82,9 +89,12 @@ use crate::{
 ///
 /// while let Some(batch) = reader.next_rb().await {
 ///     let record_batch = batch?;
-///     // Process the record batch
+///     let _row_count = record_batch.num_rows();
 /// }
-/// })
+/// # Ok::<(), rootcause::Report>(())
+/// # })?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct LakeSoulReader {
     // not use `Arc` here
@@ -262,15 +272,21 @@ impl LakeSoulReader {
 ///
 /// # Examples
 ///
-/// ```rust
-/// use lakesoul_io::lakesoul_reader::SyncSendableMutableLakeSoulReader;
+/// ```ignore
+/// use lakesoul_io::config::LakeSoulIOConfig;
+/// use lakesoul_io::reader::{LakeSoulReader, SyncSendableMutableLakeSoulReader};
 /// use tokio::runtime::Runtime;
 ///
-/// let runtime = Runtime::new()?;
-/// let mut reader = SyncSendableMutableLakeSoulReader::new(lake_soul_reader, runtime);
-/// reader.start_blocked()?;
+/// let runtime = Runtime::new().unwrap();
+/// let config = LakeSoulIOConfig::builder()
+///     .with_file("path/to/file.parquet")
+///     .build();
+/// let lake_soul_reader = LakeSoulReader::new(config).unwrap();
+/// let mut reader =
+///     SyncSendableMutableLakeSoulReader::new(lake_soul_reader, runtime);
+/// reader.start_blocked().unwrap();
 ///
-/// let (tx, rx) = std::sync::mpsc::channel(1);
+/// let (tx, rx) = std::sync::mpsc::channel();
 /// reader.next_rb_callback(Box::new(move |batch| {
 ///     tx.send(batch).unwrap();
 /// }));

--- a/rust/lakesoul-io/src/writer/mod.rs
+++ b/rust/lakesoul-io/src/writer/mod.rs
@@ -10,16 +10,30 @@
 //!
 //! # Examples
 //!
-//! ```rust
-//! use lakesoul_io::lakesoul_writer::SyncSendableMutableLakeSoulWriter;
-//! use lakesoul_io::lakesoul_io_config::LakeSoulIOConfigBuilder;
+//! ```no_run
+//! use std::sync::Arc;
 //!
-//! let config = LakeSoulIOConfigBuilder::new()
-//!     .with_files(vec!["path/to/file.parquet"])
+//! use arrow_array::{Int64Array, RecordBatch};
+//! use arrow_schema::{DataType, Field, Schema};
+//! use lakesoul_io::config::LakeSoulIOConfig;
+//! use lakesoul_io::writer::SyncSendableMutableLakeSoulWriter;
+//!
+//! let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+//! let record_batch = RecordBatch::try_new(
+//!     schema.clone(),
+//!     vec![Arc::new(Int64Array::from_iter_values([1_i64, 2, 3]))],
+//! )
+//! .unwrap();
+//!
+//! let config = LakeSoulIOConfig::builder()
+//!     .with_file("path/to/file.parquet")
+//!     .with_schema(schema)
+//!     .with_hash_bucket_num("1")
 //!     .build();
 //!
 //! let runtime = tokio::runtime::Runtime::new().unwrap();
-//! let mut writer = SyncSendableMutableLakeSoulWriter::try_new(config, runtime).unwrap();
+//! let mut writer =
+//!     SyncSendableMutableLakeSoulWriter::from_io_config(config, runtime).unwrap();
 //! writer.write_batch(record_batch).unwrap();
 //! writer.flush_and_close().unwrap();
 //! ```

--- a/rust/lakesoul-io/src/writer/mod.rs
+++ b/rust/lakesoul-io/src/writer/mod.rs
@@ -164,6 +164,7 @@ pub(crate) fn create_leaf_writer(
         file_output_mode: FileOutputMode::SingleFile,
     };
 
+    // TODO(jiax): expose vortex write options
     let sink: Arc<dyn FileSink> = match physical_format {
         PhysicalFormat::Parquet => {
             Arc::new(ParquetSink::new(sink_config, parquet_options(io_config)))

--- a/rust/lakesoul-io/tests/read_test.rs
+++ b/rust/lakesoul-io/tests/read_test.rs
@@ -765,6 +765,74 @@ async fn test_read_multiple_range_partitions() {
     assert_eq!(ids, vec![1, 2, 101, 102]);
 }
 
+#[test_log::test(tokio::test)]
+async fn test_read_multiple_range_partitions_vortex() {
+    let dir = tempdir().unwrap();
+
+    let schema = SchemaRef::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Utf8, true),
+    ]));
+    // Write two partitions
+    for (range_val, id_offset) in [("range1", 0_i64), ("range2", 100_i64)] {
+        let file_path = dir
+            .path()
+            .join(format!("range={}", range_val))
+            .join(format!("part-{}.vortex", range_val));
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values([1 + id_offset, 2 + id_offset])),
+                Arc::new(StringArray::from_iter_values(["x", "y"])),
+            ],
+        )
+        .unwrap();
+
+        write_batch(file_path.into_os_string().into_string().unwrap(), batch).await;
+    }
+
+    // Read both partitions
+    let mut read_schema_builder = SchemaBuilder::from(schema.as_ref());
+    read_schema_builder.push(Field::new("range", DataType::Utf8, true));
+
+    let files = vec![
+        dir.path()
+            .join("range=range1")
+            .join("part-range1.vortex")
+            .into_os_string()
+            .into_string()
+            .unwrap(),
+        dir.path()
+            .join("range=range2")
+            .join("part-range2.vortex")
+            .into_os_string()
+            .into_string()
+            .unwrap(),
+    ];
+
+    let reader_conf = LakeSoulIOConfig::builder()
+        .with_files(files)
+        .with_schema(Arc::new(read_schema_builder.finish()))
+        .with_range_partitions(vec!["range".to_string()])
+        .with_default_column_value("range", "range1")
+        .with_hash_bucket_num("1")
+        .with_option(OPTION_KEY_IS_COMPACTED, "false")
+        .with_option(OPTION_KEY_SKIP_MERGE_ON_READ, "false")
+        .build();
+
+    let mut reader = LakeSoulReader::new(reader_conf).unwrap();
+    reader.start().await.unwrap();
+
+    let mut ids = vec![];
+    while let Some(Ok(batch)) = reader.next_rb().await {
+        ids.extend(int64_values(&[batch], "id"));
+    }
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2, 101, 102]);
+}
+
 // --- Vortex-only tests for feature parity with Parquet ---
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
Fixes #782

## What changed

- Route LakeSoul DataFusion catalog scans through the physical format registry, so metadata-backed `.vortex` files are planned with `VortexFormat` instead of the Parquet metadata format.
- Split scan planning by detected physical file format and object store before building the merged execution plan.
- Add catalog SQL tests for Vortex-only tables, mixed Parquet/Vortex tables, and filters that reference non-projected columns.

## Root cause

`LakeSoulTableProvider::scan` always built file scans with the LakeSoul Parquet metadata format. Tables whose metadata pointed at `.vortex` files were therefore opened by the Parquet reader, which failed with corrupt footer errors.

## Validation

- `cargo fmt --check`
- `cargo test -p lakesoul-datafusion vortex_catalog_tests`