### PR TITLE
[CI] replace actions-rs toolchain setup

### DIFF
--- a/.github/workflows/consistency-ci.yml
+++ b/.github/workflows/consistency-ci.yml
@@ -92,11 +92,9 @@ jobs:
                   spark-url: "https://mirrors.huaweicloud.com/apache/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz"
             - run: spark-submit --version
 
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                   workspaces: ". -> rust/target"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,11 +20,9 @@ jobs:
                   java-version: "11"
                   distribution: "temurin"
                   cache: maven
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                 workspaces: ". -> rust/target"
@@ -58,11 +56,9 @@ jobs:
               with:
                   version: "23.x"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                 workspaces: ". -> rust/target"
@@ -97,11 +93,9 @@ jobs:
               with:
                   version: "23.x"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                   workspaces: "./rust -> target"

--- a/.github/workflows/flink-cdc-hdfs-test.yml
+++ b/.github/workflows/flink-cdc-hdfs-test.yml
@@ -66,11 +66,9 @@ jobs:
               with:
                   version: "23.x"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                   workspaces: ". -> rust/target"

--- a/.github/workflows/flink-cdc-test.yml
+++ b/.github/workflows/flink-cdc-test.yml
@@ -70,11 +70,9 @@ jobs:
         with:
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> rust/target"

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -50,11 +50,9 @@ jobs:
                   java-version: "11"
                   distribution: "temurin"
                   cache: maven
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                   workspaces: ". -> rust/target"

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -43,11 +43,9 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: maven
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> rust/target"
@@ -81,11 +79,9 @@ jobs:
         with:
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> rust/target"
@@ -120,11 +116,9 @@ jobs:
         with:
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          default: true
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> rust/target"

--- a/.github/workflows/presto-cdc-test.yml
+++ b/.github/workflows/presto-cdc-test.yml
@@ -68,11 +68,9 @@ jobs:
               with:
                   version: "23.x"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions-rs/toolchain@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
             - uses: Swatinem/rust-cache@v2
               with:
                   workspaces: ". -> rust/target"


### PR DESCRIPTION
## Summary
Replace the remaining `actions-rs/toolchain@v1` workflow setup steps with `dtolnay/rust-toolchain@master`.

## Why
Our CI has recently become unstable due to intermittent Rust toolchain installation failures:

failed to install component: 'rustfmt-preview-x86_64-unknown-linux-gnu',
detected conflict: 'bin/cargo-fmt'

The failures appear to be related to rustup recovering from a partially installed toolchain on GitHub runners.

## Changes
- update all remaining workflow files under `.github/workflows` that still used `actions-rs/toolchain@v1`
- keep each workflow on the `stable` Rust toolchain
- leave unrelated workflow behavior unchanged

Closes #784

## Validation
- verified the staged workflow diff locally before commit
- verified there are no remaining `actions-rs/toolchain@v1` references under `.github/workflows` via `rg`
- did not run GitHub Actions jobs locally