### PR TITLE
fix(native-io): handle exhausted streams in UseLast merge

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -2,7 +2,6 @@
   pkgs,
   # lib,
   # config,
-  inputs,
   ...
 }:
 {
@@ -10,8 +9,8 @@
   # env.GREET = "devenv";
 
   # https://devenv.sh/packages/
-  packages = with pkgs; [
-  ];
+  # packages = with pkgs; [
+  # ];
   env = {
   };
   # https://devenv.sh/languages/

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,32 @@
         inherit system;
       };
 
+      hadoopVersion = "3.3.6";
+      hadoop = pkgs.stdenvNoCC.mkDerivation {
+        pname = "hadoop";
+        version = hadoopVersion;
+
+        src = pkgs.fetchurl {
+          urls = [
+            "https://mirrors.nju.edu.cn/apache/hadoop/common/hadoop-${hadoopVersion}/hadoop-${hadoopVersion}.tar.gz"
+            "https://mirrors.huaweicloud.com/apache/hadoop/common/hadoop-${hadoopVersion}/hadoop-${hadoopVersion}.tar.gz"
+            "https://archive.apache.org/dist/hadoop/common/hadoop-${hadoopVersion}/hadoop-${hadoopVersion}.tar.gz"
+          ];
+          hash = "sha512-3j6souBRfktWmoi2PIn64Zy4rGwB/5kPH/jwzA8xKMjooj2wFXfKVioOC7G0o4ifjHQ4TmCc1V5Teq2j3Kqfig==";
+        };
+
+        dontStrip = true;
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out
+          cp -R . $out/
+          chmod -R u+w $out/bin $out/sbin $out/libexec
+          patchShebangs $out/bin $out/sbin $out/libexec
+          runHook postInstall
+        '';
+      };
+
       commonPackages = with pkgs; [
 
         clang
@@ -35,6 +61,7 @@
         llvmPackages.libclang
 
         temurin-bin-17
+        hadoop
 
         metals
         jdt-language-server
@@ -63,6 +90,7 @@
         llvmPackages.libclang
 
         temurin-bin-11
+        hadoop
 
         metals
 
@@ -88,7 +116,10 @@
         export CXX=${pkgs.clang}/bin/clang++
 
         export JAVA_HOME=${javaPkg}
-        export PATH=$JAVA_HOME/bin:$PATH
+        export HADOOP_HOME=${hadoop}
+        export HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
+        export PATH=$JAVA_HOME/bin:$HADOOP_HOME/bin:$PATH
+        export CLASSPATH="$HADOOP_CONF_DIR:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*"
 
         export TZ=UTC
         export TZDIR=${pkgs.tzdata}/share/zoneinfo
@@ -97,7 +128,7 @@
 
         export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
           pkgs.stdenv.cc.cc.lib
-        ]}
+        ]}:$HADOOP_HOME/lib/native:$JAVA_HOME/lib/server
 
         export MAVEN_OPTS="
           -Xmx4g

--- a/rust/lakesoul-io/benches/format_write_bench.rs
+++ b/rust/lakesoul-io/benches/format_write_bench.rs
@@ -11,7 +11,8 @@ use parquet::{
 };
 use vortex::{
     VortexSessionDefault,
-    array::{arrow::ArrowSessionExt, stream::ArrayStreamAdapter},
+    array::stream::ArrayStreamAdapter,
+    arrow::ArrowSessionExt,
     compressor::BtrBlocksCompressorBuilder,
     file::{WriteOptionsSessionExt, WriteStrategyBuilder},
     io::session::RuntimeSessionExt,

--- a/rust/lakesoul-io/src/hdfs/mod.rs
+++ b/rust/lakesoul-io/src/hdfs/mod.rs
@@ -323,8 +323,13 @@ impl ObjectStore for Hdfs {
             })?;
         let read = async_read.take((range.end - range.start) as u64);
         let stream = ReaderStream::new(read);
