### PR TITLE
[Docs] Align README documentation links

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -59,6 +59,8 @@ LakeSoul 支持自动分离式多层 Compaction 、自动表生命周期清理�
 
 [快速开始](https://lakesoul-io.github.io/zh-Hans/docs/Getting%20Started/setup-local-env)
 
+[教程](https://lakesoul-io.github.io/zh-Hans/docs/Tutorials/flink-cdc-sink)
+
 [使用文档](https://lakesoul-io.github.io/zh-Hans/docs/Usage%20Docs/setup-meta-env)
 
 # 特性路线

--- a/README.md
+++ b/README.md
@@ -80,13 +80,12 @@ Please find tutorials in doc site:
 
 # Usage Documentations
 Please find usage documentations in doc site:
-[Usage Doc](https://lakesoul-io.github.io/docs/Usage%20Docs/setup-meta-env)
 
-[快速开始](https://lakesoul-io.github.io/zh-Hans/docs/Getting%20Started/setup-local-env)
+[Quick Start](https://lakesoul-io.github.io/docs/Getting%20Started/setup-local-env)
 
-[教程](https://lakesoul-io.github.io/zh-Hans/docs/Tutorials/flink-cdc-sink)
+[Tutorials](https://lakesoul-io.github.io/docs/Tutorials/consume-cdc-via-spark-streaming)
 
-[使用文档](https://lakesoul-io.github.io/zh-Hans/docs/Usage%20Docs/setup-meta-env)
+[Usage Documentation](https://lakesoul-io.github.io/docs/Usage%20Docs/setup-meta-env)
 
 # Feature Roadmap
 ## Roadmap 2026


### PR DESCRIPTION
## Summary

- replace Chinese documentation shortcuts in README.md with English labels and URLs
- add the matching Tutorials shortcut to README-CN.md
- keep English and Chinese documentation navigation aligned

## Validation

- git diff --check

Closes #817