### PR TITLE
[Metadata] Use Arrow IPC metadata schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,7 +4557,9 @@ dependencies = [
 name = "lakesoul-common"
 version = "0.1.0"
 dependencies = [
+ "arrow-ipc",
  "arrow-schema",
+ "md5",
  "serde",
  "serde_json",
  "tracing",

--- a/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TableInfoDao.java
+++ b/lakesoul-common/src/main/java/com/dmetasoul/lakesoul/meta/dao/TableInfoDao.java
@@ -5,6 +5,7 @@
 package com.dmetasoul.lakesoul.meta.dao;
 
 import com.dmetasoul.lakesoul.meta.DBConnector;
+import com.google.protobuf.ByteString;
 import com.dmetasoul.lakesoul.meta.entity.JniWrapper;
 import com.dmetasoul.lakesoul.meta.entity.TableInfo;
 import com.dmetasoul.lakesoul.meta.jnr.NativeMetadataJavaClient;
@@ -14,7 +15,9 @@ import org.apache.commons.lang3.StringUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -141,16 +144,26 @@ public class TableInfoDao {
         try {
             conn = DBConnector.getConn();
             pstmt = conn.prepareStatement(
-                    "insert into table_info(table_id, table_name, table_path, table_schema, properties, partitions, table_namespace, domain) " +
-                            "values (?, ?, ?, ?, ?, ?, ?, ?)");
+                    "insert into table_info(table_id, table_name, table_path, table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash, properties, partitions, table_namespace, domain) " +
+                            "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
             pstmt.setString(1, tableInfo.getTableId());
             pstmt.setString(2, tableInfo.getTableName());
             pstmt.setString(3, tableInfo.getTablePath());
             pstmt.setString(4, tableInfo.getTableSchema());
-            pstmt.setString(5, tableInfo.getProperties());
-            pstmt.setString(6, tableInfo.getPartitions());
-            pstmt.setString(7, tableInfo.getTableNamespace());
-            pstmt.setString(8, tableInfo.getDomain());
+            if (tableInfo.getTableSchemaArrowIpc().isEmpty()) {
+                pstmt.setNull(5, Types.BINARY);
+            } else {
+                pstmt.setBytes(5, tableInfo.getTableSchemaArrowIpc().toByteArray());
+            }
+            if (tableInfo.getTableSchemaArrowIpcJsonHash().isEmpty()) {
+                pstmt.setNull(6, Types.VARCHAR);
+            } else {
+                pstmt.setString(6, tableInfo.getTableSchemaArrowIpcJsonHash());
+            }
+            pstmt.setString(7, tableInfo.getProperties());
+            pstmt.setString(8, tableInfo.getPartitions());
+            pstmt.setString(9, tableInfo.getTableNamespace());
+            pstmt.setString(10, tableInfo.getDomain());
             pstmt.execute();
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -243,7 +256,7 @@ public class TableInfoDao {
             sb.append(String.format("table_path = '%s', ", tablePath));
         }
         if (StringUtils.isNotBlank(tableSchema)) {
-            sb.append(String.format("table_schema = '%s', ", tableSchema));
+            sb.append(String.format("table_schema = '%s', table_schema_arrow_ipc = NULL, table_schema_arrow_ipc_json_hash = NULL, ", tableSchema));
         }
         sb = new StringBuilder(sb.substring(0, sb.length() - 2));
         sb.append(String.format(" where table_id = '%s'", tableId));
@@ -275,7 +288,7 @@ public class TableInfoDao {
     }
 
     public static TableInfo tableInfoFromResultSet(ResultSet rs) throws SQLException {
-        return TableInfo.newBuilder()
+        TableInfo.Builder builder = TableInfo.newBuilder()
                 .setTableId(rs.getString("table_id"))
                 .setTableName(rs.getString("table_name"))
                 .setTablePath(rs.getString("table_path"))
@@ -283,8 +296,32 @@ public class TableInfoDao {
                 .setProperties(rs.getString("properties"))
                 .setPartitions(rs.getString("partitions"))
                 .setTableNamespace(rs.getString("table_namespace"))
-                .setDomain(rs.getString("domain"))
-                .build();
+                .setDomain(rs.getString("domain"));
+
+        if (hasColumn(rs, "table_schema_arrow_ipc")) {
+            byte[] schemaArrowIpc = rs.getBytes("table_schema_arrow_ipc");
+            if (schemaArrowIpc != null && schemaArrowIpc.length > 0) {
+                builder.setTableSchemaArrowIpc(ByteString.copyFrom(schemaArrowIpc));
+            }
+        }
+        if (hasColumn(rs, "table_schema_arrow_ipc_json_hash")) {
+            String schemaArrowIpcJsonHash = rs.getString("table_schema_arrow_ipc_json_hash");
+            if (schemaArrowIpcJsonHash != null) {
+                builder.setTableSchemaArrowIpcJsonHash(schemaArrowIpcJsonHash);
+            }
+        }
+
+        return builder.build();
+    }
+
+    private static boolean hasColumn(ResultSet rs, String columnName) throws SQLException {
+        ResultSetMetaData metadata = rs.getMetaData();
+        for (int i = 1; i <= metadata.getColumnCount(); i++) {
+            if (columnName.equalsIgnoreCase(metadata.getColumnName(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     //  {"fields": [...]}

--- a/python/src/lakesoul/metadata/generated/entity_pb2.py
+++ b/python/src/lakesoul/metadata/generated/entity_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0c\x65ntity.proto\x12\x0cproto.entity\"\xa6\x01\n\x08MetaInfo\x12\x33\n\x0elist_partition\x18\x01 \x03(\x0b\x32\x1b.proto.entity.PartitionInfo\x12+\n\ntable_info\x18\x02 \x01(\x0b\x32\x17.proto.entity.TableInfo\x12\x38\n\x13read_partition_info\x18\x03 \x03(\x0b\x32\x1b.proto.entity.PartitionInfo\"\xac\x01\n\tTableInfo\x12\x10\n\x08table_id\x18\x01 \x01(\t\x12\x17\n\x0ftable_namespace\x18\x02 \x01(\t\x12\x12\n\ntable_name\x18\x03 \x01(\t\x12\x12\n\ntable_path\x18\x04 \x01(\t\x12\x14\n\x0ctable_schema\x18\x05 \x01(\t\x12\x12\n\nproperties\x18\x07 \x01(\t\x12\x12\n\npartitions\x18\x08 \x01(\t\x12\x0e\n\x06\x64omain\x18\t \x01(\t\"\xd2\x01\n\rPartitionInfo\x12\x10\n\x08table_id\x18\x01 \x01(\t\x12\x16\n\x0epartition_desc\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\x05\x12)\n\tcommit_op\x18\x04 \x01(\x0e\x32\x16.proto.entity.CommitOp\x12\x11\n\ttimestamp\x18\x05 \x01(\x03\x12$\n\x08snapshot\x18\x07 \x03(\x0b\x32\x12.proto.entity.Uuid\x12\x12\n\nexpression\x18\x08 \x01(\t\x12\x0e\n\x06\x64omain\x18\t \x01(\t\"S\n\tNamespace\x12\x11\n\tnamespace\x18\x01 \x01(\t\x12\x12\n\nproperties\x18\x02 \x01(\t\x12\x0f\n\x07\x63omment\x18\x03 \x01(\t\x12\x0e\n\x06\x64omain\x18\x04 \x01(\t\"h\n\nDataFileOp\x12\x0c\n\x04path\x18\x01 \x01(\t\x12%\n\x07\x66ile_op\x18\x02 \x01(\x0e\x32\x14.proto.entity.FileOp\x12\x0c\n\x04size\x18\x03 \x01(\x03\x12\x17\n\x0f\x66ile_exist_cols\x18\x04 \x01(\t\"\xee\x01\n\x0e\x44\x61taCommitInfo\x12\x10\n\x08table_id\x18\x01 \x01(\t\x12\x16\n\x0epartition_desc\x18\x02 \x01(\t\x12%\n\tcommit_id\x18\x03 \x01(\x0b\x32\x12.proto.entity.Uuid\x12*\n\x08\x66ile_ops\x18\x04 \x03(\x0b\x32\x18.proto.entity.DataFileOp\x12)\n\tcommit_op\x18\x05 \x01(\x0e\x32\x16.proto.entity.CommitOp\x12\x11\n\ttimestamp\x18\x06 \x01(\x03\x12\x11\n\tcommitted\x18\x07 \x01(\x08\x12\x0e\n\x06\x64omain\x18\x08 \x01(\t\"[\n\x0bTableNameId\x12\x12\n\ntable_name\x18\x01 \x01(\t\x12\x0f\n\x07tableId\x18\x02 \x01(\t\x12\x17\n\x0ftable_namespace\x18\x03 \x01(\t\x12\x0e\n\x06\x64omain\x18\x04 \x01(\t\"}\n\x19\x44iscardCompressedFileInfo\x12\x11\n\tfile_path\x18\x01 \x01(\t\x12\x12\n\ntable_path\x18\x02 \x01(\t\x12\x16\n\x0epartition_desc\x18\x03 \x01(\t\x12\x11\n\ttimestamp\x18\x04 \x01(\x03\x12\x0e\n\x06t_date\x18\x05 \x01(\t\"\\\n\x0bTablePathId\x12\x12\n\ntable_path\x18\x01 \x01(\t\x12\x10\n\x08table_id\x18\x02 \x01(\t\x12\x17\n\x0ftable_namespace\x18\x03 \x01(\t\x12\x0e\n\x06\x64omain\x18\x04 \x01(\t\"!\n\x04Uuid\x12\x0c\n\x04high\x18\x01 \x01(\x04\x12\x0b\n\x03low\x18\x02 \x01(\x04\"\x85\x03\n\nJniWrapper\x12*\n\tnamespace\x18\x01 \x03(\x0b\x32\x17.proto.entity.Namespace\x12+\n\ntable_info\x18\x02 \x03(\x0b\x32\x17.proto.entity.TableInfo\x12\x30\n\rtable_path_id\x18\x03 \x03(\x0b\x32\x19.proto.entity.TablePathId\x12\x30\n\rtable_name_id\x18\x04 \x03(\x0b\x32\x19.proto.entity.TableNameId\x12\x33\n\x0epartition_info\x18\x05 \x03(\x0b\x32\x1b.proto.entity.PartitionInfo\x12\x36\n\x10\x64\x61ta_commit_info\x18\x06 \x03(\x0b\x32\x1c.proto.entity.DataCommitInfo\x12M\n\x1c\x64iscard_compressed_file_info\x18\x07 \x03(\x0b\x32\'.proto.entity.DiscardCompressedFileInfo*g\n\x08\x43ommitOp\x12\x14\n\x10\x43ompactionCommit\x10\x00\x12\x10\n\x0c\x41ppendCommit\x10\x01\x12\x0f\n\x0bMergeCommit\x10\x02\x12\x10\n\x0cUpdateCommit\x10\x03\x12\x10\n\x0c\x44\x65leteCommit\x10\x04*\x1a\n\x06\x46ileOp\x12\x07\n\x03\x61\x64\x64\x10\x00\x12\x07\n\x03\x64\x65l\x10\x01\x42&\n\"com.dmetasoul.lakesoul.meta.entityP\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0c\x65ntity.proto\x12\x0cproto.entity\"\xa6\x01\n\x08MetaInfo\x12\x33\n\x0elist_partition\x18\x01 \x03(\x0b\x32\x1b.proto.entity.PartitionInfo\x12+\n\ntable_info\x18\x02 \x01(\x0b\x32\x17.proto.entity.TableInfo\x12\x38\n\x13read_partition_info\x18\x03 \x03(\x0b\x32\x1b.proto.entity.PartitionInfo\"\xf6\x01\n\tTableInfo\x12\x10\n\x08table_id\x18\x01 \x01(\t\x12\x17\n\x0ftable_namespace\x18\x02 \x01(\t\x12\x12\n\ntable_name\x18\x03 \x01(\t\x12\x12\n\ntable_path\x18\x04 \x01(\t\x12\x14\n\x0ctable_schema\x18\x05 \x01(\t\x12\x1e\n\x16table_schema_arrow_ipc\x18\n \x01(\x0c\x12(\n table_schema_arrow_ipc_json_hash\x18\x0b \x01(\t\x12\x12\n\nproperties\x18\x07 \x01(\t\x12\x12\n\npartitions\x18\x08 \x01(\t\x12\x0e\n\x06\x64omain\x18\t \x01(\t\"\xd2\x01\n\rPartitionInfo\x12\x10\n\x08table_id\x18\x01 \x01(\t\x12\x16\n\x0epartition_desc\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\x05\x12)\n\tcommit_op\x18\x04 \x01(\x0e\x32\x16.proto.entity.CommitOp\x12\x11\n\ttimestamp\x18\x05 \x01(\x03\x12$\n\x08snapshot\x18\x07 \x03(\x0b\x32\x12.proto.entity.Uuid\x12\x12\n\nexpression\x18\x08 \x01(\t\x12\x0e\n\x06\x64omain\x18\t \x01(\t\"S\n\tNamespace\x12\x11\n\tnamespace\x18\x01 \x01(\t\x12\x12\n\nproperties\x18\x02 \x01(\t\x12\x0f\n\x07\x63omment\x18\x03 \x01(\t\x12\x0e\n\x06\x64omain\x18\x04 \x01(\t\"h\n\nDataFileOp\x12\x0c\n\x04path\x18\x01 \x01(\t\x12%\n\x07\x66ile_op\x18\x02 \x01(\x0e\x32\x14.proto.entity.FileOp\x12\x0c\n\x04size\x18\x03 \x01(\x03\x12\x17\n\x0f\x66ile_exist_cols\x18\x04 \x01(\t\"\xee\x01\n\x0e\x44\x61taCommitInfo\x12\x10\n\x08table_id\x18\x01 \x01(\t\x12\x16\n\x0epartition_desc\x18\x02 \x01(\t\x12%\n\tcommit_id\x18\x03 \x01(\x0b\x32\x12.proto.entity.Uuid\x12*\n\x08\x66ile_ops\x18\x04 \x03(\x0b\x32\x18.proto.entity.DataFileOp\x12)\n\tcommit_op\x18\x05 \x01(\x0e\x32\x16.proto.entity.CommitOp\x12\x11\n\ttimestamp\x18\x06 \x01(\x03\x12\x11\n\tcommitted\x18\x07 \x01(\x08\x12\x0e\n\x06\x64omain\x18\x08 \x01(\t\"[\n\x0bTableNameId\x12\x12\n\ntable_name\x18\x01 \x01(\t\x12\x0f\n\x07tableId\x18\x02 \x01(\t\x12\x17\n\x0ftable_namespace\x18\x03 \x01(\t\x12\x0e\n\x06\x64omain\x18\x04 \x01(\t\"}\n\x19\x44iscardCompressedFileInfo\x12\x11\n\tfile_path\x18\x01 \x01(\t\x12\x12\n\ntable_path\x18\x02 \x01(\t\x12\x16\n\x0epartition_desc\x18\x03 \x01(\t\x12\x11\n\ttimestamp\x18\x04 \x01(\x03\x12\x0e\n\x06t_date\x18\x05 \x01(\t\"\\\n\x0bTablePathId\x12\x12\n\ntable_path\x18\x01 \x01(\t\x12\x10\n\x08table_id\x18\x02 \x01(\t\x12\x17\n\x0ftable_namespace\x18\x03 \x01(\t\x12\x0e\n\x06\x64omain\x18\x04 \x01(\t\"!\n\x04Uuid\x12\x0c\n\x04high\x18\x01 \x01(\x04\x12\x0b\n\x03low\x18\x02 \x01(\x04\"\x85\x03\n\nJniWrapper\x12*\n\tnamespace\x18\x01 \x03(\x0b\x32\x17.proto.entity.Namespace\x12+\n\ntable_info\x18\x02 \x03(\x0b\x32\x17.proto.entity.TableInfo\x12\x30\n\rtable_path_id\x18\x03 \x03(\x0b\x32\x19.proto.entity.TablePathId\x12\x30\n\rtable_name_id\x18\x04 \x03(\x0b\x32\x19.proto.entity.TableNameId\x12\x33\n\x0epartition_info\x18\x05 \x03(\x0b\x32\x1b.proto.entity.PartitionInfo\x12\x36\n\x10\x64\x61ta_commit_info\x18\x06 \x03(\x0b\x32\x1c.proto.entity.DataCommitInfo\x12M\n\x1c\x64iscard_compressed_file_info\x18\x07 \x03(\x0b\x32\'.proto.entity.DiscardCompressedFileInfo*g\n\x08\x43ommitOp\x12\x14\n\x10\x43ompactionCommit\x10\x00\x12\x10\n\x0c\x41ppendCommit\x10\x01\x12\x0f\n\x0bMergeCommit\x10\x02\x12\x10\n\x0cUpdateCommit\x10\x03\x12\x10\n\x0c\x44\x65leteCommit\x10\x04*\x1a\n\x06\x46ileOp\x12\x07\n\x03\x61\x64\x64\x10\x00\x12\x07\n\x03\x64\x65l\x10\x01\x42&\n\"com.dmetasoul.lakesoul.meta.entityP\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,30 +32,30 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'entity_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\"com.dmetasoul.lakesoul.meta.entityP\001'
-  _globals['_COMMITOP']._serialized_start=1760
-  _globals['_COMMITOP']._serialized_end=1863
-  _globals['_FILEOP']._serialized_start=1865
-  _globals['_FILEOP']._serialized_end=1891
+  _globals['_COMMITOP']._serialized_start=1834
+  _globals['_COMMITOP']._serialized_end=1937
+  _globals['_FILEOP']._serialized_start=1939
+  _globals['_FILEOP']._serialized_end=1965
   _globals['_METAINFO']._serialized_start=31
   _globals['_METAINFO']._serialized_end=197
   _globals['_TABLEINFO']._serialized_start=200
-  _globals['_TABLEINFO']._serialized_end=372
-  _globals['_PARTITIONINFO']._serialized_start=375
-  _globals['_PARTITIONINFO']._serialized_end=585
-  _globals['_NAMESPACE']._serialized_start=587
-  _globals['_NAMESPACE']._serialized_end=670
-  _globals['_DATAFILEOP']._serialized_start=672
-  _globals['_DATAFILEOP']._serialized_end=776
-  _globals['_DATACOMMITINFO']._serialized_start=779
-  _globals['_DATACOMMITINFO']._serialized_end=1017
-  _globals['_TABLENAMEID']._serialized_start=1019
-  _globals['_TABLENAMEID']._serialized_end=1110
-  _globals['_DISCARDCOMPRESSEDFILEINFO']._serialized_start=1112
-  _globals['_DISCARDCOMPRESSEDFILEINFO']._serialized_end=1237
-  _globals['_TABLEPATHID']._serialized_start=1239
-  _globals['_TABLEPATHID']._serialized_end=1331
-  _globals['_UUID']._serialized_start=1333
-  _globals['_UUID']._serialized_end=1366
-  _globals['_JNIWRAPPER']._serialized_start=1369
-  _globals['_JNIWRAPPER']._serialized_end=1758
+  _globals['_TABLEINFO']._serialized_end=446
+  _globals['_PARTITIONINFO']._serialized_start=449
+  _globals['_PARTITIONINFO']._serialized_end=659
+  _globals['_NAMESPACE']._serialized_start=661
+  _globals['_NAMESPACE']._serialized_end=744
+  _globals['_DATAFILEOP']._serialized_start=746
+  _globals['_DATAFILEOP']._serialized_end=850
+  _globals['_DATACOMMITINFO']._serialized_start=853
+  _globals['_DATACOMMITINFO']._serialized_end=1091
+  _globals['_TABLENAMEID']._serialized_start=1093
+  _globals['_TABLENAMEID']._serialized_end=1184
+  _globals['_DISCARDCOMPRESSEDFILEINFO']._serialized_start=1186
+  _globals['_DISCARDCOMPRESSEDFILEINFO']._serialized_end=1311
+  _globals['_TABLEPATHID']._serialized_start=1313
+  _globals['_TABLEPATHID']._serialized_end=1405
+  _globals['_UUID']._serialized_start=1407
+  _globals['_UUID']._serialized_end=1440
+  _globals['_JNIWRAPPER']._serialized_start=1443
+  _globals['_JNIWRAPPER']._serialized_end=1832
 # @@protoc_insertion_point(module_scope)

--- a/python/src/lakesoul/metadata/generated/entity_pb2.pyi
+++ b/python/src/lakesoul/metadata/generated/entity_pb2.pyi
@@ -37,12 +37,14 @@ class MetaInfo(_message.Message):
     def __init__(self, list_partition: _Optional[_Iterable[_Union[PartitionInfo, _Mapping]]] = ..., table_info: _Optional[_Union[TableInfo, _Mapping]] = ..., read_partition_info: _Optional[_Iterable[_Union[PartitionInfo, _Mapping]]] = ...) -> None: ...
 
 class TableInfo(_message.Message):
-    __slots__ = ("table_id", "table_namespace", "table_name", "table_path", "table_schema", "properties", "partitions", "domain")
+    __slots__ = ("table_id", "table_namespace", "table_name", "table_path", "table_schema", "table_schema_arrow_ipc", "table_schema_arrow_ipc_json_hash", "properties", "partitions", "domain")
     TABLE_ID_FIELD_NUMBER: _ClassVar[int]
     TABLE_NAMESPACE_FIELD_NUMBER: _ClassVar[int]
     TABLE_NAME_FIELD_NUMBER: _ClassVar[int]
     TABLE_PATH_FIELD_NUMBER: _ClassVar[int]
     TABLE_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    TABLE_SCHEMA_ARROW_IPC_FIELD_NUMBER: _ClassVar[int]
+    TABLE_SCHEMA_ARROW_IPC_JSON_HASH_FIELD_NUMBER: _ClassVar[int]
     PROPERTIES_FIELD_NUMBER: _ClassVar[int]
     PARTITIONS_FIELD_NUMBER: _ClassVar[int]
     DOMAIN_FIELD_NUMBER: _ClassVar[int]
@@ -51,10 +53,12 @@ class TableInfo(_message.Message):
     table_name: str
     table_path: str
     table_schema: str
+    table_schema_arrow_ipc: bytes
+    table_schema_arrow_ipc_json_hash: str
     properties: str
     partitions: str
     domain: str
-    def __init__(self, table_id: _Optional[str] = ..., table_namespace: _Optional[str] = ..., table_name: _Optional[str] = ..., table_path: _Optional[str] = ..., table_schema: _Optional[str] = ..., properties: _Optional[str] = ..., partitions: _Optional[str] = ..., domain: _Optional[str] = ...) -> None: ...
+    def __init__(self, table_id: _Optional[str] = ..., table_namespace: _Optional[str] = ..., table_name: _Optional[str] = ..., table_path: _Optional[str] = ..., table_schema: _Optional[str] = ..., table_schema_arrow_ipc: _Optional[bytes] = ..., table_schema_arrow_ipc_json_hash: _Optional[str] = ..., properties: _Optional[str] = ..., partitions: _Optional[str] = ..., domain: _Optional[str] = ...) -> None: ...
 
 class PartitionInfo(_message.Message):
     __slots__ = ("table_id", "partition_desc", "version", "commit_op", "timestamp", "snapshot", "expression", "domain")

--- a/python/src/metadata.rs
+++ b/python/src/metadata.rs
@@ -167,7 +167,8 @@ fn build_table_info(
     partitions: String,
     domain: String,
 ) -> PyResult<TableInfo> {
-    let schema_json = lakesoul_common::ser::arrow_java::schema_to_metadata_str(&table_schema.0);
+    let (schema_json, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash) =
+        lakesoul_common::ser::arrow_java::schema_to_metadata_parts(&table_schema.0);
     let table_path = if table_path.is_empty() {
         format!(
             "file://{}/{}/{}",
@@ -186,6 +187,8 @@ fn build_table_info(
         table_name,
         table_path,
         table_schema: schema_json,
+        table_schema_arrow_ipc,
+        table_schema_arrow_ipc_json_hash,
         properties,
         partitions,
         domain,

--- a/rust/lakesoul-common/Cargo.toml
+++ b/rust/lakesoul-common/Cargo.toml
@@ -11,7 +11,9 @@ version.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 arrow-schema = { workspace = true }
+arrow-ipc = { workspace = true }
 tracing.workspace = true
+md5 = "0.7.0"
 
 [lints]
 workspace = true

--- a/rust/lakesoul-common/src/ser/arrow_java.rs
+++ b/rust/lakesoul-common/src/ser/arrow_java.rs
@@ -17,8 +17,13 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use arrow_ipc::{
+    convert::try_schema_from_flatbuffer_bytes,
+    writer::{DictionaryTracker, IpcDataGenerator, IpcWriteOptions},
+};
 use arrow_schema::{
-    DataType, Field, FieldRef, Fields, IntervalUnit, Schema, SchemaRef, TimeUnit,
+    ArrowError, DataType, Field, FieldRef, Fields, IntervalUnit, Schema, SchemaRef,
+    TimeUnit,
 };
 use serde::Deserialize;
 
@@ -449,10 +454,19 @@ impl From<&FieldRef> for ArrowJavaField {
             DataType::Union(_, _) => todo!("Union type not supported"),
             DataType::Dictionary(_, _) => todo!("Dictionary type not supported"),
             DataType::RunEndEncoded(_, _) => todo!("RunEndEncoded type not supported"),
-            DataType::BinaryView => todo!("BinaryView type not supported"),
-            DataType::Utf8View => todo!("Utf8View type not supported"),
-            DataType::ListView(_) => todo!("ListView type not supported"),
-            DataType::LargeListView(_) => todo!("LargeListView type not supported"),
+
+            // View types are an Arrow in-memory layout optimization that Spark
+            // and Arrow Java 15 cannot consume as metadata. Keep table_schema
+            // Java-compatible and preserve exact view types in
+            // table_schema_arrow_ipc instead.
+            DataType::BinaryView => (ArrowJavaType::Binary, vec![]),
+            DataType::Utf8View => (ArrowJavaType::Utf8, vec![]),
+            DataType::ListView(field) => {
+                (ArrowJavaType::List, vec![ArrowJavaField::from(field)])
+            }
+            DataType::LargeListView(field) => {
+                (ArrowJavaType::LargeList, vec![ArrowJavaField::from(field)])
+            }
         };
         let nullable = field.is_nullable();
         ArrowJavaField {
@@ -640,6 +654,64 @@ impl From<ArrowJavaSchema> for SchemaRef {
 /// because Arrow Java's `Schema::fromJSON` cannot parse that representation.
 pub fn schema_to_metadata_str(schema: &Schema) -> String {
     serde_json::to_string(&ArrowJavaSchema::from(schema.clone())).unwrap()
+}
+
+/// Stable hash of the Java-compatible schema JSON stored in
+/// `table_info.table_schema`.
+pub fn schema_metadata_json_hash(schema_json: &str) -> String {
+    format!("{:x}", md5::compute(schema_json.as_bytes()))
+}
+
+/// Encode a full-fidelity Rust Arrow schema for
+/// `table_info.table_schema_arrow_ipc`.
+pub fn schema_to_metadata_ipc(schema: &Schema) -> Vec<u8> {
+    let mut dictionary_tracker = DictionaryTracker::new(false);
+    IpcDataGenerator::default()
+        .schema_to_bytes_with_dictionary_tracker(
+            schema,
+            &mut dictionary_tracker,
+            &IpcWriteOptions::default(),
+        )
+        .ipc_message
+}
+
+/// Decode full-fidelity schema IPC from `table_info.table_schema_arrow_ipc`.
+pub fn schema_from_metadata_ipc(bytes: &[u8]) -> Result<Schema, ArrowError> {
+    try_schema_from_flatbuffer_bytes(bytes)
+}
+
+/// Produce all schema metadata fields for a table_info write.
+pub fn schema_to_metadata_parts(schema: &Schema) -> (String, Vec<u8>, String) {
+    let schema_json = schema_to_metadata_str(schema);
+    let schema_ipc = schema_to_metadata_ipc(schema);
+    let schema_ipc_json_hash = schema_metadata_json_hash(&schema_json);
+    (schema_json, schema_ipc, schema_ipc_json_hash)
+}
+
+/// Decode schema from table_info, preferring full-fidelity IPC when it is
+/// present and still matches `table_schema`.
+pub fn schema_from_table_info_metadata(
+    schema_json: &str,
+    schema_ipc: &[u8],
+    schema_ipc_json_hash: &str,
+) -> Result<Schema, serde_json::Error> {
+    if !schema_ipc.is_empty() {
+        let expected_hash = schema_metadata_json_hash(schema_json);
+        if schema_ipc_json_hash == expected_hash {
+            match schema_from_metadata_ipc(schema_ipc) {
+                Ok(schema) => return Ok(schema),
+                Err(e) => tracing::warn!(
+                    "deserialize Arrow IPC schema failed, fallback to table_schema JSON: {e}"
+                ),
+            }
+        } else {
+            tracing::warn!(
+                "table_schema_arrow_ipc hash mismatch, fallback to table_schema JSON"
+            );
+        }
+    }
+
+    schema_from_metadata_str(schema_json)
 }
 
 /// Decode schema JSON from `table_info.table_schema`.
@@ -845,6 +917,49 @@ mod tests {
         assert!(json.contains(r#""name":"largebinary""#));
         assert!(json.contains(r#""name":"largelist""#));
         assert_eq!(parsed, schema);
+    }
+
+    #[test]
+    fn view_types_are_compatible_in_json_and_lossless_in_ipc() {
+        let schema = Schema::new(vec![
+            Field::new("text", DataType::Utf8View, true),
+            Field::new("bytes", DataType::BinaryView, true),
+            Field::new(
+                "items",
+                DataType::ListView(Arc::new(Field::new(
+                    "item",
+                    DataType::Utf8View,
+                    true,
+                ))),
+                true,
+            ),
+        ]);
+
+        let (schema_json, schema_ipc, schema_hash) = schema_to_metadata_parts(&schema);
+        let parsed_json = schema_from_metadata_str(&schema_json).unwrap();
+        let parsed_ipc =
+            schema_from_table_info_metadata(&schema_json, &schema_ipc, &schema_hash)
+                .unwrap();
+        let parsed_stale_ipc =
+            schema_from_table_info_metadata(&schema_json, &schema_ipc, "stale-hash")
+                .unwrap();
+
+        assert!(schema_json.contains(r#""name":"utf8""#));
+        assert!(schema_json.contains(r#""name":"binary""#));
+        assert!(schema_json.contains(r#""name":"list""#));
+        assert!(!schema_json.contains("utf8view"));
+        assert_eq!(
+            parsed_json.field_with_name("text").unwrap().data_type(),
+            &DataType::Utf8
+        );
+        assert_eq!(
+            parsed_stale_ipc
+                .field_with_name("text")
+                .unwrap()
+                .data_type(),
+            &DataType::Utf8
+        );
+        assert_eq!(parsed_ipc, schema);
     }
 
     #[test]

--- a/rust/lakesoul-datafusion/src/catalog/mod.rs
+++ b/rust/lakesoul-datafusion/src/catalog/mod.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 
 use crate::Result;
 use crate::lakesoul_table::helpers::create_io_config_builder_from_table_info;
-use lakesoul_common::ser::arrow_java::ArrowJavaSchema;
+use lakesoul_common::ser::arrow_java::schema_to_metadata_parts;
 
 pub mod lakesoul_catalog;
 //  used in catalog_test, but still say unused_imports, I think it is a bug about rust-lint.
@@ -94,6 +94,10 @@ pub(crate) async fn create_table(
     config: LakeSoulIOConfig,
 ) -> Result<()> {
     debug!("create_table: {:?}", &table_name);
+    let target_schema = config.target_schema();
+    let (table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash) =
+        schema_to_metadata_parts(target_schema.as_ref());
+
     client
         .create_table(TableInfo {
             table_id: format!("table_{}", uuid::Uuid::new_v4()),
@@ -106,9 +110,9 @@ pub(crate) async fn create_table(
                     .ok_or(report!("can not get $TMPDIR"))?,
                 table_name
             ),
-            table_schema: serde_json::to_string::<ArrowJavaSchema>(
-                &config.target_schema().into(),
-            )?,
+            table_schema,
+            table_schema_arrow_ipc,
+            table_schema_arrow_ipc_json_hash,
             table_namespace: "default".to_string(),
             properties: serde_json::to_string(&LakeSoulTableProperty {
                 hash_bucket_num: Some(String::from("4")),

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -72,7 +72,9 @@ use crate::lakesoul_table::helpers::{
     create_io_config_builder_from_table_info, listing_partition_info,
     parse_partitions_for_partition_desc, prune_partitions,
 };
-use lakesoul_common::ser::arrow_java::{ArrowJavaSchema, schema_from_metadata_str};
+use lakesoul_common::ser::arrow_java::{
+    schema_from_table_info_metadata, schema_to_metadata_parts,
+};
 
 use super::file_format::LakeSoulMetaDataParquetFormat;
 
@@ -193,8 +195,11 @@ impl LakeSoulTableProvider {
         table_info: Arc<TableInfo>,
         as_sink: bool,
     ) -> Result<Self> {
-        let logical_schema =
-            Arc::new(schema_from_metadata_str(&table_info.table_schema)?);
+        let logical_schema = Arc::new(schema_from_table_info_metadata(
+            &table_info.table_schema,
+            &table_info.table_schema_arrow_ipc,
+            &table_info.table_schema_arrow_ipc_json_hash,
+        )?);
         let (range_partitions, hash_partitions) =
             parse_table_info_partitions(&table_info.partitions)?;
         let (file_schema, scan_schema) =
@@ -303,13 +308,16 @@ impl LakeSoulTableProvider {
         let (file_schema, scan_schema) =
             Self::split_schemas(logical_schema.clone(), &range_partitions)?;
 
+        let (table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash) =
+            schema_to_metadata_parts(logical_schema.as_ref());
+
         let table_info = Arc::new(TableInfo {
             table_id: format!("table_{}", uuid::Uuid::new_v4()),
             table_namespace: cmd.name.schema().unwrap_or("default").to_string(),
             table_name: case_fold_table_name(cmd.name.table()),
-            table_schema: serde_json::to_string::<ArrowJavaSchema>(
-                &logical_schema.clone().into(),
-            )?,
+            table_schema,
+            table_schema_arrow_ipc,
+            table_schema_arrow_ipc_json_hash,
             properties: serde_json::to_string(&LakeSoulTableProperty {
                 hash_bucket_num: if primary_keys.is_empty() {
                     None

--- a/rust/lakesoul-datafusion/src/lakesoul_table/helpers.rs
+++ b/rust/lakesoul-datafusion/src/lakesoul_table/helpers.rs
@@ -28,7 +28,7 @@ use proto::proto::entity::{PartitionInfo, TableInfo};
 use url::Url;
 
 use crate::Result;
-use lakesoul_common::ser::arrow_java::schema_from_metadata_str;
+use lakesoul_common::ser::arrow_java::schema_from_table_info_metadata;
 
 use crate::catalog::{LakeSoulTableProperty, parse_table_info_partitions};
 
@@ -51,8 +51,10 @@ pub(crate) fn create_io_config_builder_from_table_info(
     let dynamic_partition = hash_partitions.len() + range_partitions.len() > 0;
 
     let mut builder = LakeSoulIOConfigBuilder::new()
-        .with_schema(Arc::new(schema_from_metadata_str(
+        .with_schema(Arc::new(schema_from_table_info_metadata(
             &table_info.table_schema,
+            &table_info.table_schema_arrow_ipc,
+            &table_info.table_schema_arrow_ipc_json_hash,
         )?))
         .with_prefix(table_info.table_path.clone())
         .with_primary_keys(hash_partitions)

--- a/rust/lakesoul-datafusion/src/lakesoul_table/mod.rs
+++ b/rust/lakesoul-datafusion/src/lakesoul_table/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     },
     planner::query_planner::LakeSoulQueryPlanner,
 };
-use lakesoul_common::ser::arrow_java::schema_from_metadata_str;
+use lakesoul_common::ser::arrow_java::schema_from_table_info_metadata;
 
 pub mod helpers;
 
@@ -114,7 +114,11 @@ impl LakeSoulTable {
         client: MetaDataClientRef,
         table_info: TableInfo,
     ) -> Result<Self> {
-        let table_schema = Arc::new(schema_from_metadata_str(&table_info.table_schema)?);
+        let table_schema = Arc::new(schema_from_table_info_metadata(
+            &table_info.table_schema,
+            &table_info.table_schema_arrow_ipc,
+            &table_info.table_schema_arrow_ipc_json_hash,
+        )?);
 
         let table_name = table_info.table_name.clone();
         let properties =

--- a/rust/lakesoul-datafusion/src/lib.rs
+++ b/rust/lakesoul-datafusion/src/lib.rs
@@ -29,6 +29,7 @@ use url::Url;
 use crate::planner::LakeSoulQueryPlanner;
 
 // re export
+pub use datafusion::*;
 pub use lakesoul_common::ser;
 pub use lakesoul_metadata::{MetaDataClient, MetaDataClientRef};
 

--- a/rust/lakesoul-datafusion/src/tests/catalog_tests.rs
+++ b/rust/lakesoul-datafusion/src/tests/catalog_tests.rs
@@ -22,7 +22,7 @@ use crate::catalog::{LakeSoulCatalog, LakeSoulNamespace, LakeSoulTableProperty};
 use crate::cli::CoreArgs;
 use crate::create_lakesoul_session_ctx;
 use crate::lakesoul_table::LakeSoulTable;
-use lakesoul_common::ser::arrow_java::ArrowJavaSchema;
+use lakesoul_common::ser::arrow_java::schema_to_metadata_parts;
 
 fn create_batch_i32(names: Vec<&str>, values: Vec<&[i32]>) -> RecordBatch {
     let values = values
@@ -65,7 +65,7 @@ fn random_tables(
 ) -> Vec<(Namespace, Vec<TableInfo>)> {
     let mut ret = Vec::with_capacity(nps.len());
     let rng = &mut rand::rng();
-    let schema = serde_json::to_string::<ArrowJavaSchema>(&schema.into()).unwrap();
+    let (schema, schema_ipc, schema_hash) = schema_to_metadata_parts(schema.as_ref());
     for np in nps {
         let n = rng.random_range(1usize..10);
         let mut v = Vec::with_capacity(n);
@@ -99,6 +99,8 @@ fn random_tables(
                 table_name,
                 table_path: format!("file://{}", path.clone()),
                 table_schema: schema.clone(),
+                table_schema_arrow_ipc: schema_ipc.clone(),
+                table_schema_arrow_ipc_json_hash: schema_hash.clone(),
                 properties: np.properties.clone(),
                 partitions: ";range,hash".to_string(),
                 domain: np.domain.clone(),

--- a/rust/lakesoul-datafusion/src/tests/vortex_catalog_tests.rs
+++ b/rust/lakesoul-datafusion/src/tests/vortex_catalog_tests.rs
@@ -25,7 +25,7 @@ use crate::catalog::{
 use crate::cli::CoreArgs;
 use crate::create_lakesoul_session_ctx;
 use crate::lakesoul_table::LakeSoulTable;
-use crate::ser::arrow_java::ArrowJavaSchema;
+use crate::ser::arrow_java::schema_to_metadata_parts;
 
 fn test_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
@@ -140,6 +140,10 @@ async fn create_cdc_table(client: MetaDataClientRef, table_name: &str) -> Result
         .with_option(OPTION_KEY_STABLE_SORT, "true")
         .build();
 
+    let target_schema = io_config.target_schema();
+    let (table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash) =
+        schema_to_metadata_parts(target_schema.as_ref());
+
     client
         .create_table(TableInfo {
             table_id: format!("table_{}", uuid::Uuid::new_v4()),
@@ -149,9 +153,9 @@ async fn create_cdc_table(client: MetaDataClientRef, table_name: &str) -> Result
                 std::env::current_dir()?.to_string_lossy(),
                 table_name
             ),
-            table_schema: serde_json::to_string::<ArrowJavaSchema>(
-                &io_config.target_schema().into(),
-            )?,
+            table_schema,
+            table_schema_arrow_ipc,
+            table_schema_arrow_ipc_json_hash,
             table_namespace: "default".to_string(),
             properties: serde_json::to_string(&LakeSoulTableProperty {
                 hash_bucket_num: Some(String::from("4")),

--- a/rust/lakesoul-flight/src/flight_sql_service.rs
+++ b/rust/lakesoul-flight/src/flight_sql_service.rs
@@ -46,7 +46,7 @@ use lakesoul_datafusion::catalog::LakeSoulTableProperty;
 use lakesoul_datafusion::create_lakesoul_session_ctx;
 use lakesoul_datafusion::lakesoul_table::LakeSoulTable;
 use lakesoul_datafusion::lakesoul_table::helpers::case_fold_column_name;
-use lakesoul_datafusion::ser::arrow_java::schema_from_metadata_str;
+use lakesoul_datafusion::ser::arrow_java::schema_from_table_info_metadata;
 use lakesoul_io::helpers::get_batch_memory_size;
 use lakesoul_io::writer::async_writer::FlushOutput;
 use lakesoul_metadata::MetaDataClientRef;
@@ -529,8 +529,13 @@ impl FlightSqlService for FlightSqlServiceImpl {
         if let Some(table_info) = table_info {
             info!("get_flight_info_primary_keys table_info: {:?}", table_info);
             let schema = Arc::new(
-                schema_from_metadata_str(&table_info.table_schema).map_err(|e| {
-                    Status::internal(format!("arrow java schema json parse error: {}", e))
+                schema_from_table_info_metadata(
+                    &table_info.table_schema,
+                    &table_info.table_schema_arrow_ipc,
+                    &table_info.table_schema_arrow_ipc_json_hash,
+                )
+                .map_err(|e| {
+                    Status::internal(format!("arrow schema parse error: {}", e))
                 })?,
             );
             info!("get_flight_info_primary_keys schema: {:?}", schema);

--- a/rust/lakesoul-io-c/src/lib.rs
+++ b/rust/lakesoul-io-c/src/lib.rs
@@ -22,6 +22,9 @@ use arrow_schema::{Schema, SchemaRef};
 use datafusion_substrait::substrait::proto::Plan;
 use lakesoul_io::config::{LakeSoulIOConfig, LakeSoulIOConfigBuilder};
 use lakesoul_io::helpers;
+use lakesoul_io::helpers::transform::{
+    normalize_record_batch_for_java, normalize_schema_for_java,
+};
 use lakesoul_io::reader::{LakeSoulReader, SyncSendableMutableLakeSoulReader};
 use lakesoul_io::writer::SyncSendableMutableLakeSoulWriter;
 use prost::Message;
@@ -811,6 +814,37 @@ pub unsafe extern "C" fn start_reader_with_data(
     }
 }
 
+fn export_record_batch_for_java(
+    batch: RecordBatch,
+    array_addr: c_ptrdiff_t,
+    schema_addr: Option<c_ptrdiff_t>,
+) -> std::result::Result<i32, String> {
+    let batch = normalize_record_batch_for_java(batch).map_err(|e| e.to_string())?;
+    let rows = batch.num_rows() as i32;
+    let batch: Arc<StructArray> = Arc::new(batch.into());
+    let schema = schema_addr
+        .map(|_| FFI_ArrowSchema::try_from(batch.data_type()))
+        .transpose()
+        .map_err(|e| e.to_string())?;
+
+    let ffi_array = FFI_ArrowArray::new(&batch.to_data());
+    unsafe {
+        (&ffi_array as *const FFI_ArrowArray)
+            .copy_to(array_addr as *mut FFI_ArrowArray, 1);
+    }
+    std::mem::forget(ffi_array);
+
+    if let (Some(schema_addr), Some(schema)) = (schema_addr, schema) {
+        unsafe {
+            (&schema as *const FFI_ArrowSchema)
+                .copy_to(schema_addr as *mut FFI_ArrowSchema, 1);
+        }
+        std::mem::forget(schema);
+    }
+
+    Ok(rows)
+}
+
 /// Call [`SyncSendableMutableLakeSoulReader::next_rb_callback`] of the [`Reader`]
 ///
 /// # Safety
@@ -843,25 +877,16 @@ pub unsafe extern "C" fn next_record_batch(
                     );
                 }
                 Ok(rb) => {
-                    let rows = rb.num_rows() as i32;
-                    let batch: Arc<StructArray> = Arc::new(rb.into());
-                    let ffi_array = FFI_ArrowArray::new(&batch.to_data());
-                    (&ffi_array as *const FFI_ArrowArray)
-                        .copy_to(array_addr as *mut FFI_ArrowArray, 1);
-                    std::mem::forget(ffi_array);
-                    let schema_result = FFI_ArrowSchema::try_from(batch.data_type());
-                    match schema_result {
-                        Ok(schema) => {
-                            (&schema as *const FFI_ArrowSchema)
-                                .copy_to(schema_addr as *mut FFI_ArrowSchema, 1);
-                            std::mem::forget(schema);
+                    match export_record_batch_for_java(rb, array_addr, Some(schema_addr))
+                    {
+                        Ok(rows) => {
                             call_i32_result_callback(callback, rows, std::ptr::null());
                         }
                         Err(e) => {
                             call_i32_result_callback(
                                 callback,
                                 -1,
-                                CString::new(e.to_string()).unwrap().into_raw(),
+                                CString::new(e).unwrap().into_raw(),
                             );
                         }
                     }
@@ -893,15 +918,10 @@ pub unsafe extern "C" fn next_record_batch_blocked(
             None => (0, std::ptr::null()),
             Some(rb_result) => match rb_result {
                 Err(e) => (-1, CString::new(e.to_string()).unwrap().into_raw()),
-                Ok(rb) => {
-                    let rows = rb.num_rows() as i32;
-                    let batch: Arc<StructArray> = Arc::new(rb.into());
-                    let ffi_array = FFI_ArrowArray::new(&batch.to_data());
-                    (&ffi_array as *const FFI_ArrowArray)
-                        .copy_to(array_addr as *mut FFI_ArrowArray, 1);
-                    std::mem::forget(ffi_array);
-                    (rows, std::ptr::null())
-                }
+                Ok(rb) => match export_record_batch_for_java(rb, array_addr, None) {
+                    Ok(rows) => (rows, std::ptr::null()),
+                    Err(e) => (-1, CString::new(e).unwrap().into_raw()),
+                },
             },
         };
         convert_to_nonnull(CStatus { status, err })
@@ -954,18 +974,9 @@ pub unsafe extern "C" fn next_record_batch_with_data(
                     );
                 }
                 Ok(rb) => {
-                    let rows = rb.num_rows() as i32;
-                    let batch: Arc<StructArray> = Arc::new(rb.into());
-                    let ffi_array = FFI_ArrowArray::new(&batch.to_data());
-                    (&ffi_array as *const FFI_ArrowArray)
-                        .copy_to(array_addr as *mut FFI_ArrowArray, 1);
-                    std::mem::forget(ffi_array);
-                    let schema_result = FFI_ArrowSchema::try_from(batch.data_type());
-                    match schema_result {
-                        Ok(schema) => {
-                            (&schema as *const FFI_ArrowSchema)
-                                .copy_to(schema_addr as *mut FFI_ArrowSchema, 1);
-                            std::mem::forget(schema);
+                    match export_record_batch_for_java(rb, array_addr, Some(schema_addr))
+                    {
+                        Ok(rows) => {
                             call_i32_data_result_callback(
                                 callback,
                                 rows,
@@ -977,7 +988,7 @@ pub unsafe extern "C" fn next_record_batch_with_data(
                             call_i32_data_result_callback(
                                 callback,
                                 -1,
-                                CString::new(e.to_string()).unwrap().into_raw(),
+                                CString::new(e).unwrap().into_raw(),
                                 data,
                             );
                         }
@@ -1008,6 +1019,7 @@ pub unsafe extern "C" fn lakesoul_reader_get_schema(
             .as_ref()
             .get_schema()
             .unwrap_or_else(|| Arc::new(Schema::empty()));
+        let schema = normalize_schema_for_java(schema.as_ref());
         let schema_addr = schema_addr as *mut FFI_ArrowSchema;
         let _ = FFI_ArrowSchema::try_from(schema.as_ref()).map(|s| {
             std::ptr::write_unaligned(schema_addr, s);

--- a/rust/lakesoul-io/src/file_format.rs
+++ b/rust/lakesoul-io/src/file_format.rs
@@ -34,7 +34,7 @@ use object_store::{ObjectMeta, ObjectStore};
 use parquet::arrow::parquet_to_arrow_schema;
 use rootcause::compat::boxed_error::IntoBoxedError;
 use rootcause::{Report, bail, report};
-use vortex_datafusion::VortexFormat;
+use vortex_datafusion::{VortexFormat, VortexTableOptions};
 
 use crate::Result;
 use crate::config::LakeSoulIOConfig;
@@ -103,7 +103,16 @@ impl LakeSoulFormatRegistry {
             ),
             io_config,
         ));
-        let vortex = Arc::new(VortexFormat::new(VortexSession::default()));
+        let opts = {
+            let mut opts = VortexTableOptions::default();
+            opts.projection_pushdown = true;
+            opts.predicate_pushdown = true;
+            opts
+        };
+        let vortex = Arc::new(VortexFormat::new_with_options(
+            VortexSession::default(),
+            opts,
+        ));
 
         Ok(Self { parquet, vortex })
     }

--- a/rust/lakesoul-io/src/helpers/transform.rs
+++ b/rust/lakesoul-io/src/helpers/transform.rs
@@ -27,6 +27,7 @@ use arrow_array::{
 };
 use arrow_schema::{
     DataType, Field, FieldRef, Fields, Schema, SchemaBuilder, SchemaRef, TimeUnit,
+    UnionFields,
 };
 use datafusion_common::DataFusionError;
 use rootcause::{bail, report};
@@ -72,6 +73,138 @@ pub fn uniform_record_batch(batch: RecordBatch) -> Result<RecordBatch> {
         false,
         Arc::new(Default::default()),
     )
+}
+
+pub fn normalize_data_type_for_java(data_type: &DataType) -> DataType {
+    match data_type {
+        DataType::Utf8View => DataType::Utf8,
+        DataType::BinaryView => DataType::Binary,
+        DataType::ListView(field) => DataType::List(normalize_field_for_java(field)),
+        DataType::LargeListView(field) => {
+            DataType::LargeList(normalize_field_for_java(field))
+        }
+        DataType::List(field) => DataType::List(normalize_field_for_java(field)),
+        DataType::LargeList(field) => {
+            DataType::LargeList(normalize_field_for_java(field))
+        }
+        DataType::FixedSizeList(field, size) => {
+            DataType::FixedSizeList(normalize_field_for_java(field), *size)
+        }
+        DataType::Struct(fields) => DataType::Struct(Fields::from(
+            fields
+                .iter()
+                .map(normalize_field_for_java)
+                .collect::<Vec<_>>(),
+        )),
+        DataType::Map(field, sorted) => {
+            DataType::Map(normalize_field_for_java(field), *sorted)
+        }
+        DataType::Dictionary(key, value) => DataType::Dictionary(
+            Box::new(normalize_data_type_for_java(key)),
+            Box::new(normalize_data_type_for_java(value)),
+        ),
+        DataType::Union(fields, mode) => DataType::Union(
+            fields
+                .iter()
+                .map(|(type_id, field)| (type_id, normalize_field_for_java(field)))
+                .collect::<UnionFields>(),
+            *mode,
+        ),
+        DataType::RunEndEncoded(run_ends, values) => DataType::RunEndEncoded(
+            normalize_field_for_java(run_ends),
+            normalize_field_for_java(values),
+        ),
+        _ => data_type.clone(),
+    }
+}
+
+pub fn normalize_field_for_java(field: &FieldRef) -> FieldRef {
+    Arc::new(
+        Field::new(
+            field.name(),
+            normalize_data_type_for_java(field.data_type()),
+            field.is_nullable(),
+        )
+        .with_metadata(field.metadata().clone()),
+    )
+}
+
+pub fn normalize_schema_for_java(schema: &Schema) -> SchemaRef {
+    Arc::new(Schema::new_with_metadata(
+        schema
+            .fields()
+            .iter()
+            .map(normalize_field_for_java)
+            .collect::<Vec<_>>(),
+        schema.metadata().clone(),
+    ))
+}
+
+fn data_type_needs_java_normalization(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Utf8View
+        | DataType::BinaryView
+        | DataType::ListView(_)
+        | DataType::LargeListView(_) => true,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _) => {
+            data_type_needs_java_normalization(field.data_type())
+        }
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| data_type_needs_java_normalization(field.data_type())),
+        DataType::Dictionary(key, value) => {
+            data_type_needs_java_normalization(key)
+                || data_type_needs_java_normalization(value)
+        }
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, field)| data_type_needs_java_normalization(field.data_type())),
+        DataType::RunEndEncoded(run_ends, values) => {
+            data_type_needs_java_normalization(run_ends.data_type())
+                || data_type_needs_java_normalization(values.data_type())
+        }
+        _ => false,
+    }
+}
+
+pub fn schema_needs_java_normalization(schema: &Schema) -> bool {
+    schema
+        .fields()
+        .iter()
+        .any(|field| data_type_needs_java_normalization(field.data_type()))
+}
+
+pub fn normalize_record_batch_for_java(batch: RecordBatch) -> Result<RecordBatch> {
+    if !schema_needs_java_normalization(batch.schema().as_ref()) {
+        return Ok(batch);
+    }
+
+    let num_rows = batch.num_rows();
+    let normalized_schema = normalize_schema_for_java(batch.schema().as_ref());
+    let columns = batch
+        .columns()
+        .iter()
+        .zip(normalized_schema.fields().iter())
+        .map(|(array, field)| {
+            transform_array(
+                field.name().to_string(),
+                field.data_type().clone(),
+                array.clone(),
+                num_rows,
+                false,
+                Arc::new(HashMap::new()),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(RecordBatch::try_new_with_options(
+        normalized_schema,
+        columns,
+        &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+    )?)
 }
 
 pub fn transform_schema(
@@ -500,7 +633,8 @@ pub fn make_default_array(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::StringViewArray;
+    use arrow_array::builder::{ListViewBuilder, StringViewBuilder};
+    use arrow_array::{ListArray, StringViewArray};
 
     #[test]
     fn transform_record_batch_materializes_utf8_view_as_utf8() {
@@ -538,5 +672,84 @@ mod tests {
         assert_eq!(values.value(1), "bbb");
         assert!(values.is_null(2));
         assert_eq!(values.value(3), "long string over twelve bytes");
+    }
+
+    #[test]
+    fn normalize_record_batch_for_java_materializes_nested_view_types() {
+        let top_text: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("abc"),
+            Some("database-system"),
+        ]));
+
+        let nested_text: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("nested"),
+            Some("long nested string"),
+        ]));
+        let nested_fields =
+            Fields::from(vec![Arc::new(Field::new("name", DataType::Utf8View, true))]);
+        let nested_struct: ArrayRef = Arc::new(StructArray::new(
+            nested_fields.clone(),
+            vec![nested_text],
+            None,
+        ));
+
+        let item_field = Arc::new(Field::new("item", DataType::Utf8View, true));
+        let mut list_builder =
+            ListViewBuilder::new(StringViewBuilder::new()).with_field(item_field.clone());
+        list_builder.append_value([Some("x"), Some("long list value")]);
+        list_builder.append_null();
+        let list_view: ArrayRef = Arc::new(list_builder.finish());
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("top_text", DataType::Utf8View, true),
+            Field::new("nested", DataType::Struct(nested_fields), true),
+            Field::new("items", DataType::ListView(item_field), true),
+        ]));
+        let batch =
+            RecordBatch::try_new(schema, vec![top_text, nested_struct, list_view])
+                .unwrap();
+
+        let normalized = normalize_record_batch_for_java(batch).unwrap();
+
+        assert_eq!(normalized.schema().field(0).data_type(), &DataType::Utf8);
+        assert_eq!(normalized.column(0).data_type(), &DataType::Utf8);
+        let top_values = normalized
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(top_values.value_offsets(), &[0, 3, 18]);
+        assert_eq!(top_values.value_data().as_ref(), b"abcdatabase-system");
+
+        match normalized.schema().field(1).data_type() {
+            DataType::Struct(fields) => {
+                assert_eq!(fields[0].data_type(), &DataType::Utf8);
+            }
+            other => panic!("expected struct, got {other:?}"),
+        }
+        let struct_values = normalized
+            .column(1)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(struct_values.column(0).data_type(), &DataType::Utf8);
+
+        match normalized.schema().field(2).data_type() {
+            DataType::List(field) => {
+                assert_eq!(field.data_type(), &DataType::Utf8);
+            }
+            other => panic!("expected list, got {other:?}"),
+        }
+        let list_values = normalized
+            .column(2)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        assert_eq!(
+            list_values.data_type(),
+            normalized.schema().field(2).data_type()
+        );
+        assert!(list_values.is_null(1));
+        assert_eq!(list_values.value(0).data_type(), &DataType::Utf8);
     }
 }

--- a/rust/lakesoul-io/src/helpers/transform.rs
+++ b/rust/lakesoul-io/src/helpers/transform.rs
@@ -719,7 +719,7 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(top_values.value_offsets(), &[0, 3, 18]);
-        assert_eq!(top_values.value_data().as_ref(), b"abcdatabase-system");
+        assert_eq!(top_values.value_data(), b"abcdatabase-system");
 
         match normalized.schema().field(1).data_type() {
             DataType::Struct(fields) => {

--- a/rust/lakesoul-metadata/src/lib.rs
+++ b/rust/lakesoul-metadata/src/lib.rs
@@ -341,21 +341,21 @@ async fn get_prepared_statement<'a>(
 
         // Select TableInfo
         DaoType::SelectTableInfoByTableId =>
-            "select table_id, table_name, table_path, table_schema, properties, partitions, table_namespace, domain
-            from table_info
-            where table_id = $1::TEXT",
-        DaoType::SelectTableInfoByTableNameAndNameSpace =>
-            "select table_id, table_name, table_path, table_schema, properties, partitions, table_namespace, domain
-            from table_info
-            where table_name = $1::TEXT and table_namespace=$2::TEXT",
-        DaoType::SelectTableInfoByTablePath =>
-            "select table_id, table_name, table_path, table_schema, properties, partitions, table_namespace, domain
-            from table_info
-            where table_path = $1::TEXT",
-        DaoType::SelectTableInfoByIdAndTablePath =>
-            "select table_id, table_name, table_path, table_schema, properties, partitions, table_namespace, domain
-            from table_info
-            where table_id = $1::TEXT and table_path=$2::TEXT",
+                    "select table_id, table_name, table_path, table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash, properties, partitions, table_namespace, domain
+                    from table_info
+                    where table_id = $1::TEXT",
+                DaoType::SelectTableInfoByTableNameAndNameSpace =>
+                    "select table_id, table_name, table_path, table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash, properties, partitions, table_namespace, domain
+                    from table_info
+                    where table_name = $1::TEXT and table_namespace=$2::TEXT",
+                DaoType::SelectTableInfoByTablePath =>
+                    "select table_id, table_name, table_path, table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash, properties, partitions, table_namespace, domain
+                    from table_info
+                    where table_path = $1::TEXT",
+                DaoType::SelectTableInfoByIdAndTablePath =>
+                    "select table_id, table_name, table_path, table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash, properties, partitions, table_namespace, domain
+                    from table_info
+                    where table_id = $1::TEXT and table_path=$2::TEXT",
 
         // Select PartitionInfo
         DaoType::SelectPartitionVersionByTableIdAndDescAndVersion =>
@@ -442,11 +442,13 @@ async fn get_prepared_statement<'a>(
                 table_name,
                 table_path,
                 table_schema,
+                table_schema_arrow_ipc,
+                table_schema_arrow_ipc_json_hash,
                 properties,
                 partitions,
                 table_namespace,
                 domain)
-            values($1::TEXT, $2::TEXT, $3::TEXT, $4::TEXT, $5::JSON, $6::TEXT, $7::TEXT, $8::TEXT)",
+            values($1::TEXT, $2::TEXT, $3::TEXT, $4::TEXT, $5::BYTEA, $6::TEXT, $7::JSON, $8::TEXT, $9::TEXT, $10::TEXT)",
         DaoType::InsertTableNameId =>
             "insert into table_name_id(
                 table_id,
@@ -994,10 +996,16 @@ pub async fn execute_query(
                     table_name: row.get(1),
                     table_path: row.get(2),
                     table_schema: row.get(3),
-                    properties: row.get::<_, serde_json::Value>(4).to_string(),
-                    partitions: row.get(5),
-                    table_namespace: row.get(6),
-                    domain: row.get(7),
+                    table_schema_arrow_ipc: row
+                        .get::<_, Option<Vec<u8>>>(4)
+                        .unwrap_or_default(),
+                    table_schema_arrow_ipc_json_hash: row
+                        .get::<_, Option<String>>(5)
+                        .unwrap_or_default(),
+                    properties: row.get::<_, serde_json::Value>(6).to_string(),
+                    partitions: row.get(7),
+                    table_namespace: row.get(8),
+                    domain: row.get(9),
                 })
                 .collect();
             entity::JniWrapper {
@@ -1134,6 +1142,12 @@ pub async fn execute_insert(
             let table_info = wrapper.table_info.first().unwrap();
             let properties: serde_json::Value =
                 serde_json::from_str(&table_info.properties)?;
+            let table_schema_arrow_ipc: Option<&[u8]> =
+                (!table_info.table_schema_arrow_ipc.is_empty())
+                    .then_some(table_info.table_schema_arrow_ipc.as_slice());
+            let table_schema_arrow_ipc_json_hash: Option<&str> =
+                (!table_info.table_schema_arrow_ipc_json_hash.is_empty())
+                    .then_some(table_info.table_schema_arrow_ipc_json_hash.as_str());
             client
                 .execute(
                     &statement,
@@ -1142,6 +1156,8 @@ pub async fn execute_insert(
                         &table_info.table_name,
                         &table_info.table_path,
                         &table_info.table_schema,
+                        &table_schema_arrow_ipc,
+                        &table_schema_arrow_ipc_json_hash,
                         &properties,
                         &table_info.partitions,
                         &table_info.table_namespace,
@@ -1561,7 +1577,11 @@ pub async fn execute_update(
                 if idx > 2 {
                     statement += ",";
                 }
-                statement += format!("table_schema = ${}::TEXT ", idx).as_str();
+                statement += format!(
+                    "table_schema = ${}::TEXT, table_schema_arrow_ipc = NULL, table_schema_arrow_ipc_json_hash = NULL ",
+                    idx
+                )
+                .as_str();
                 idx += 1;
                 filter_params.push(params[3].clone());
             }
@@ -1780,6 +1800,8 @@ mod tests {
             table_name: "test_table_name".to_owned(),
             table_path: "test_table_path".to_owned(),
             table_schema: "StructType {}".to_owned(),
+            table_schema_arrow_ipc: vec![],
+            table_schema_arrow_ipc_json_hash: String::new(),
             properties: "{}".to_owned(),
             partitions: "".to_owned(),
             domain: "public".to_owned(),

--- a/rust/lakesoul-metadata/src/rbac.rs
+++ b/rust/lakesoul-metadata/src/rbac.rs
@@ -87,6 +87,8 @@ mod tests {
             table_name: table_name.to_string(),
             table_path: path.to_string(),
             table_schema: String::new(),
+            table_schema_arrow_ipc: vec![],
+            table_schema_arrow_ipc_json_hash: String::new(),
             table_namespace: "default".to_string(),
             properties: "{}".to_string(),
             partitions: "id;range".to_string(),

--- a/rust/lakesoul-s3-proxy/src/main.rs
+++ b/rust/lakesoul-s3-proxy/src/main.rs
@@ -736,7 +736,7 @@ mod tests {
     use lakesoul_datafusion::catalog::create_io_config_builder;
     use lakesoul_datafusion::lakesoul_table::LakeSoulTable;
     use lakesoul_datafusion::planner::LakeSoulQueryPlanner;
-    use lakesoul_datafusion::ser::arrow_java::ArrowJavaSchema;
+    use lakesoul_datafusion::ser::arrow_java::schema_to_metadata_parts;
     use lakesoul_io::session::create_session_context_with_planner;
     use lakesoul_metadata::MetaDataClientRef;
     use proto::proto::entity::TableInfo;
@@ -859,12 +859,16 @@ mod tests {
         meta_data_client: MetaDataClientRef,
     ) -> Result<(String, String), anyhow::Error> {
         let schema = record_batch.schema();
+        let (table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash) =
+            schema_to_metadata_parts(schema.as_ref());
         let table_id = format!("table_{}", uuid::Uuid::new_v4());
         let ti = TableInfo {
             table_id: table_id.clone(),
             table_name: table_name.to_string(),
             table_path: path.to_string(),
-            table_schema: serde_json::to_string::<ArrowJavaSchema>(&schema.into())?,
+            table_schema,
+            table_schema_arrow_ipc,
+            table_schema_arrow_ipc_json_hash,
             table_namespace: "default".to_string(),
             properties: "{}".to_string(),
             partitions: ";".to_string(),

--- a/rust/proto/src/entity.proto
+++ b/rust/proto/src/entity.proto
@@ -27,8 +27,12 @@ message TableInfo {
   string table_name = 3;
   //  Physical qualified path of table
   string table_path = 4;
-  //  Spark-formatted schema of table
+  //  Spark/Java-compatible schema of table.
   string table_schema = 5;
+  //  Full-fidelity Arrow IPC schema for Rust/Vortex clients.
+  bytes table_schema_arrow_ipc = 10;
+  //  Hash of table_schema used to detect stale table_schema_arrow_ipc values.
+  string table_schema_arrow_ipc_json_hash = 11;
   //  Properties of table, used to tag table with information not tracked by SQL
   string properties = 7;
   //  Partition columns of table. Format of partitions is 'comma_separated_range_column;hash_column'
@@ -96,7 +100,7 @@ enum FileOp {
 
 //  Singleton Data File information
 message DataFileOp {
-  //  Physical qualified non-percent-encoded path of a parquet file, 
+  //  Physical qualified non-percent-encoded path of a parquet file,
   string path = 1;
   //  Specific operation of this file
   FileOp file_op = 2;

--- a/script/meta_init.sql
+++ b/script/meta_init.sql
@@ -21,11 +21,15 @@ create table if not exists table_info
     table_name      text,
     table_path      text,
     table_schema    text,
+    table_schema_arrow_ipc bytea,
+    table_schema_arrow_ipc_json_hash text,
     properties      json,
     partitions      text,
     domain          text default 'public',
     primary key (table_id)
 );
+ALTER TABLE table_info ADD COLUMN IF NOT EXISTS table_schema_arrow_ipc bytea;
+ALTER TABLE table_info ADD COLUMN IF NOT EXISTS table_schema_arrow_ipc_json_hash text;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS table_info_name_index ON table_info (table_namespace, table_name);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS table_info_path_index ON table_info (table_path);
 


### PR DESCRIPTION
## Summary

- update metadata serialization and table metadata handling for Arrow IPC schema support
- adjust Rust metadata/DataFusion integration around the updated metadata branch changes
- fix metadata branch clippy issues against the current DataFusion `MemoryPool` trait requirements

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --no-deps --all-features --all-targets --workspace -- -D warnings`
- `git push -u origin metadata` pre-push hook passed Rust Format and Rust Clippy

close #796 
