### PR TITLE
[Rust] Fix Vortex merge ordering and simplify distribution builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,3 +54,25 @@ copy-to-java ext="dylib":
   mkdir -p lakesoul-common/target/classes/
   cp rust/target/debug/liblakesoul_io_c.{{ext}} lakesoul-common/target/classes/
   cp rust/target/debug/liblakesoul_metadata_c.{{ext}} lakesoul-common/target/classes/
+
+dist:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export ROOT="$PWD"
+    export CARGO_TARGET_DIR="$ROOT/rust/target"
+    mkdir -p "$ROOT/dist"
+
+    cd "$ROOT/python"
+    uvx --from 'maturin[zig]==1.14.1' maturin build \
+        --release \
+        --zig \
+        --target x86_64-unknown-linux-gnu \
+        --features 'pyo3/extension-module,dist-ffi' \
+        --auditwheel repair \
+        --compatibility manylinux2014 \
+        --out "$ROOT/dist"
+
+    cp \
+        "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/deps/liblakesoul_io_c.so" \
+        "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/deps/liblakesoul_metadata_c.so" \
+        "$ROOT/dist/"

--- a/python/justfile
+++ b/python/justfile
@@ -15,9 +15,6 @@ pytest:
 sync:
     uv sync --reinstall-package lakesoul
 
-dist:
-    uvx --from 'maturin[zig]' maturin build --release --zig --target x86_64-unknown-linux-gnu --auditwheel repair --compatibility manylinux2014 --out ../dist
-
 # must use venv python
 # must in python dir
 compact engines="jvm" mode="smoke":

--- a/rust/lakesoul-io/src/physical_plan/merge/mod.rs
+++ b/rust/lakesoul-io/src/physical_plan/merge/mod.rs
@@ -7,12 +7,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow_schema::{Field, Schema, SchemaRef};
+use arrow_schema::{Field, Schema, SchemaRef, SortOptions};
 use datafusion::catalog::memory::DataSourceExec;
 use datafusion::dataframe::DataFrame;
+use datafusion::datasource::physical_plan::FileScanConfigBuilder;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion::logical_expr::Expr;
-use datafusion::physical_expr::{EquivalenceProperties, LexOrdering};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalSortExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::{ExecutionPlanProperties, Partitioning, PlanProperties};
 use datafusion::prelude::SessionContext;
@@ -36,6 +38,40 @@ use crate::stream::default_column::DefaultColumnStream;
 use crate::stream::empty_schema::EmptySchemaStream;
 
 pub mod sorted;
+
+/// Merge-on-read requires every input stream to be sorted by the primary
+/// keys: the k-way merge only merges rows with equal keys when they surface
+/// adjacently across streams. Declare the primary key ordering on each scan
+/// config so file sources preserve file order — the vortex reader otherwise
+/// scans row-group splits concurrently and yields batches out of order,
+/// silently breaking merge-on-read deduplication.
+fn with_primary_key_ordering(
+    config: FileScanConfig,
+    primary_keys: &[String],
+) -> FileScanConfig {
+    if primary_keys.is_empty() {
+        return config;
+    }
+    let table_schema = config.file_source.table_schema().table_schema().clone();
+    let Some(ordering) = LexOrdering::new(
+        primary_keys
+            .iter()
+            .filter_map(|pk| {
+                Column::new_with_schema(pk, &table_schema).ok().map(|col| {
+                    PhysicalSortExpr::new(Arc::new(col), SortOptions::default())
+                })
+            })
+            .collect::<Vec<_>>(),
+    ) else {
+        return config;
+    };
+    if ordering.is_empty() {
+        return config;
+    }
+    FileScanConfigBuilder::from(config)
+        .with_output_ordering(vec![ordering])
+        .build()
+}
 
 /// [`ExecutionPlan`] implementation for the merge on read operation.
 #[derive(Debug)]
