### PR TITLE
[Presto] resolve case-sensitive name matching for uppercase column ta…

### DIFF
--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulConfig.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulConfig.java
@@ -32,6 +32,7 @@ public class LakeSoulConfig {
         this.user = config.get("fs.hdfs.user");
         this.virtualPathStyle = Boolean.parseBoolean(config.getOrDefault("fs.s3a.path.style.access", "false"));
         this.timeZone = config.getOrDefault("timezone","");
+        this.caseSensitiveNameMatching = Boolean.parseBoolean(config.getOrDefault("case-sensitive-name-matching", "false"));
     }
 
     private String accessKey;
@@ -44,6 +45,7 @@ public class LakeSoulConfig {
     private String defaultFS;
     private String timeZone;
     private boolean virtualPathStyle;
+    private boolean caseSensitiveNameMatching;
 
 
     public String getAccessKey() {
@@ -124,5 +126,13 @@ public class LakeSoulConfig {
 
     public void setVirtualPathStyle(boolean virtualPathStyle) {
         this.virtualPathStyle = virtualPathStyle;
+    }
+
+    public boolean isCaseSensitiveNameMatching() {
+        return caseSensitiveNameMatching;
+    }
+
+    public void setCaseSensitiveNameMatching(boolean caseSensitiveNameMatching) {
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
     }
 }

--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulMetadata.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulMetadata.java
@@ -52,30 +52,64 @@ public class LakeSoulMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session) {
-        return dbManager.listNamespaces();
+        return dbManager.listNamespaces().stream()
+                .map(namespace -> normalizeIdentifier(session, namespace))
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    private String resolvePhysicalNamespace(ConnectorSession session, String logicalNamespace) {
+        if (isCaseSensitiveNameMatching()) {
+            return dbManager.listNamespaces().contains(logicalNamespace)
+                    ? logicalNamespace
+                    : null;
+        }
+
+        List<String> matchedNamespaces = dbManager.listNamespaces().stream()
+                .filter(namespace -> normalizeIdentifier(session, namespace).equals(logicalNamespace))
+                .collect(Collectors.toList());
+
+        if (matchedNamespaces.size() > 1) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    String.format(
+                            "Multiple LakeSoul schemas match case-insensitive name '%s': %s. " +
+                                    "Set case-sensitive-name-matching=true to distinguish them.",
+                            logicalNamespace,
+                            matchedNamespaces));
+        }
+
+        return matchedNamespaces.isEmpty() ? null : matchedNamespaces.get(0);
     }
 
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName) {
-        String namespace = schemaName.orElse("default");
-        return dbManager.listTableNamesByNamespace(namespace)
+        String logicalNamespace = schemaName.orElse("default");
+        String physicalNamespace = resolvePhysicalNamespace(session, logicalNamespace);
+        if (physicalNamespace == null) {
+            return Collections.emptyList();
+        }
+
+        return dbManager.listTableNamesByNamespace(physicalNamespace)
                 .stream()
-                .map(name -> new SchemaTableName(namespace, name))
+                .map(name -> new SchemaTableName(
+                        logicalNamespace,
+                        normalizeIdentifier(session, name)))
                 .collect(Collectors.toList());
     }
 
     @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName) {
-        if (!listSchemaNames(session).contains(tableName.getSchemaName())) {
+        String physicalNamespace = resolvePhysicalNamespace(session, tableName.getSchemaName());
+        if (physicalNamespace == null) {
             return null;
         }
 
         String physicalTableName = tableName.getTableName();
         if (!isCaseSensitiveNameMatching()) {
-            String logicalTableName = normalizeIdentifier(session, tableName.getTableName());
-            List<String> matchedTableNames = dbManager.listTableNamesByNamespace(tableName.getSchemaName())
+            List<String> matchedTableNames = dbManager.listTableNamesByNamespace(physicalNamespace)
                     .stream()
-                    .filter(name -> normalizeIdentifier(session, name).equals(logicalTableName))
+                    .filter(name -> normalizeIdentifier(session, name).equals(tableName.getTableName()))
                     .collect(Collectors.toList());
 
             if (matchedTableNames.size() > 1) {
@@ -94,7 +128,7 @@ public class LakeSoulMetadata implements ConnectorMetadata {
 
         TableInfo
                 tableInfo =
-                dbManager.getTableInfoByNameAndNamespace(physicalTableName, tableName.getSchemaName());
+                dbManager.getTableInfoByNameAndNamespace(physicalTableName, physicalNamespace);
 
         if (tableInfo == null) {
             throw new RuntimeException("no such table: " + tableName);
@@ -273,9 +307,14 @@ public class LakeSoulMetadata implements ConnectorMetadata {
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session,
                                                                        SchemaTablePrefix prefix) {
         //prefix: lakesoul.default.table1
-        String schema = prefix.getSchemaName();
+        String logicalSchema = prefix.getSchemaName();
+        String physicalSchema = resolvePhysicalNamespace(session, logicalSchema);
+        if (physicalSchema == null) {
+            return Collections.emptyMap();
+        }
+
         String tableNamePrefix = prefix.getTableName();
-        List<String> tableNames = dbManager.listTableNamesByNamespace(schema);
+        List<String> tableNames = dbManager.listTableNamesByNamespace(physicalSchema);
         Map<SchemaTableName, List<ColumnMetadata>> results = new HashMap<>();
         for (String physicalTableName : tableNames) {
             String logicalTableName = normalizeIdentifier(session, physicalTableName);
@@ -284,7 +323,7 @@ public class LakeSoulMetadata implements ConnectorMetadata {
                 continue;
             }
 
-            SchemaTableName schemaTableName = new SchemaTableName(schema, logicalTableName);
+            SchemaTableName schemaTableName = new SchemaTableName(logicalSchema, logicalTableName);
             ConnectorTableHandle tableHandle = getTableHandle(session, schemaTableName);
             ConnectorTableMetadata tableMetadata = getTableMetadata(session, tableHandle);
             results.put(schemaTableName, tableMetadata.getColumns());

--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulMetadata.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulMetadata.java
@@ -39,6 +39,16 @@ public class LakeSoulMetadata implements ConnectorMetadata {
         this.typeConverter = new ArrowBlockBuilder(typeManager);
     }
 
+    private static boolean isCaseSensitiveNameMatching() {
+        LakeSoulConfig config = LakeSoulConfig.getInstance();
+        return config != null && config.isCaseSensitiveNameMatching();
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier) {
+        return isCaseSensitiveNameMatching() ? identifier : identifier.toLowerCase(Locale.ENGLISH);
+    }
+
     @Override
     public List<String> listSchemaNames(ConnectorSession session) {
         return dbManager.listNamespaces();
@@ -159,7 +169,7 @@ public class LakeSoulMetadata implements ConnectorMetadata {
             }
 
             ColumnMetadata columnMetadata = ColumnMetadata.builder()
-                    .setName(field.getName())
+                    .setName(normalizeIdentifier(session, field.getName()))
                     .setType(typeConverter.getPrestoTypeFromArrowField(field))
                     .setNullable(field.isNullable())
                     .setComment(field.getMetadata().getOrDefault("spark_comment", ""))
@@ -206,12 +216,13 @@ public class LakeSoulMetadata implements ConnectorMetadata {
             if (field.getName().equals(cdcChangeColumn)) {
                 continue;
             }
+            String logicalName = normalizeIdentifier(session, field.getName());
             LakeSoulTableColumnHandle columnHandle =
                     new LakeSoulTableColumnHandle(table,
                             field.getName(),
                             typeConverter.getPrestoTypeFromArrowField(field),
                             field);
-            map.put(field.getName(), columnHandle);
+            map.put(logicalName, columnHandle);
         }
         return map;
     }
@@ -224,7 +235,7 @@ public class LakeSoulMetadata implements ConnectorMetadata {
         Field field = handle.getArrowField();
         Map<String, Object> properties = new HashMap<>(field.getMetadata());
         return ColumnMetadata.builder()
-                .setName(field.getName())
+                .setName(normalizeIdentifier(session, handle.getColumnName()))
                 .setType(typeConverter.getPrestoTypeFromArrowField(field))
                 .setNullable(field.isNullable())
                 .setComment(field.getMetadata().getOrDefault("spark_comment", ""))

--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulMetadata.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/LakeSoulMetadata.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.lakesoul.util.PrestoUtil.CDC_CHANGE_COLUMN;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public class LakeSoulMetadata implements ConnectorMetadata {
 
@@ -68,9 +69,32 @@ public class LakeSoulMetadata implements ConnectorMetadata {
         if (!listSchemaNames(session).contains(tableName.getSchemaName())) {
             return null;
         }
+
+        String physicalTableName = tableName.getTableName();
+        if (!isCaseSensitiveNameMatching()) {
+            String logicalTableName = normalizeIdentifier(session, tableName.getTableName());
+            List<String> matchedTableNames = dbManager.listTableNamesByNamespace(tableName.getSchemaName())
+                    .stream()
+                    .filter(name -> normalizeIdentifier(session, name).equals(logicalTableName))
+                    .collect(Collectors.toList());
+
+            if (matchedTableNames.size() > 1) {
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        String.format(
+                                "Multiple LakeSoul tables match case-insensitive name '%s': %s. " +
+                                        "Set case-sensitive-name-matching=true to distinguish them.",
+                                tableName,
+                                matchedTableNames));
+            }
+            if (!matchedTableNames.isEmpty()) {
+                physicalTableName = matchedTableNames.get(0);
+            }
+        }
+
         TableInfo
                 tableInfo =
-                dbManager.getTableInfoByNameAndNamespace(tableName.getTableName(), tableName.getSchemaName());
+                dbManager.getTableInfoByNameAndNamespace(physicalTableName, tableName.getSchemaName());
 
         if (tableInfo == null) {
             throw new RuntimeException("no such table: " + tableName);
@@ -253,13 +277,17 @@ public class LakeSoulMetadata implements ConnectorMetadata {
         String tableNamePrefix = prefix.getTableName();
         List<String> tableNames = dbManager.listTableNamesByNamespace(schema);
         Map<SchemaTableName, List<ColumnMetadata>> results = new HashMap<>();
-        for (String tableName : tableNames) {
-            if (tableName.startsWith(tableNamePrefix)) {
-                SchemaTableName schemaTableName = new SchemaTableName(schema, tableName);
-                ConnectorTableHandle tableHandle = getTableHandle(session, schemaTableName);
-                ConnectorTableMetadata tableMetadata = getTableMetadata(session, tableHandle);
-                results.put(schemaTableName, tableMetadata.getColumns());
+        for (String physicalTableName : tableNames) {
+            String logicalTableName = normalizeIdentifier(session, physicalTableName);
+            if (tableNamePrefix != null &&
+                    !logicalTableName.startsWith(normalizeIdentifier(session, tableNamePrefix))) {
+                continue;
             }
+
+            SchemaTableName schemaTableName = new SchemaTableName(schema, logicalTableName);
+            ConnectorTableHandle tableHandle = getTableHandle(session, schemaTableName);
+            ConnectorTableMetadata tableMetadata = getTableMetadata(session, tableHandle);
+            results.put(schemaTableName, tableMetadata.getColumns());
         }
         return results;
     }

--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/security/LakeSoulSystemAccessControl.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/security/LakeSoulSystemAccessControl.java
@@ -9,6 +9,7 @@ import com.dmetasoul.lakesoul.meta.NamespaceTableName;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.lakesoul.LakeSoulConfig;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.*;
@@ -35,6 +36,19 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
 
     private final Set<String> sensitiveSystemSessionPropertiesAllowDomains;
     private final Set<String> systemSchemas;
+
+    private static String normalizeIdentifier(String identifier) {
+        LakeSoulConfig config = LakeSoulConfig.getInstance();
+        return config != null && config.isCaseSensitiveNameMatching()
+                ? identifier
+                : identifier.toLowerCase(Locale.ENGLISH);
+    }
+
+    private static SchemaTableName normalizeSchemaTableName(NamespaceTableName tableName) {
+        return new SchemaTableName(
+                normalizeIdentifier(tableName.getNamespace()),
+                normalizeIdentifier(tableName.getTableName()));
+    }
 
     public LakeSoulSystemAccessControl(
             Set<String> sensitiveSystemSessionProperties,
@@ -198,9 +212,9 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
                 if (!domain.equals(publicDomain)) {
                     tables.addAll(dbManager.listTableNamesByDomain(domain));
                 }
-                List<SchemaTableName> schemaTableNames = tables.stream().map(e -> {
-                    return new SchemaTableName(e.getNamespace(), e.getTableName());
-                }).collect(Collectors.toList());
+                List<SchemaTableName> schemaTableNames = tables.stream()
+                        .map(LakeSoulSystemAccessControl::normalizeSchemaTableName)
+                        .collect(Collectors.toList());
                 filteredTableNames.retainAll(schemaTableNames);
                 filteredTableNames.addAll(
                         tableNames.stream().filter(e -> {
@@ -212,9 +226,9 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
                 return filteredTableNames;
             }
         }
-        List<SchemaTableName> schemaTableNames = publicTables.stream().map(e -> {
-            return new SchemaTableName(e.getNamespace(), e.getTableName());
-        }).collect(Collectors.toList());
+        List<SchemaTableName> schemaTableNames = publicTables.stream()
+                .map(LakeSoulSystemAccessControl::normalizeSchemaTableName)
+                .collect(Collectors.toList());
         filteredTableNames.retainAll(schemaTableNames);
         filteredTableNames.addAll(
                 tableNames.stream().filter(e -> {

--- a/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/security/LakeSoulSystemAccessControl.java
+++ b/lakesoul-presto/src/main/java/com/facebook/presto/lakesoul/security/LakeSoulSystemAccessControl.java
@@ -50,6 +50,12 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
                 normalizeIdentifier(tableName.getTableName()));
     }
 
+    private static Set<String> normalizeNamespaces(Collection<String> namespaces) {
+        return namespaces.stream()
+                .map(LakeSoulSystemAccessControl::normalizeIdentifier)
+                .collect(Collectors.toSet());
+    }
+
     public LakeSoulSystemAccessControl(
             Set<String> sensitiveSystemSessionProperties,
             boolean principalNeedMatchUsername,
@@ -179,13 +185,13 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
                 if (!domain.equals(publicDomain)) {
                     namespaces.addAll(dbManager.listNamespacesByDomain(domain));
                 }
-                filteredSchemas.retainAll(namespaces);
+                filteredSchemas.retainAll(normalizeNamespaces(namespaces));
                 log.info("Filter schemas by domain <%s + public>, original schemas: %s, filtered schemas: %s",
                         domain, schemaNames, filteredSchemas);
                 return filteredSchemas;
             }
         }
-        filteredSchemas.retainAll(publicAndSystemNamespaces);
+        filteredSchemas.retainAll(normalizeNamespaces(publicAndSystemNamespaces));
         log.info("Filter schemas by domain <public>, original schemas: %s, filtered schemas: %s",
                 schemaNames, filteredSchemas);
         return filteredSchemas;
@@ -251,7 +257,7 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
                 if (!domain.equals(publicDomain)) {
                     namespaces.addAll(dbManager.listNamespacesByDomain(domain));
                 }
-                if (!namespaces.contains(schema.getSchemaName())) {
+                if (!normalizeNamespaces(namespaces).contains(schema.getSchemaName())) {
                     throw new AccessDeniedException(
                             String.format(
                                     "Access denied: user '%s' and domain '%s' is not allowed to show tables metadata in schema '%s'.",
@@ -260,7 +266,7 @@ public class LakeSoulSystemAccessControl implements SystemAccessControl {
                 return;
             }
         }
-        if (!publicAndSystemNamespaces.contains(schema.getSchemaName())) {
+        if (!normalizeNamespaces(publicAndSystemNamespaces).contains(schema.getSchemaName())) {
             throw new AccessDeniedException(
                     String.format("Access denied: user '%s' is not allowed to show tables metadata in schema '%s'.",
                             identity.getUser(), schema.getSchemaName()));


### PR DESCRIPTION
1.logical column name: controlled by case-sensitive-name-matching physical column name(default false), always the original Arrow/Parquet field name
2. DESCRIBE and metadata display respect the configured case behavior (lowercased when false, as-is when true)
Close #805 