### PR TITLE
[Metadata] Exclude deleted files from active partition data files in Rust and Python

### DIFF
--- a/python/src/lakesoul/metadata/native_client.py
+++ b/python/src/lakesoul/metadata/native_client.py
@@ -272,6 +272,19 @@ class NativeMetadataClient:
             partition_info.snapshot,
         )
 
+    def get_data_files_of_single_partition(
+        self,
+        partition_info: PartitionInfo,
+    ) -> list[str]:
+        snapshot = [
+            (commit_id.high, commit_id.low) for commit_id in partition_info.snapshot
+        ]
+        return self._inner.get_data_files_of_single_partition(
+            partition_info.table_id,
+            partition_info.partition_desc,
+            snapshot,
+        )
+
     def get_arrow_schema_by_table_name(
         self,
         table_name: str,
@@ -382,13 +395,7 @@ class NativeMetadataClient:
             # )
         if not pk_cols:
             for partition in partition_infos:
-                data_files = []
-                data_commit_info_list = self.get_table_single_partition_data_info(
-                    partition
-                )
-                for data_commit_info in data_commit_info_list:
-                    for file_op in data_commit_info.file_ops:
-                        data_files.append(file_op.path)
+                data_files = self.get_data_files_of_single_partition(partition)
                 plan_partitions.append(
                     LakeSoulScanPlanPartition(
                         data_files,
@@ -403,17 +410,13 @@ class NativeMetadataClient:
             bucket_id_pattern = r".*_(\d+)(?:\..*)?$"
             for partition in partition_infos:
                 files = collections.defaultdict(list)
-                data_commit_info_list = self.get_table_single_partition_data_info(
-                    partition
-                )
-                for data_commit_info in data_commit_info_list:
-                    for file_op in data_commit_info.file_ops:
-                        match = re.search(bucket_id_pattern, file_op.path)
-                        if not match:
-                            raise ValueError(
-                                f"Cannot determine bucket id from file name {file_op.path}"
-                            )
-                        files[int(match.group(1))].append(file_op.path)
+                for path in self.get_data_files_of_single_partition(partition):
+                    match = re.search(bucket_id_pattern, path)
+                    if not match:
+                        raise ValueError(
+                            f"Cannot determine bucket id from file name {path}"
+                        )
+                    files[int(match.group(1))].append(path)
                 for bucket_id, bucket_files in files.items():
                     plan_partitions.append(
                         LakeSoulScanPlanPartition(
@@ -449,9 +452,6 @@ class NativeMetadataClient:
                     break
             if filtered:
                 continue
-            data_commit_info_list = self.get_table_single_partition_data_info(partition)
-            for data_commit_info in data_commit_info_list:
-                for file_op in data_commit_info.file_ops:
-                    data_files.append(file_op.path)
+            data_files.extend(self.get_data_files_of_single_partition(partition))
         _, pk_cols = self.get_partition_and_pk_cols(table_info)
         return data_files, pk_cols

--- a/python/src/metadata.rs
+++ b/python/src/metadata.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use arrow_pyarrow::PyArrowType;
 use arrow_schema::Schema;
 use lakesoul_metadata::{MetaDataClient, transfusion::DataFileInfo, utils::qualify_path};
-use lakesoul_metadata_proto::entity::{CommitOp, TableInfo};
+use lakesoul_metadata_proto::entity::{CommitOp, PartitionInfo, TableInfo, Uuid};
 use pyo3::{exceptions::PyRuntimeError, exceptions::PyValueError, prelude::*};
 
 use crate::install_module;
@@ -89,6 +89,32 @@ impl NativeMetadataClient {
                     files,
                     CommitOp::AppendCommit,
                 ))
+                .map_err(|error| PyRuntimeError::new_err(error.to_string()))
+        })
+    }
+
+    fn get_data_files_of_single_partition(
+        &self,
+        py: Python,
+        table_id: String,
+        partition_desc: String,
+        snapshot: Vec<(u64, u64)>,
+    ) -> PyResult<Vec<String>> {
+        let partition_info = PartitionInfo {
+            table_id,
+            partition_desc,
+            snapshot: snapshot
+                .into_iter()
+                .map(|(high, low)| Uuid { high, low })
+                .collect(),
+            ..Default::default()
+        };
+        py.detach(|| {
+            RUNTIME
+                .block_on(
+                    self.client
+                        .get_data_files_of_single_partition(&partition_info),
+                )
                 .map_err(|error| PyRuntimeError::new_err(error.to_string()))
         })
     }

--- a/python/tests/metadata/test_catalog_api.py
+++ b/python/tests/metadata/test_catalog_api.py
@@ -7,7 +7,13 @@ import pyarrow as pa
 
 import lakesoul.catalog as catalog_module
 from lakesoul.catalog import LakeSoulCatalog, LakeSoulTable, PostgresMetadataConfig
-from lakesoul.metadata import LakeSoulScanPlanPartition, TableInfo
+from lakesoul.metadata import (
+    LakeSoulScanPlanPartition,
+    NativeMetadataClient,
+    PartitionInfo,
+    TableInfo,
+    Uuid,
+)
 
 
 class DummyNativeClient:
@@ -334,3 +340,51 @@ def test_scan_resolves_catalog_context_to_scan_config() -> None:
         "analytics",
     )
     assert client.last_schema_request == ("events", "analytics", True)
