### PR TITLE
[CI] Enforce incremental formatting with treefmt

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2023 LakeSoul Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Format Check
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: format-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.11.0
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check formatting
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          ensure_commit() {
+            local commit="$1"
+
+            if git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+              return
+            fi
+
+            git fetch --no-tags origin "$commit"
+            if ! git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+              echo "Unable to resolve commit: $commit" >&2
+              exit 1
+            fi
+          }
+
+          ensure_commit "$HEAD_SHA"
+
+          case "$EVENT_NAME" in
+            pull_request)
+              ensure_commit "$BASE_SHA"
+              diff_range="${BASE_SHA}...${HEAD_SHA}"
+              ;;
+            push)
+              if [[ "$BASE_SHA" =~ ^0+$ ]]; then
+                if [[ "$REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+                  BASE_SHA="$(git hash-object -t tree /dev/null)"
+                  diff_range="${BASE_SHA}..${HEAD_SHA}"
+                else
+                  git fetch --no-tags origin \
+                    "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+                  BASE_SHA="$(git merge-base "origin/${DEFAULT_BRANCH}" "$HEAD_SHA")"
+                  diff_range="${BASE_SHA}...${HEAD_SHA}"
+                fi
+              else
+                ensure_commit "$BASE_SHA"
+                diff_range="${BASE_SHA}..${HEAD_SHA}"
+              fi
+              ;;
+            workflow_dispatch)
+              if BASE_SHA="$(git rev-parse "${HEAD_SHA}^" 2>/dev/null)"; then
+                diff_range="${BASE_SHA}..${HEAD_SHA}"
+              else
+                BASE_SHA="$(git hash-object -t tree /dev/null)"
+                diff_range="${BASE_SHA}..${HEAD_SHA}"
+              fi
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          files_path="${RUNNER_TEMP}/treefmt-files"
+          git diff --name-only --diff-filter=ACMR -z "$diff_range" > "$files_path"
+          mapfile -d '' files < "$files_path"
+
+          if (( ${#files[@]} == 0 )); then
+            echo "No changed files to format"
+            exit 0
+          fi
+
+          if ! nix develop .#formatter --command treefmt --ci -- "${files[@]}"; then
+            git --no-pager diff
+            exit 1
+          fi

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -7,13 +7,13 @@ on:
     paths:
       - "rust/**"
     branches:
-      - 'main'
+      - "main"
   pull_request:
     paths:
       - "rust/**"
     branches:
-      - 'main'
-      - 'release/**'
+      - "main"
+      - "release/**"
   workflow_dispatch:
 
 name: Rust Clippy Check
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses:  dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: clippy,rustfmt
+          components: clippy
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:
@@ -40,8 +40,5 @@ jobs:
         with:
           workspaces: ". -> rust/target"
           key: "ubuntu-24.04-clippy"
-      - name: Run Format
-        run: cargo fmt --all --check
       - name: Run Clippy
         run: cargo clippy --no-deps --all-features -p lakesoul-io-c -p lakesoul-metadata-c -p lakesoul-python -p lakesoul-io
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,22 @@ To ensure your pull request is accepted, follow these guidelines:
 * Your pull request title should be of the form `[component] name`, where `[component]` is the part of LakeSoul repo that your PR changes. For example: `[Flink] add table source implementation`
 * Use tags to indicate parts of the repository that your PR refers to
 
+### Formatting
+
+LakeSoul uses [treefmt](https://treefmt.com) as the repository-wide formatting entry point. During the incremental rollout, format the files you change before opening a pull request:
+
+```sh
+treefmt path/to/changed-file
+```
+
+On x86-64 Linux, use the formatter versions provided by the Nix development environment:
+
+```sh
+nix develop .#formatter --command treefmt path/to/changed-file
+```
+
+The pre-push hook provides a best-effort local check with `treefmt --ci`. The Format Check workflow is the authoritative check for pull requests and pushes.
+
 ### Branching
 
 * Use a _group_ at the beginning of your branch names:

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,17 @@
         '';
       };
 
-      commonPackages = with pkgs; [
+      formatterPackages = with pkgs; [
+        google-java-format
+        prettier
+        ruff
+        rustfmt
+        scalafmt
+        taplo
+        treefmt
+      ];
+
+      commonPackages = formatterPackages ++ (with pkgs; [
 
         clang
         lld
@@ -66,11 +76,6 @@
         metals
         jdt-language-server
 
-        google-java-format
-        prettier
-        treefmt
-        scalafmt
-
         postgresql_14
 
         tzdata
@@ -81,9 +86,9 @@
         pkg-config
 
         unstable.ty
-      ];
+      ]);
 
-      fhsPackages = with pkgs; [
+      fhsPackages = formatterPackages ++ (with pkgs; [
 
         clang
         lld
@@ -94,11 +99,6 @@
 
         metals
 
-        google-java-format
-        prettier
-        treefmt
-        scalafmt
-
         postgresql_14
 
         tzdata
@@ -109,7 +109,7 @@
         pkg-config
 
         unstable.ty
-      ];
+      ]);
 
       envFor = javaPkg: ''
         export CC=${pkgs.clang}/bin/clang
@@ -152,6 +152,10 @@
     in
     {
       devShells.${system} = {
+
+        formatter = pkgs.mkShell {
+          packages = formatterPackages;
+        };
 
         #
         # 普通开发环境（推荐）

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,9 +4,10 @@
 #   https://lefthook.dev/configuration/
 #
 pre-push:
-    parallel: true
-    jobs:
-        - name: Rust Format
-          run: cargo fmt --all -- --check
-        - name: Rust Clippy
-          run: cargo clippy --no-deps --all-features --all-targets --workspace -- -D warnings
+  parallel: false
+  jobs:
+    - name: Format
+      glob: "*.{rs,java,scala,sbt,py,toml,yml,yaml,json}"
+      run: treefmt --ci -- {push_files}
+    - name: Rust Clippy
+      run: cargo clippy --no-deps --all-features --all-targets --workspace -- -D warnings

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -2,8 +2,8 @@
 # https://treefmt.com
 #
 # Usage:
-#   treefmt              # format all files
-#   treefmt --fail-on-change  # check-only (CI / pre-push)
+#   treefmt <paths...>  # format selected files
+#   treefmt --ci <paths...>  # check selected files (CI / pre-push)
 
 [global]
 excludes = [
@@ -21,6 +21,7 @@ excludes = [
   "**/uv.lock",
   "website/package-lock.json",
   # Generated code
+  "lakesoul-flink/src/main/java/org/apache/flink/fnexecution/v1/FlinkFnApi.java",
   "python/src/lakesoul/metadata/generated/**",
 ]
 
@@ -28,6 +29,7 @@ excludes = [
 # Config: rust/rustfmt.toml (picked up automatically)
 [formatter.rust]
 command = "rustfmt"
+options = ["--edition", "2024", "--config", "skip_children=true"]
 includes = ["*.rs"]
 
 # Java ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a standalone Format Check workflow that runs treefmt on files changed by pull requests and pushes
- provision pinned formatter tooling through a lightweight Nix formatter shell
- update Lefthook to check files pending push before running Clippy
- remove the duplicate cargo fmt step from the Rust Clippy workflow
- document the incremental formatting workflow for contributors

## Rollout

This PR intentionally enforces formatting only on added, modified, and renamed files. A full treefmt run currently changes 596 files and would create a large mechanical diff, so repository-wide formatting will be submitted in a follow-up PR under #795.

The commit containing that full formatting pass will also be added to .git-blame-ignore-revs so git blame can ignore the mechanical formatting churn and preserve useful history.

## Validation

- treefmt --ci on all formatter-supported files changed by this PR
- nix flake check --no-write-lock-file
- actionlint on the new Format Check and updated Rust Clippy workflows
- cargo -q clippy --no-deps --all-features --all-targets --workspace -- -D warnings
- git diff --check

Closes #819
Part of #795