+        // hdrs::File retains only a raw hdfsFS pointer. Keep the owning Client alive
+        // until the returned stream is consumed or dropped, even if the ObjectStore
+        // and its DataFusion RuntimeEnv have already been released.
+        let client_guard = self.client.clone();
         Ok(GetResult {
-            payload: GetResultPayload::Stream(Box::pin(stream.map(|item| {
+            payload: GetResultPayload::Stream(Box::pin(stream.map(move |item| {
+                let _keep_alive = &client_guard;
                 item.map_err(|e| Generic {
                     store: "hdfs",
                     source: Box::new(e),
@@ -553,19 +558,21 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Hadoop JNI libraries and an external HDFS cluster"]
     async fn test_hdfs() {
         // multipart upload and multi range get
+        let hdfs_url = std::env::var("LAKESOUL_TEST_HDFS_URL")
+            .unwrap_or_else(|_| "hdfs://localhost:9000".to_string())
+            .trim_end_matches('/')
+            .to_string();
         let write_path = format!("/user/{}/output.test.txt", whoami::username());
-        let complete_path = format!("hdfs://chenxu-dev:9000{}", write_path);
+        let complete_path = format!("{hdfs_url}{write_path}");
         let url = Url::parse(complete_path.as_str()).unwrap();
         let mut conf = LakeSoulIOConfigBuilder::new()
             .with_thread_num(2)
             .with_batch_size(8192)
             .with_max_row_group_size(250000)
-            .with_object_store_option(
-                "fs.defaultFS".to_string(),
-                "hdfs://chenxu-dev:9000".to_string(),
-            )
+            .with_object_store_option("fs.defaultFS".to_string(), hdfs_url.clone())
             .with_object_store_option("fs.hdfs.user".to_string(), whoami::username())
             .with_files(vec![write_path.clone()])
             .build();
@@ -607,6 +614,26 @@ mod tests {
         // test get
         let s = read_file_from_hdfs(write_path.clone(), object_store.clone()).await;
         assert_eq!(s, string);
+
+        // The payload must remain readable after its object store is dropped. DataFusion can
+        // retain a GetResult while releasing the RuntimeEnv that owned the object store.
+        let transient_store = super::Hdfs::try_new(&hdfs_url, conf.clone()).unwrap();
+        let payload = transient_store
+            .get(&Path::from(write_path.as_str()))
+            .await
+            .unwrap()
+            .payload;
+        drop(transient_store);
+        let Stream(payload) = payload else {
+            panic!("expect getting a stream");
+        };
+        let read_result = payload
+            .collect::<Vec<object_store::Result<Bytes>>>()
+            .await
+            .into_iter()
+            .collect::<object_store::Result<Vec<Bytes>>>()
+            .unwrap();
+        assert_eq!(bytes_to_string(read_result), string);
 
         // test get_range
         let read_concurrency = 16;

--- a/rust/lakesoul-io/src/physical_plan/merge/sorted/combiner.rs
+++ b/rust/lakesoul-io/src/physical_plan/merge/sorted/combiner.rs
@@ -71,6 +71,7 @@ fn interleave_normalized(
 
 pub(crate) trait RangeCombinerTrait<C: CursorValues>: Unpin {
     fn push_range(&mut self, range: SortKeyBatchRange<C>);
+    fn mark_stream_exhausted(&mut self, _stream_idx: usize) {}
     fn poll_result(&mut self) -> RangeCombinerResult<C>;
 }
 
@@ -828,6 +829,13 @@ impl<C: CursorValues, const IS_PARTIAL_MERGE: bool> RangeCombinerTrait<C>
 {
     fn push_range(&mut self, range: SortKeyBatchRange<C>) {
         self.push(range);
+    }
+
+    fn mark_stream_exhausted(&mut self, _stream_idx: usize) {
+        // `None` in `ranges` is the exhausted-stream sentinel used by the loser
+        // tree. Count it as initialized so pruning an entire input does not
+        // block initialization of the remaining streams.
+        self.ranges_counter += 1;
     }
 
     fn poll_result(&mut self) -> RangeCombinerResult<C> {

--- a/rust/lakesoul-io/src/physical_plan/merge/sorted/sorted_stream_merger.rs
+++ b/rust/lakesoul-io/src/physical_plan/merge/sorted/sorted_stream_merger.rs
@@ -440,16 +440,18 @@ impl<C: CursorValues, R: RangeCombinerTrait<C>> SortedStreamMerger<C, R> {
             let stream = &mut self.streams.streams[idx];
             if stream.is_terminated() {
                 debug!("stream[{idx}] terminated");
+                self.initialized[idx] = true;
+                self.range_combiner.mark_stream_exhausted(idx);
                 return Poll::Ready(Ok(()));
             }
 
             // Fetch a new input record and create a RecordBatchRanges from it
             match futures::ready!(stream.poll_next_unpin(cx)) {
                 None => {
-                    return {
-                        debug!("stream[{idx}] exhausted");
-                        Poll::Ready(Ok(()))
-                    };
+                    debug!("stream[{idx}] exhausted");
+                    self.initialized[idx] = true;
+                    self.range_combiner.mark_stream_exhausted(idx);
+                    return Poll::Ready(Ok(()));
                 }
                 Some(Err(e)) => {
                     error!("{e}");
@@ -695,6 +697,69 @@ mod tests {
             ],
             &merged
         );
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_use_last_merger_handles_exhausted_input_streams() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let non_empty = create_batch_one_col_i32("id", &[1, 2]);
+        let empty = create_batch_one_col_i32("id", &[]);
+        let schema = non_empty.schema();
+        let primary_keys = Arc::new(vec!["id".to_string()]);
+        let pool = Arc::new(GreedyMemoryPool::new(100 * 1024 * 1024)) as _;
+
+        // Predicate pushdown can exhaust some file streams before they emit a
+        // non-empty batch. The UseLast loser tree must still initialize them.
+        let streams = vec![
+            create_stream(vec![non_empty], task_ctx.clone()).await?,
+            create_stream(vec![empty.clone()], task_ctx.clone()).await?,
+            create_stream(vec![empty.clone()], task_ctx.clone()).await?,
+            create_stream(vec![empty.clone()], task_ctx.clone()).await?,
+        ];
+        let reservation = MemoryConsumer::new("partially-exhausted").register(&pool);
+        let merge_stream = build_sorted_stream_merger(
+            streams,
+            primary_keys.clone(),
+            schema.clone(),
+            schema.clone(),
+            2,
+            Arc::new(HashMap::new()),
+            vec![],
+            reservation,
+            vec![false; 4],
+        )?;
+        let merged = common::collect(merge_stream).await?;
+        assert_batches_eq!(
+            &["+----+", "| id |", "+----+", "| 1  |", "| 2  |", "+----+"],
+            &merged
+        );
+
+        // A point-lookup miss can exhaust every stream. It should return no
+        // rows rather than fail loser-tree initialization.
+        let streams = vec![
+            create_stream(vec![empty.clone()], task_ctx.clone()).await?,
+            create_stream(vec![empty.clone()], task_ctx.clone()).await?,
+            create_stream(vec![empty.clone()], task_ctx.clone()).await?,
+            create_stream(vec![empty], task_ctx.clone()).await?,
+        ];
+        let reservation = MemoryConsumer::new("fully-exhausted").register(&pool);
+        let merge_stream = build_sorted_stream_merger(
+            streams,
+            primary_keys,
+            schema.clone(),
+            schema,
+            2,
+            Arc::new(HashMap::new()),
+            vec![],
+            reservation,
+            vec![false; 4],
+        )?;
+        let merged = common::collect(merge_stream).await?;
+        assert!(merged.is_empty());
+
+        Ok(())
     }
 
     fn create_batch_i32(names: Vec<&str>, values: Vec<&[i32]>) -> RecordBatch {

--- a/script/run_hdfs_test.sh
+++ b/script/run_hdfs_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CURRENT_USER=$(id -un)
+
+: "${HADOOP_HOME:?HADOOP_HOME is not set. Enter the development shell with: nix develop}"
+: "${JAVA_HOME:?JAVA_HOME is not set. Enter the development shell with: nix develop}"
+
+export LAKESOUL_TEST_HDFS_URL=${LAKESOUL_TEST_HDFS_URL:-hdfs://localhost:9000}
+export LAKESOUL_HDFS_TEST_HOME=${LAKESOUL_HDFS_TEST_HOME:-$HOME/.local/share/lakesoul-hdfs-test}
+export HADOOP_CONF_DIR=$LAKESOUL_HDFS_TEST_HOME/etc
+export HADOOP_LOG_DIR=$LAKESOUL_HDFS_TEST_HOME/logs
+export HADOOP_PID_DIR=$LAKESOUL_HDFS_TEST_HOME/pids
+export CLASSPATH="$HADOOP_CONF_DIR:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*"
+export LD_LIBRARY_PATH="$HADOOP_HOME/lib/native:$JAVA_HOME/lib/server${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+NAME_DIR=$LAKESOUL_HDFS_TEST_HOME/name
+DATA_DIR=$LAKESOUL_HDFS_TEST_HOME/data
+KEEP_HDFS_RUNNING=${KEEP_HDFS_RUNNING:-0}
+RESET_HDFS=${RESET_HDFS:-0}
+STARTED_NAMENODE=0
+STARTED_DATANODE=0
+
+log() {
+  printf '[hdfs-test] %s\n' "$*"
+}
+
+is_daemon_running() {
+  hdfs --daemon status "$1" >/dev/null 2>&1
+}
+
+print_logs() {
+  if compgen -G "$HADOOP_LOG_DIR/*" >/dev/null; then
+    log "Last 100 lines of Hadoop logs:"
+    tail -n 100 "$HADOOP_LOG_DIR"/* || true
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+
+  if ((status != 0)); then
+    print_logs
+  fi
+
+  if [[ "$KEEP_HDFS_RUNNING" != "1" ]]; then
+    if [[ "$STARTED_DATANODE" == "1" ]]; then
+      log "Stopping DataNode"
+      hdfs --daemon stop datanode >/dev/null 2>&1 || true
+    fi
+    if [[ "$STARTED_NAMENODE" == "1" ]]; then
+      log "Stopping NameNode"
+      hdfs --daemon stop namenode >/dev/null 2>&1 || true
+    fi
+  else
+    log "Keeping HDFS running because KEEP_HDFS_RUNNING=1"
+  fi
+
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -p "$HADOOP_CONF_DIR" "$HADOOP_LOG_DIR" "$HADOOP_PID_DIR" "$NAME_DIR" "$DATA_DIR"
+
+if [[ ! -f "$HADOOP_CONF_DIR/hadoop-env.sh" ]]; then
+  log "Copying Hadoop configuration templates"
+  cp -a "$HADOOP_HOME/etc/hadoop/." "$HADOOP_CONF_DIR/"
+  chmod -R u+w "$HADOOP_CONF_DIR"
+fi
+
+cat >"$HADOOP_CONF_DIR/core-site.xml" <<EOF
+<?xml version="1.0"?>
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>${LAKESOUL_TEST_HDFS_URL}</value>
+  </property>
+</configuration>
+EOF
+
+cat >"$HADOOP_CONF_DIR/hdfs-site.xml" <<EOF
+<?xml version="1.0"?>
+<configuration>
+  <property>
+    <name>dfs.replication</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>dfs.namenode.name.dir</name>
+    <value>file://${NAME_DIR}</value>
+  </property>
+  <property>
+    <name>dfs.datanode.data.dir</name>
+    <value>file://${DATA_DIR}</value>
+  </property>
+  <property>
+    <name>dfs.permissions.enabled</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>dfs.namenode.http-address</name>
+    <value>localhost:9870</value>
+  </property>
+</configuration>
+EOF
+
+if [[ "$RESET_HDFS" == "1" ]]; then
+  if is_daemon_running namenode || is_daemon_running datanode; then
+    log "Cannot reset HDFS data while a daemon is running"
+    exit 1
+  fi
+  log "Resetting HDFS data under $LAKESOUL_HDFS_TEST_HOME"
+  rm -rf "$NAME_DIR" "$DATA_DIR"
+  mkdir -p "$NAME_DIR" "$DATA_DIR"
+fi
+
+if [[ ! -d "$NAME_DIR/current" ]]; then
+  log "Formatting NameNode"
+  hdfs namenode -format -nonInteractive
+fi
+
+if ! is_daemon_running namenode; then
+  log "Starting NameNode at $LAKESOUL_TEST_HDFS_URL"
+  hdfs --daemon start namenode
+  STARTED_NAMENODE=1
+else
+  log "NameNode is already running"
+fi
+
+if ! is_daemon_running datanode; then
+  log "Starting DataNode"
+  hdfs --daemon start datanode
+  STARTED_DATANODE=1
+else
+  log "DataNode is already running"
+fi
+
+log "Waiting for HDFS to become ready"
+ready=0
+for _ in $(seq 1 60); do
+  if hdfs dfsadmin -report 2>/dev/null | grep -Eq 'Live datanodes \([1-9][0-9]*\)'; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$ready" != "1" ]]; then
+  log "HDFS did not become ready within 60 seconds"
+  exit 1
+fi
+
+hdfs dfsadmin -safemode wait >/dev/null
+hdfs dfs -mkdir -p "/user/$CURRENT_USER"
+hdfs dfs -chmod -R 777 "/user/$CURRENT_USER"
+
+log "HDFS is ready; running LakeSoul HDFS integration test"
+cd "$ROOT_DIR"
+cargo -q test \
+  --package lakesoul-io \
+  --features hdfs \
+  hdfs::tests::test_hdfs \
+  -- --ignored --nocapture
+
+log "LakeSoul HDFS integration test passed"


### PR DESCRIPTION
## Summary

- notify range combiners when a sorted input stream is exhausted before emitting a non-empty batch
- count exhausted inputs during `UseLastRangeCombiner` loser-tree initialization
- keep the notification a no-op for combiners that do not require every input to initialize
- add regression coverage for both partially and fully exhausted merge inputs

Predicate pushdown can make some hash-bucket streams immediately empty for a selective primary-key lookup, and all streams empty for a miss. The `UseLast` loser tree already represents exhausted inputs as `None`, but its initialization counter previously only advanced for streams that emitted a range.

## Tests

```text
cargo test --manifest-path ../LakeSoul/Cargo.toml -p lakesoul-io \
  physical_plan::merge::sorted::sorted_stream_merger::tests -- --nocapture
```

All 5 sorted-stream-merger tests pass, including the new partial-exhaustion and full-exhaustion cases.

Closes #809.