+
+
+def test_native_scan_plan_uses_active_files_from_rust_client() -> None:
+    class NativeInner:
+        request: tuple[str, str, list[tuple[int, int]]] | None = None
+
+        def get_data_files_of_single_partition(
+            self,
+            table_id: str,
+            partition_desc: str,
+            snapshot: list[tuple[int, int]],
+        ) -> list[str]:
+            self.request = (table_id, partition_desc, snapshot)
+            return ["active.parquet", "readded.parquet", "new.parquet"]
+
+    inner = NativeInner()
+
+    class ScanPlanClient(NativeMetadataClient):
+        def __init__(self) -> None:
+            self._inner = inner
+
+        def get_table_info_by_name(self, table_name: str, namespace: str) -> TableInfo:
+            return _table_info(
+                table_name=table_name,
+                table_namespace=namespace,
+                partitions="part;",
+            )
+
+        def get_all_partition_info(self, table_id: str) -> list[PartitionInfo]:
+            return [
+                PartitionInfo(
+                    table_id=table_id,
+                    partition_desc="part=north",
+                    snapshot=[Uuid(high=1, low=2)],
+                )
+            ]
+
+    scan_plan = ScanPlanClient().get_scan_plan_partitions(
+        "events", namespace="analytics"
+    )
+
+    assert len(scan_plan) == 1
+    assert scan_plan[0].files == [
+        "active.parquet",
+        "readded.parquet",
+        "new.parquet",
+    ]
+    assert inner.request == ("table-id", "part=north", [(1, 2)])

--- a/rust/lakesoul-metadata/src/metadata_client.rs
+++ b/rust/lakesoul-metadata/src/metadata_client.rs
@@ -8,7 +8,10 @@ use std::fmt::{Debug, Formatter};
 use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::{collections::HashMap, env, fs, vec};
+use std::{
+    collections::{HashMap, HashSet},
+    env, fs, vec,
+};
 
 use postgres::Config;
 use prost::Message;
@@ -1010,18 +1013,7 @@ impl MetaDataClient {
         let data_commit_info_list = self
             .get_data_commit_info_of_single_partition(partition_info)
             .await?;
-        // let data_commit_info_list = Vec::<DataCommitInfo>::new();
-        let data_file_list = data_commit_info_list
-            .iter()
-            .flat_map(|data_commit_info| {
-                data_commit_info
-                    .file_ops
-                    .iter()
-                    .map(|file_op| file_op.path.clone())
-                    .collect::<Vec<String>>()
-            })
-            .collect::<Vec<String>>();
-        Ok(data_file_list)
+        Ok(active_data_files(&data_commit_info_list))
     }
 
     async fn get_data_commit_info_of_single_partition(
@@ -1232,6 +1224,29 @@ pub fn table_path_id_from_table_info(table_info: &TableInfo) -> TablePathId {
     }
 }
 