@@ -98,6 +134,8 @@ impl MergeParquetExec {
         let mut inputs = Vec::<Arc<dyn ExecutionPlan>>::new();
         for (i, config) in flatten_configs.into_iter().enumerate() {
             debug!("flatten_configs[{i}]:{:?}", config);
+            let config =
+                with_primary_key_ordering(config, io_config.primary_keys.as_slice());
             let single_exec = DataSourceExec::from_data_source(config);
             inputs.push(single_exec);
         }

--- a/rust/lakesoul-io/tests/merge_on_read_vortex.rs
+++ b/rust/lakesoul-io/tests/merge_on_read_vortex.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression test: merge-on-read over multiple vortex files must deduplicate
+//! primary keys exactly.
+//!
+//! The merge-on-read k-way merge requires every input stream to be sorted by
+//! the primary key. The vortex file source reads row-group splits
+//! concurrently and, unless the scan declares an output ordering, emits
+//! batches in completion order — silently breaking the merge's deduplication
+//! and leaking duplicate rows (e2e symptom: `COUNT(*)` exceeds the number of
+//! unique primary keys after an upsert).
+//!
+//! This test writes three vortex files whose id spaces fully overlap (like
+//! repeated upsert batches of the same table), with multiple row-group splits
+//! per file like production data, then reads all files with
+//! `primary_keys=["id"]` and asserts the merged count equals the number of
+//! unique ids. It fails without the ordering declaration in
+//! `MergeParquetExec::new`.
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, Int64Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use lakesoul_io::config::LakeSoulIOConfigBuilder;
+use lakesoul_io::file_format::PhysicalFormat;
+use lakesoul_io::reader::LakeSoulReader;
+use lakesoul_io::writer::create_writer_with_io_config;
+
+/// Number of distinct ids shared by all files.
+const N: i64 = 1_000_000;
+
+fn ids_batch(values: impl IntoIterator<Item = i64>) -> RecordBatch {
+    let col: ArrayRef =
+        Arc::new(Int64Array::from(values.into_iter().collect::<Vec<_>>()));
+    RecordBatch::try_from_iter(vec![("id", col)]).expect("batch construction failed")
+}
+
+/// Write a vortex file containing `ids`, sorted by `id` by the sort writer
+/// (same as the LakeSoul upsert write path). Row groups of 100k rows produce
+/// multiple splits per file, like production files.
+async fn write_vortex_file(path: &str, ids: RecordBatch) {
+    let conf = LakeSoulIOConfigBuilder::new()
+        .with_files(vec![path.to_string()])
+        .with_primary_key("id".to_string())
+        .with_schema(ids.schema())
+        .with_batch_size(8192)
+        .with_max_row_group_size(100_000)
+        .with_physical_format(PhysicalFormat::VortexCompact)
+        .build();
+    let mut writer = create_writer_with_io_config(conf)
+        .await
+        .expect("writer creation failed");
+    writer
+        .write_record_batch(ids)
+        .await
+        .expect("batch write failed");
+    writer.flush_and_close().await.expect("flush failed");
+}
+
+#[tokio::test]
+async fn merge_on_read_dedups_overlapping_vortex_files() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    // Three files with fully overlapping id spaces, like three upsert batches
+    // of the same table. Every row beyond the first occurrence is a duplicate
+    // that merge-on-read must remove.
+    let files: Vec<String> = (0..3)
+        .map(|i| {
+            temp_dir
+                .path()
+                .join(format!("batch{i}.vortex"))
+                .into_os_string()
+                .into_string()
+                .unwrap()
+        })
+        .collect();
+    for f in &files {
+        // unsorted runs so the sort writer must actually sort
+        write_vortex_file(f, ids_batch((1..=N).chain((1..=N).rev()))).await;
+    }
+
+    // Read through the exact production merge-on-read path.
+    let conf = LakeSoulIOConfigBuilder::new()
+        .with_files(files)
+        .with_primary_keys(vec!["id".to_string()])
+        .with_schema(Arc::new(Schema::new(vec![Field::new(
+            "id",
+            DataType::Int64,
+            false,
+        )])))
+        .with_batch_size(8192)
+        .with_thread_num(4)
+        .with_hash_bucket_num("2".to_string())
+        .build();
+    let mut reader = LakeSoulReader::new(conf).expect("reader creation failed");
+    reader.start().await.expect("reader start failed");
+
+    let mut count = 0usize;
+    while let Some(rb) = reader.next_rb().await {
+        count += rb.expect("batch read failed").num_rows();
+    }
+
+    assert_eq!(
+        count, N as usize,
+        "merge-on-read must deduplicate overlapping primary keys exactly"
+    );
+}


### PR DESCRIPTION
## Summary

- add a root `dist` recipe that builds the Python wheel and native FFI libraries in one invocation
- remove the duplicate Python-local distribution recipe
- declare primary-key output ordering on each merge-on-read file scan
- preserve Vortex split emission order before the sorted k-way merge
- add a regression test covering overlapping keys across multi-split Vortex files

## Merge-on-read fix

Vortex reads row-group splits concurrently. Without an output ordering declaration, batches can be emitted in completion order rather than file order. `SortedStreamMerger` requires each input stream to remain sorted by the primary key, so out-of-order batches can leak duplicate rows after upserts.

## Distribution build

The root `dist` recipe uses one pinned Maturin/Zig invocation with the `dist-ffi` feature, writes the repaired manylinux wheel to `dist/`, and copies `liblakesoul_io_c.so` and `liblakesoul_metadata_c.so` from the same Cargo target directory.

## Testing

- `cargo fmt --all --check`
- `cargo -q test -p lakesoul-io --test merge_on_read_vortex`
- `LAKESOUL_IO_USE_V2_MERGE=true cargo -q test -p lakesoul-io --test merge_on_read_vortex`
- `cargo -q clippy -p lakesoul-io --test merge_on_read_vortex -- -D warnings`
- `just --list`
- `just --dry-run dist`
- `cargo -q build -p lakesoul-python --release --target x86_64-unknown-linux-gnu --features pyo3/extension-module,dist-ffi`