+fn active_data_files(commits: &[DataCommitInfo]) -> Vec<String> {
+    let mut deleted = HashSet::new();
+    let mut active = Vec::new();
+
+    for file_op in commits
+        .iter()
+        .flat_map(|commit| commit.file_ops.iter())
+        .rev()
+    {
+        match file_op.file_op() {
+            entity::FileOp::Del => {
+                deleted.insert(&file_op.path);
+            }
+            entity::FileOp::Add if !deleted.contains(&file_op.path) => {
+                active.push(file_op.path.clone());
+            }
+            entity::FileOp::Add => {}
+        }
+    }
+    active.reverse();
+    active
+}
+
 fn data_commit_info_list_from_files(
     table_info: &TableInfo,
     files: Vec<DataFileInfo>,
@@ -1372,5 +1387,43 @@ mod tests {
         assert_eq!(commits[0].timestamp, 123);
         assert_eq!(commits[0].domain, "public");
         assert!(commits.iter().all(|commit| commit.commit_id.is_some()));
+    }
+
+    #[test]
+    fn active_data_files_apply_operations_in_snapshot_order() {
+        let file_op = |path: &str, operation: entity::FileOp| entity::DataFileOp {
+            path: path.to_string(),
+            file_op: operation.into(),
+            ..Default::default()
+        };
+        let commits = vec![
+            DataCommitInfo {
+                file_ops: vec![
+                    file_op("replaced.parquet", entity::FileOp::Add),
+                    file_op("readded.parquet", entity::FileOp::Add),
+                    file_op("active.parquet", entity::FileOp::Add),
+                ],
+                ..Default::default()
+            },
+            DataCommitInfo {
+                file_ops: vec![
+                    file_op("replaced.parquet", entity::FileOp::Del),
+                    file_op("readded.parquet", entity::FileOp::Del),
+                ],
+                ..Default::default()
+            },
+            DataCommitInfo {
+                file_ops: vec![
+                    file_op("readded.parquet", entity::FileOp::Add),
+                    file_op("new.parquet", entity::FileOp::Add),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        assert_eq!(
+            active_data_files(&commits),
+            vec!["active.parquet", "readded.parquet", "new.parquet"]
+        );
     }
 }


### PR DESCRIPTION
### Description
In LakeSoul metadata, `DataCommitInfo` records individual `DataFileOp` operations where `file_op` indicates either `Add` (0) or `Del` (1).

Previously, the Rust metadata client flattened all `DataFileOp` paths indiscriminately without checking `file_op`. Python scan planning also queried raw commit records and repeated the same behavior. As a result, deleted or compacted files could be included in active file lists and scan plans.

This PR aligns native metadata behavior with the Scala implementation (`DataOperation.filterFiles`):

1. Add a reverse-traversal `active_data_files` reducer in Rust to replay file operations in snapshot order and exclude deleted paths.
2. Use the reducer from `MetaDataClient::get_data_files_of_single_partition`.
3. Expose that Rust method through PyO3, passing the partition identity and snapshot commit IDs across the boundary.
4. Make Python scan planning consume the native active-file result instead of implementing `Add`/`Del` semantics in Python.
5. Add Rust coverage for `Add -> Del -> Re-Add` behavior and Python coverage for the PyO3 delegation used by scan planning.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- `cargo -q test --package lakesoul-metadata active_data_files`
- `cargo -q check --package lakesoul-python`
- `cargo -q test --package lakesoul-python`
- `cd python && uv run pytest tests/metadata/test_catalog_api.py`
