### PR TITLE
[Vector] CAS-free commit protocol for manifest updates on all object stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5043,6 +5043,7 @@ dependencies = [
 name = "lakesoul-vector"
 version = "4.0.0-dev.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "crc32fast",
  "faer",

--- a/rust/lakesoul-vector/Cargo.toml
+++ b/rust/lakesoul-vector/Cargo.toml
@@ -45,6 +45,7 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+async-trait = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/lakesoul-vector/src/rabitq/ivf/builder.rs
+++ b/rust/lakesoul-vector/src/rabitq/ivf/builder.rs
@@ -114,18 +114,13 @@ impl IvfRabitqBuilder {
         use_faster_config: bool,
     ) -> Result<Self, RabitqError> {
         if crate::rabitq::manifest::manifest_exists(mstore).await {
-            // Try LATEST first, fall back to legacy manifest.bin
+            // Resolve the current view (LATEST hint + unique commits),
+            // falling back to the legacy manifest.bin when nothing newer
+            // exists.
             let (header, cluster_map) =
-                match crate::rabitq::manifest::read_latest(mstore).await {
-                    Ok(snap) if snap.generation > 0 => {
-                        crate::rabitq::manifest::load_manifest_by_gen_ver(
-                            mstore,
-                            snap.generation,
-                            snap.version,
-                        )
-                        .await?
-                    }
-                    _ => crate::rabitq::manifest::load_manifest(mstore).await?,
+                match crate::rabitq::manifest::resolve_view(mstore).await? {
+                    Some(view) => (view.header, view.cluster_map),
+                    None => crate::rabitq::manifest::load_manifest(mstore).await?,
                 };
             let mut clusters = Vec::with_capacity(cluster_map.len());
             for entry in cluster_map.values() {
@@ -560,11 +555,14 @@ impl IvfRabitqBuilder {
                     });
                 }
 
-                // 3. CAS loop: read LATEST, write versioned manifest, CAS-write LATEST.
-                let latest = manifest::read_latest(mstore).await?;
-                let new_version = latest.version + 1;
+                // 3. Commit the delta via the CAS-free protocol: publish an
+                //    immutable uniquely-named manifest and advance the
+                //    LATEST hint; concurrent writers are reconciled by
+                //    union-merging the derived view.  cluster_map carries
+                //    the appended delta segments (deduped by filename when
+                //    merged against the freshest view).
                 let header = ManifestHeader {
-                    generation: latest.generation,
+                    generation: 0, // filled from the resolved view by commit_delta
                     dim: index.dim,
                     padded_dim: index.padded_dim,
                     metric: index.metric,
@@ -573,46 +571,7 @@ impl IvfRabitqBuilder {
                     ex_bits: index.ex_bits,
                     total_bits: index.ex_bits + 1,
                 };
-
-                // Write the new immutable versioned manifest.
-                manifest::save_manifest(mstore, &header, &cluster_map, new_version)
-                    .await?;
-
-                // CAS the LATEST pointer.
-                match manifest::write_latest(
-                    mstore,
-                    latest.generation,
-                    new_version,
-                    latest.e_tag,
-                )
-                .await
-                {
-                    Ok(_) => {} // committed
-                    Err(RabitqError::VersionConflict) => {
-                        // Check if generation changed (compaction happened).
-                        let latest2 = manifest::read_latest(mstore).await?;
-                        if latest2.generation != latest.generation {
-                            return Err(RabitqError::GenerationConflict);
-                        }
-                        // Same generation, just concurrent flush — retry once.
-                        let new_version2 = latest2.version + 1;
-                        manifest::save_manifest(
-                            mstore,
-                            &header,
-                            &cluster_map,
-                            new_version2,
-                        )
-                        .await?;
-                        manifest::write_latest(
-                            mstore,
-                            latest2.generation,
-                            new_version2,
-                            latest2.e_tag,
-                        )
-                        .await?;
-                    }
-                    Err(e) => return Err(e),
-                }
+                manifest::commit_delta(mstore, &header, &cluster_map).await?;
 
                 // 4. Reset clusters to centroid-only state for next insert cycle.
                 for &cid_u32 in &dirty_cids {

--- a/rust/lakesoul-vector/src/rabitq/ivf/mod.rs
+++ b/rust/lakesoul-vector/src/rabitq/ivf/mod.rs
@@ -1788,8 +1788,10 @@ impl IvfRabitqIndex {
                 },
             );
         }
-        manifest::save_manifest(mstore, &header, &cluster_map, 0).await?;
-        manifest::write_latest(mstore, 1, 0, None).await?;
+        // A fresh build replaces everything: publish as a new-generation
+        // commit at base key (0, 0) so concurrent fresh builds conflict
+        // instead of duplicating segments.
+        manifest::commit_rebuild(mstore, &header, &cluster_map, (0, 0)).await?;
         println!(
             "Saved V4 index: {} clusters, {} base segments",
             self.clusters.len(),
@@ -1804,18 +1806,12 @@ impl IvfRabitqIndex {
     /// deltas) for every cluster, merging them into a single `ClusterData`
     /// in memory.
     pub async fn load_from_v4(mstore: &ManifestStore) -> Result<Self, RabitqError> {
-        // Try LATEST → versioned manifest first, fall back to legacy manifest.bin.
+        // Resolve the current view (LATEST hint + unique commits), fall
+        // back to the legacy manifest.bin when nothing newer exists.
         let (header, cluster_map) =
-            match crate::rabitq::manifest::read_latest(mstore).await {
-                Ok(snap) if snap.generation > 0 => {
-                    crate::rabitq::manifest::load_manifest_by_gen_ver(
-                        mstore,
-                        snap.generation,
-                        snap.version,
-                    )
-                    .await?
-                }
-                _ => crate::rabitq::manifest::load_manifest(mstore).await?,
+            match crate::rabitq::manifest::resolve_view(mstore).await? {
+                Some(view) => (view.header, view.cluster_map),
+                None => crate::rabitq::manifest::load_manifest(mstore).await?,
             };
         let mut clusters = Vec::with_capacity(cluster_map.len());
         for entry in cluster_map.values() {
@@ -2086,135 +2082,124 @@ impl IvfRabitqIndex {
     }
 
     /// Compaction: merge all delta segments into new base segments,
-    /// bump the generation, and atomically update the LATEST pointer.
+    /// bump the generation, and publish a new commit.
     ///
-    /// Reads the current manifest, loads all segments (base + deltas) for
-    /// every cluster, merges them in memory, writes new base segments
-    /// (version 0), writes a new manifest with `generation+1`, and
-    /// CAS-updates LATEST.
-    ///
-    /// Old segment files are **not** deleted (object-store immutability).
-    /// Other readers continue to use the old generation until they re-read
-    /// LATEST.
+    /// Reads the current derived view, loads all segments (base + deltas)
+    /// for every cluster, merges them in memory, writes new base segments
+    /// (version 0) with unique names, and publishes a new generation via
+    /// [`commit_rebuild`].  Old segments and manifests are **not**
+    /// deleted — the index only ever grows, so readers that resolved an
+    /// older view keep working.  If a concurrent writer publishes while
+    /// compaction runs, the merge is redone against the fresher view.
     pub async fn compact_v4(mstore: &ManifestStore) -> Result<(), RabitqError> {
         use crate::rabitq::manifest::{
             self, ClusterManifestEntry, ClusterSegmentData, ManifestHeader,
             SegmentManifestEntry,
         };
 
-        // 1. Read current LATEST and load manifest.
-        let latest = manifest::read_latest(mstore).await?;
-        let (_, cluster_map) = if latest.generation > 0 {
-            manifest::load_manifest_by_gen_ver(mstore, latest.generation, latest.version)
+        for _ in 0..manifest::COMMIT_RETRIES {
+            // 1. Resolve the current view; abort on an empty store.
+            let view = manifest::resolve_view(mstore)
                 .await?
-        } else {
-            manifest::load_manifest(mstore).await?
-        };
+                .ok_or(RabitqError::InvalidPersistence("no vector index found"))?;
+            let base_key = view.key();
+            let cluster_map = view.cluster_map;
+            let old_header = &view.header;
+            let new_gen = base_key.0.max(1) + 1;
+            println!(
+                "Compaction: gen {} → {}, {} clusters",
+                base_key.0.max(1),
+                new_gen,
+                cluster_map.len()
+            );
 
-        let new_gen = latest.generation.max(1) + 1;
-        println!(
-            "Compaction: gen {} → {}, {} clusters",
-            latest.generation.max(1),
-            new_gen,
-            cluster_map.len()
-        );
+            // 2. Merge all segments for each cluster and write new base.
+            let mut new_map: std::collections::BTreeMap<u32, ClusterManifestEntry> =
+                std::collections::BTreeMap::new();
 
-        // 2. Merge all segments for each cluster and write new base.
-        let mut new_map: std::collections::BTreeMap<u32, ClusterManifestEntry> =
-            std::collections::BTreeMap::new();
-
-        for (&cid, entry) in cluster_map.iter() {
-            // Merge all segments (base + deltas) for this cluster.
-            let mut merged: Option<ClusterData> = None;
-            for seg_entry in &entry.segments {
-                let seg =
-                    manifest::read_segment_full(mstore, &seg_entry.segment_filename)
-                        .await?;
-                let cd = ClusterData::from_segment(seg);
-                if let Some(m) = merged.as_mut() {
-                    m.ids.extend_from_slice(&cd.ids);
-                    m.batch_data.extend_from_slice(&cd.batch_data);
-                    m.ex_codes_packed.extend_from_slice(&cd.ex_codes_packed);
-                    m.f_add_ex.extend_from_slice(&cd.f_add_ex);
-                    m.f_rescale_ex.extend_from_slice(&cd.f_rescale_ex);
-                    m.delta.extend_from_slice(&cd.delta);
-                    m.vl.extend_from_slice(&cd.vl);
-                    m.num_vectors += cd.num_vectors;
-                } else {
-                    merged = Some(cd);
+            for (&cid, entry) in cluster_map.iter() {
+                // Merge all segments (base + deltas) for this cluster.
+                let mut merged: Option<ClusterData> = None;
+                for seg_entry in &entry.segments {
+                    let seg =
+                        manifest::read_segment_full(mstore, &seg_entry.segment_filename)
+                            .await?;
+                    let cd = ClusterData::from_segment(seg);
+                    if let Some(m) = merged.as_mut() {
+                        m.ids.extend_from_slice(&cd.ids);
+                        m.batch_data.extend_from_slice(&cd.batch_data);
+                        m.ex_codes_packed.extend_from_slice(&cd.ex_codes_packed);
+                        m.f_add_ex.extend_from_slice(&cd.f_add_ex);
+                        m.f_rescale_ex.extend_from_slice(&cd.f_rescale_ex);
+                        m.delta.extend_from_slice(&cd.delta);
+                        m.vl.extend_from_slice(&cd.vl);
+                        m.num_vectors += cd.num_vectors;
+                    } else {
+                        merged = Some(cd);
+                    }
                 }
+
+                let cd = merged.ok_or_else(|| {
+                    RabitqError::InvalidPersistence("cluster has no segments")
+                })?;
+
+                // Write new compacted base segment (version 0).
+                let fname = manifest::segment_filename(cid, 0);
+                let seg_data = ClusterSegmentData::from_cluster_data(
+                    cid,
+                    cd.centroid.clone(),
+                    cd.padded_dim,
+                    cd.ex_bits,
+                    cd.ids.clone(),
+                    cd.batch_data.clone(),
+                    cd.ex_codes_packed.clone(),
+                    cd.f_add_ex.clone(),
+                    cd.f_rescale_ex.clone(),
+                    cd.delta.clone(),
+                    cd.vl.clone(),
+                );
+                let file_size =
+                    manifest::write_segment(mstore, &fname, &seg_data, 0).await?;
+
+                new_map.insert(
+                    cid,
+                    ClusterManifestEntry {
+                        cluster_id: cid,
+                        segments: vec![SegmentManifestEntry {
+                            segment_filename: fname,
+                            segment_version: 0,
+                            num_vectors: cd.num_vectors as u32,
+                            file_size,
+                        }],
+                    },
+                );
             }
 
-            let cd = merged.ok_or_else(|| {
-                RabitqError::InvalidPersistence("cluster has no segments")
-            })?;
-
-            // Write new compacted base segment (version 0).
-            let fname = manifest::segment_filename(cid, 0);
-            let seg_data = ClusterSegmentData::from_cluster_data(
-                cid,
-                cd.centroid.clone(),
-                cd.padded_dim,
-                cd.ex_bits,
-                cd.ids.clone(),
-                cd.batch_data.clone(),
-                cd.ex_codes_packed.clone(),
-                cd.f_add_ex.clone(),
-                cd.f_rescale_ex.clone(),
-                cd.delta.clone(),
-                cd.vl.clone(),
-            );
-            let file_size = manifest::write_segment(mstore, &fname, &seg_data, 0).await?;
-
-            new_map.insert(
-                cid,
-                ClusterManifestEntry {
-                    cluster_id: cid,
-                    segments: vec![SegmentManifestEntry {
-                        segment_filename: fname,
-                        segment_version: 0,
-                        num_vectors: cd.num_vectors as u32,
-                        file_size,
-                    }],
-                },
-            );
+            // 3. Publish a new-generation commit; retry on concurrent writes.
+            let header = ManifestHeader {
+                generation: new_gen,
+                dim: old_header.dim,
+                padded_dim: old_header.padded_dim,
+                metric: old_header.metric,
+                rotator_type: old_header.rotator_type,
+                rotator_data: old_header.rotator_data.clone(),
+                ex_bits: old_header.ex_bits,
+                total_bits: old_header.total_bits,
+            };
+            match manifest::commit_rebuild(mstore, &header, &new_map, base_key).await {
+                Ok(()) => {
+                    println!(
+                        "Compaction complete: gen {} ({} segments)",
+                        new_gen,
+                        new_map.len()
+                    );
+                    return Ok(());
+                }
+                Err(RabitqError::CommitConflict) => continue,
+                Err(e) => return Err(e),
+            }
         }
-
-        // 3. Write new-gen manifest (version 1), carrying forward header config.
-        let (old_header, _) = if latest.generation > 0 {
-            manifest::load_manifest_by_gen_ver(mstore, latest.generation, latest.version)
-                .await?
-        } else {
-            manifest::load_manifest(mstore).await?
-        };
-        let header = ManifestHeader {
-            generation: new_gen,
-            dim: old_header.dim,
-            padded_dim: old_header.padded_dim,
-            metric: old_header.metric,
-            rotator_type: old_header.rotator_type,
-            rotator_data: old_header.rotator_data,
-            ex_bits: old_header.ex_bits,
-            total_bits: old_header.total_bits,
-        };
-        manifest::save_manifest(mstore, &header, &new_map, 1).await?;
-
-        // 4. CAS-update LATEST.
-        manifest::write_latest(mstore, new_gen, 1, latest.e_tag).await
-            .map_err(|e| {
-                if matches!(e, RabitqError::VersionConflict) {
-                    RabitqError::InvalidPersistence(
-                        "compaction conflict: another process wrote LATEST during compaction"
-                    )
-                } else { e }
-            })?;
-
-        println!(
-            "Compaction complete: gen {} ({} segments)",
-            new_gen,
-            new_map.len()
-        );
-        Ok(())
+        Err(RabitqError::CommitConflict)
     }
 }
 
@@ -2285,17 +2270,6 @@ where
     use builder::IvfRabitqBuilder;
     use futures::StreamExt;
 
-    // 1. Read current LATEST, determine new generation.
-    let latest = manifest::read_latest(mstore).await?;
-    let new_gen = latest.generation.max(1) + 1;
-    println!(
-        "rebuild_v4: gen {} → {} ({} clusters, {} bits)",
-        latest.generation.max(1),
-        new_gen,
-        nlist,
-        total_bits
-    );
-
     // 2. Always fresh builder — rebuild must train new centroids.
     let mut builder = IvfRabitqBuilder::new(
         dim,
@@ -2334,8 +2308,9 @@ where
         index.estimate_memory_mb()
     );
 
-    // 3. Persist with new generation.
-    // Write base segments (version 0) per cluster, then versioned manifest.
+    // 3. Persist with a new generation via the CAS-free commit protocol:
+    //    write unique-named base segments (version 0) per cluster, then
+    //    publish a new-generation commit.
     let mut cluster_map: std::collections::BTreeMap<u32, ClusterManifestEntry> =
         std::collections::BTreeMap::new();
     for (i, cluster) in index.clusters.iter().enumerate() {
@@ -2370,7 +2345,7 @@ where
     }
 
     let header = ManifestHeader {
-        generation: new_gen,
+        generation: 1,
         dim: index.dim,
         padded_dim: index.padded_dim,
         metric: index.metric,
@@ -2379,28 +2354,33 @@ where
         ex_bits: index.ex_bits,
         total_bits: index.ex_bits + 1,
     };
-    manifest::save_manifest(mstore, &header, &cluster_map, 1).await?;
-
-    // 4. CAS LATEST.
-    manifest::write_latest(mstore, new_gen, 1, latest.e_tag)
-        .await
-        .map_err(|e| {
-            if matches!(e, RabitqError::VersionConflict) {
-                RabitqError::InvalidPersistence(
-                    "rebuild conflict: another process wrote LATEST during rebuild",
-                )
-            } else {
-                e
+    // Rebuilds produce a complete new generation.  If the view moved
+    // (e.g. a flush landed mid-rebuild), retry the whole rebuild against
+    // the fresher base so no committed delta is ever dropped.
+    for _ in 0..manifest::COMMIT_RETRIES {
+        let base_key = match manifest::resolve_view(mstore).await? {
+            Some(view) => view.key(),
+            None => (0, 0),
+        };
+        let new_gen = base_key.0.max(1) + 1;
+        let mut gen_header = header.clone();
+        gen_header.generation = new_gen;
+        match manifest::commit_rebuild(mstore, &gen_header, &cluster_map, base_key).await
+        {
+            Ok(()) => {
+                println!(
+                    "rebuild_v4 complete: gen {} ({} base segments, {} vectors)",
+                    new_gen,
+                    cluster_map.len(),
+                    index.len()
+                );
+                return Ok(());
             }
-        })?;
-
-    println!(
-        "rebuild_v4 complete: gen {} ({} base segments, {} vectors)",
-        new_gen,
-        cluster_map.len(),
-        index.len()
-    );
-    Ok(())
+            Err(RabitqError::CommitConflict) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(RabitqError::CommitConflict)
 }
 
 // ----------------------------------------------------------------------------

--- a/rust/lakesoul-vector/src/rabitq/manifest.rs
+++ b/rust/lakesoul-vector/src/rabitq/manifest.rs
@@ -6,14 +6,27 @@
 //! |---------|-----------|-------------|
 //! | 1       | initial   | Single segment per cluster |
 //! | 2       | delta-seg | Multiple (base + delta) segments per cluster |
+//! | 3       | commit    | Generation+version control, CAS-free commit protocol |
+//!
+//! ## Commit protocol (V3)
+//!
+//! Every commit is an **immutable, uniquely named** manifest under
+//! `manifests/`; nothing is ever overwritten or deleted.  The current view
+//! is derived by listing `manifests/` and taking the newest commit
+//! (max generation, then max version, tie-broken by unioning every commit
+//! at the max key).  `LATEST` is a best-effort hint whose value is
+//! `generation:version:<manifest-filename>`; it is written with a plain
+//! overwrite, never with conditional headers, so the protocol works on any
+//! object store (S3, Aliyun OSS, local disk) without `If-Match` support.
 //!
 //! V2 is always written; V1 can still be read (auto-upgraded on next write).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::io::{Cursor, Read, Write};
 use std::sync::Arc;
 
 use crc32fast::Hasher;
+use futures::StreamExt;
 use object_store::path::Path as StorePath;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload, WriteMultipart};
 
@@ -77,10 +90,41 @@ impl ManifestStore {
     }
 }
 
-/// Manifest directory + filename for a specific (generation, version) pair.
+/// Manifest directory + filename for a specific (generation, version) pair
+/// (legacy deterministic name, written by V2-era code).
 pub fn versioned_manifest_filename(generation: u64, version: u64) -> String {
     format!("{MANIFESTS_PREFIX}/g{generation:08}_v{version:08}.bin")
 }
+
+/// Manifest filename with a unique suffix, so concurrent commits never
+/// overwrite each other.
+pub fn versioned_manifest_filename_unique(generation: u64, version: u64) -> String {
+    format!(
+        "{MANIFESTS_PREFIX}/g{generation:08}_v{version:08}_{}.bin",
+        unique_suffix()
+    )
+}
+
+/// 16-hex-char random suffix for immutable object names.
+fn unique_suffix() -> String {
+    format!("{:016x}", rand::random::<u64>())
+}
+
+/// Parse a manifest object name into its (generation, version) key.
+/// Accepts both the legacy deterministic name and the unique-suffix form.
+fn parse_manifest_key(name: &str) -> Option<(u64, u64)> {
+    let base = name.strip_suffix(".bin")?;
+    let parts = base.split('_').collect::<Vec<_>>();
+    if parts.len() < 2 {
+        return None;
+    }
+    let generation = parts[0].strip_prefix('g')?.parse().ok()?;
+    let version = parts[1].strip_prefix('v')?.parse().ok()?;
+    Some((generation, version))
+}
+
+/// Maximum number of publish/verify rounds per commit.
+pub const COMMIT_RETRIES: usize = 3;
 
 // ---- little-endian read/write with optional hasher ----
 
@@ -223,11 +267,14 @@ pub struct ManifestHeader {
     pub total_bits: usize,
 }
 
-/// Latest snapshot pointer: (generation, version, e_tag).
+/// Latest snapshot pointer: (generation, version, optional manifest
+/// filename, e_tag).  ``manifest_filename`` is set for LATEST v2 values
+/// written by the V3 commit protocol; None for legacy `gen:ver` values.
 #[derive(Debug, Clone)]
 pub struct LatestSnapshot {
     pub generation: u64,
     pub version: u64,
+    pub manifest_filename: Option<String>,
     pub e_tag: Option<String>,
 }
 
@@ -439,7 +486,20 @@ pub async fn save_manifest(
     cluster_map: &BTreeMap<u32, ClusterManifestEntry>,
     version: u64,
 ) -> Result<(), RabitqError> {
-    let key = mstore.full_path(&versioned_manifest_filename(header.generation, version));
+    let key = versioned_manifest_filename(header.generation, version);
+    save_manifest_to(mstore, header, cluster_map, &key).await
+}
+
+/// Write a manifest to an explicit (relative) key.  The key must be unique
+/// for every commit — the caller passes a uniquely named filename — so
+/// concurrent writers never overwrite each other's commits.
+pub async fn save_manifest_to(
+    mstore: &ManifestStore,
+    header: &ManifestHeader,
+    cluster_map: &BTreeMap<u32, ClusterManifestEntry>,
+    key: &str,
+) -> Result<(), RabitqError> {
+    let key = mstore.full_path(key);
     let mut b = Vec::new();
     b.write_all(&V4_MANIFEST_MAGIC).unwrap();
     wle!(b, V4_MANIFEST_VERSION, u32);
@@ -727,7 +787,10 @@ pub async fn write_segment(
 // ---- helpers ----
 
 pub fn segment_filename(cluster_id: u32, version: u32) -> String {
-    format!("cluster_{cluster_id:04}_{version:04}.seg")
+    format!(
+        "cluster_{cluster_id:04}_{version:04}_{}.seg",
+        unique_suffix()
+    )
 }
 
 pub async fn delete_segment(
@@ -743,7 +806,11 @@ pub async fn delete_segment(
 
 // ---- version control: LATEST file ----
 
-/// Read LATEST to get the current (generation, version) and etag for CAS.
+/// Read LATEST to get the current (generation, version) hint.
+///
+/// Accepts both the legacy `generation:version` format and the V3
+/// `generation:version:<manifest-filename>` format.  When no LATEST file
+/// exists, returns a zeroed snapshot (generation=0, version=0).
 pub async fn read_latest(mstore: &ManifestStore) -> Result<LatestSnapshot, RabitqError> {
     let key = mstore.full_path(LATEST_FILENAME);
     match mstore.store.head(&key).await {
@@ -767,81 +834,280 @@ pub async fn read_latest(mstore: &ManifestStore) -> Result<LatestSnapshot, Rabit
                 parts.next().and_then(|s| s.parse().ok()).ok_or_else(|| {
                     RabitqError::InvalidPersistence("LATEST invalid format")
                 })?;
+            let filename = parts.next().map(str::to_string);
             Ok(LatestSnapshot {
                 generation: gen_val,
                 version: ver,
+                manifest_filename: filename,
                 e_tag: meta.e_tag,
             })
         }
         Err(object_store::Error::NotFound { .. }) => Ok(LatestSnapshot {
             generation: 0,
             version: 0,
+            manifest_filename: None,
             e_tag: None,
         }),
         Err(e) => Err(os_err(e)),
     }
 }
 
-/// Atomically write LATEST using CAS (If-Match on the expected etag).
-/// Returns the new etag on success, or `Error::VersionConflict` if the etag
-/// didn't match (someone else updated LATEST first).
+/// Write the LATEST hint as `generation:version:<manifest-filename>`.
+///
+/// This is a plain overwrite — no conditional headers (`If-Match`) are
+/// used, so it works on every object store (S3, Aliyun OSS, local disk).
+/// Concurrency safety comes from the immutable uniquely-named commits and
+/// the derived view in [`resolve_view`], not from this pointer.
 pub async fn write_latest(
     mstore: &ManifestStore,
     generation: u64,
     version: u64,
-    expected_etag: Option<String>,
-) -> Result<Option<String>, RabitqError> {
-    use object_store::PutMode;
+    manifest_filename: &str,
+) -> Result<(), RabitqError> {
     let key = mstore.full_path(LATEST_FILENAME);
-    let content = format!("{generation}:{version}");
-    // Try CAS (Update) first if etag is provided and store type supports it.
-    // On LocalFileSystem and other stores without CAS support, fall back to
-    // Overwrite.  We detect this by a generic error catch rather than pattern
-    // matching, because object_store::Error variants differ across versions.
-    let content_bytes = content.into_bytes();
-    let make_payload = || PutPayload::from_bytes(content_bytes.clone().into());
-    let result = if let Some(ref tag) = expected_etag {
-        let update_opts = object_store::PutOptions {
-            mode: PutMode::Update(object_store::UpdateVersion {
-                e_tag: Some(tag.clone()),
-                version: None,
-            }),
-            ..Default::default()
-        };
-        match mstore
-            .store
-            .put_opts(&key, make_payload(), update_opts)
-            .await
-        {
-            Ok(r) => Ok(r),
-            Err(object_store::Error::Precondition { .. }) => {
-                Err(RabitqError::VersionConflict)
-            }
-            Err(_) => {
-                // Fallback: store might not support CAS (e.g. LocalFileSystem)
-                let overwrite_opts = object_store::PutOptions {
-                    mode: PutMode::Overwrite,
-                    ..Default::default()
-                };
-                mstore
-                    .store
-                    .put_opts(&key, make_payload(), overwrite_opts)
-                    .await
-                    .map_err(os_err)
+    let content = format!("{generation}:{version}:{manifest_filename}");
+    mstore
+        .store
+        .put(&key, PutPayload::from_bytes(content.into_bytes().into()))
+        .await
+        .map(|_| ())
+        .map_err(os_err)
+}
+
+// ---- V3 commit protocol ----
+
+/// The current derived view of an index: the newest commit key and the
+/// union of every commit at that key (concurrent writers that published at
+/// the same (generation, version) are merged by segment filename).
+#[derive(Debug, Clone)]
+pub struct ResolvedView {
+    pub generation: u64,
+    pub version: u64,
+    pub header: ManifestHeader,
+    pub cluster_map: BTreeMap<u32, ClusterManifestEntry>,
+    /// Relative manifest filenames of every commit at the resolved key.
+    pub manifest_filenames: Vec<String>,
+}
+
+impl ResolvedView {
+    /// (generation, version) key of this view.
+    pub fn key(&self) -> (u64, u64) {
+        (self.generation, self.version)
+    }
+}
+
+/// Resolve the current index view without any conditional writes.
+///
+/// Candidates are the LATEST pointer (when present) and every object
+/// listed under `manifests/`.  The newest key wins; all commits at that
+/// key are unioned so that concurrent writers never lose data.  When
+/// nothing exists at all, returns `None`; when only the legacy
+/// `manifest.bin` exists, returns a view at key (0, 0) from it.
+pub async fn resolve_view(
+    mstore: &ManifestStore,
+) -> Result<Option<ResolvedView>, RabitqError> {
+    let dir = mstore.full_path(MANIFESTS_PREFIX);
+    let mut listed: Vec<(u64, u64, String)> = Vec::new();
+    let mut stream = mstore.store.list(Some(&dir));
+    while let Some(meta) = stream.next().await {
+        let meta = meta.map_err(os_err)?;
+        if let Some(filename) = meta.location.filename() {
+            let filename = filename.to_string();
+            if let Some((generation, version)) = parse_manifest_key(&filename) {
+                listed.push((
+                    generation,
+                    version,
+                    format!("{MANIFESTS_PREFIX}/{filename}"),
+                ));
             }
         }
+    }
+
+    let snap = read_latest(mstore).await?;
+    let pointer: Option<(u64, u64, String)> = if snap.generation > 0 {
+        Some((
+            snap.generation,
+            snap.version,
+            snap.manifest_filename.clone().unwrap_or_else(|| {
+                versioned_manifest_filename(snap.generation, snap.version)
+            }),
+        ))
     } else {
-        let opts = object_store::PutOptions {
-            mode: PutMode::Overwrite,
-            ..Default::default()
-        };
-        mstore
-            .store
-            .put_opts(&key, make_payload(), opts)
-            .await
-            .map_err(os_err)
+        None
     };
-    result.map(|r| r.e_tag)
+
+    // Collect candidate (key, filename) pairs.  A pointer whose manifest is
+    // missing is skipped — the listed commits remain authoritative.
+    let mut candidates: Vec<(u64, u64, String)> = Vec::new();
+    if let Some((generation, version, fname)) = &pointer
+        && read_manifest_bytes(mstore, fname).await.is_ok()
+    {
+        candidates.push((*generation, *version, fname.clone()));
+    }
+    for (generation, version, fname) in &listed {
+        if !candidates.iter().any(|(_, _, f)| f == fname) {
+            candidates.push((*generation, *version, fname.clone()));
+        }
+    }
+
+    if candidates.is_empty() {
+        // Nothing under manifests/ and no usable pointer: fall back to the
+        // legacy single manifest.bin (V1/V2), or None if the store is empty.
+        if mstore
+            .store
+            .head(&mstore.full_path(MANIFEST_FILENAME))
+            .await
+            .is_ok()
+        {
+            let (header, cluster_map) = load_manifest(mstore).await?;
+            return Ok(Some(ResolvedView {
+                generation: 0,
+                version: 0,
+                header,
+                cluster_map,
+                manifest_filenames: Vec::new(),
+            }));
+        }
+        return Ok(None);
+    }
+
+    let max_key = candidates.iter().map(|(g, v, _)| (*g, *v)).max().unwrap();
+    let mut cluster_map: BTreeMap<u32, ClusterManifestEntry> = BTreeMap::new();
+    let mut header: Option<ManifestHeader> = None;
+    let mut manifest_filenames = Vec::new();
+    for (generation, version, fname) in &candidates {
+        if (*generation, *version) != max_key {
+            continue;
+        }
+        let (h, map) = read_manifest_bytes(mstore, fname).await?;
+        if header.is_none() {
+            header = Some(h);
+        }
+        cluster_map = merge_cluster_maps(&cluster_map, &map);
+        manifest_filenames.push(fname.clone());
+    }
+    let header = header.ok_or(RabitqError::InvalidPersistence(
+        "manifest list did not yield a header",
+    ))?;
+    Ok(Some(ResolvedView {
+        generation: max_key.0,
+        version: max_key.1,
+        header,
+        cluster_map,
+        manifest_filenames,
+    }))
+}
+
+/// Union two cluster maps: per cluster, append segments from `extra` that
+/// are not already referenced (dedup by segment filename).  A segment is
+/// immutable and uniquely named, so unioning is idempotent.
+pub fn merge_cluster_maps(
+    base: &BTreeMap<u32, ClusterManifestEntry>,
+    extra: &BTreeMap<u32, ClusterManifestEntry>,
+) -> BTreeMap<u32, ClusterManifestEntry> {
+    let mut out = base.clone();
+    for (&cid, entry) in extra {
+        match out.get_mut(&cid) {
+            Some(existing) => {
+                let existing_filenames: HashSet<String> = existing
+                    .segments
+                    .iter()
+                    .map(|s| s.segment_filename.clone())
+                    .collect();
+                for seg in &entry.segments {
+                    if !existing_filenames.contains(&seg.segment_filename) {
+                        existing.segments.push(seg.clone());
+                    }
+                }
+            }
+            None => {
+                out.insert(cid, entry.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Commit an incremental delta flush.
+///
+/// Publishes a new commit at `(view.generation, view.version + 1)` whose
+/// cluster map is the union of the current resolved view and *deltas*.
+/// Retries by rebasing onto the freshest view whenever a concurrent writer
+/// publishes first; fails loudly (rather than silently losing data) when
+/// the retry budget is exhausted.
+pub async fn commit_delta(
+    mstore: &ManifestStore,
+    header: &ManifestHeader,
+    deltas: &BTreeMap<u32, ClusterManifestEntry>,
+) -> Result<(), RabitqError> {
+    for _ in 0..COMMIT_RETRIES {
+        let view = match resolve_view(mstore).await? {
+            Some(v) => v,
+            None => ResolvedView {
+                generation: 0,
+                version: 0,
+                header: header.clone(),
+                cluster_map: BTreeMap::new(),
+                manifest_filenames: Vec::new(),
+            },
+        };
+        let target_gen = view.generation.max(1);
+        let target_ver = view.version + 1;
+        let merged = merge_cluster_maps(&view.cluster_map, deltas);
+        let fname = versioned_manifest_filename_unique(target_gen, target_ver);
+        let mut commit_header = header.clone();
+        commit_header.generation = target_gen;
+        save_manifest_to(mstore, &commit_header, &merged, &fname).await?;
+        write_latest(mstore, target_gen, target_ver, &fname).await?;
+        if let Some(after) = resolve_view(mstore).await?
+            && after.key() == (target_gen, target_ver)
+        {
+            return Ok(());
+        }
+    }
+    Err(RabitqError::CommitConflict)
+}
+
+/// Commit a full rebuild (compaction / rebuild from scratch).
+///
+/// Publishes a new generation commit at `(base_key.0 + 1, 1)`.  The
+/// caller's *map* must be a complete replacement derived from the view at
+/// *base_key*.  If the view has moved since, or another rebuild already
+/// claimed the target key, returns [`RabitqError::CommitConflict`] so the
+/// caller can redo its (expensive) rebuild against the fresher view.
+pub async fn commit_rebuild(
+    mstore: &ManifestStore,
+    header: &ManifestHeader,
+    map: &BTreeMap<u32, ClusterManifestEntry>,
+    base_key: (u64, u64),
+) -> Result<(), RabitqError> {
+    // An empty store resolves to base key (0, 0), so a fresh rebuild can
+    // publish its first generation (1, 1) without a precondition.
+    let view_key = match resolve_view(mstore).await? {
+        Some(view) => view.key(),
+        None => (0, 0),
+    };
+    if view_key != base_key {
+        return Err(RabitqError::CommitConflict);
+    }
+    let target_key = (base_key.0 + 1, 1u64);
+    let fname = versioned_manifest_filename_unique(target_key.0, target_key.1);
+    let mut commit_header = header.clone();
+    commit_header.generation = target_key.0;
+    save_manifest_to(mstore, &commit_header, map, &fname).await?;
+    write_latest(mstore, target_key.0, target_key.1, &fname).await?;
+    match resolve_view(mstore).await? {
+        Some(after) if after.key() == target_key => {
+            if after.manifest_filenames.len() == 1 && after.manifest_filenames[0] == fname
+            {
+                Ok(())
+            } else {
+                // Another rebuild claimed the same key — refuse the race.
+                Err(RabitqError::CommitConflict)
+            }
+        }
+        _ => Err(RabitqError::CommitConflict),
+    }
 }
 
 // ---- backward-compat (existing V1/V2 manifest read) ----

--- a/rust/lakesoul-vector/src/rabitq/mod.rs
+++ b/rust/lakesoul-vector/src/rabitq/mod.rs
@@ -66,6 +66,9 @@ pub enum RabitqError {
     #[error("generation conflict: compaction changed the generation")]
     GenerationConflict,
 
+    #[error("commit conflict: another writer published a newer commit")]
+    CommitConflict,
+
     #[error("I/O error: {0}")]
     Io(String),
 

--- a/rust/lakesoul-vector/tests/commit_protocol.rs
+++ b/rust/lakesoul-vector/tests/commit_protocol.rs
@@ -1,0 +1,526 @@
+// SPDX-FileCopyrightText: 2025 LakeSoul Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! CAS-free commit protocol tests.
+//!
+//! The V3 commit protocol must be correct on object stores that do **not**
+//! support conditional (`If-Match`) PUTs — Aliyun OSS ignores unknown
+//! precondition headers, and `LocalFileSystem` rejects them.  These tests
+//! exercise the protocol through a store wrapper that fails loudly on any
+//! conditional put, so a regression back to `PutMode::Update` fails here
+//! instead of silently losing data in production.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+};
+
+use lakesoul_vector::rabitq::manifest::{
+    self, COMMIT_RETRIES, ClusterManifestEntry, ManifestHeader, ManifestStore,
+    ResolvedView, SegmentManifestEntry,
+};
+use lakesoul_vector::{Metric, RotatorType};
+
+/// An object store that rejects conditional puts, like Aliyun OSS (which
+/// ignores `If-Match` on PutObject) or `LocalFileSystem` (which returns
+/// `NotImplemented`).
+#[derive(Debug)]
+struct NoCasStore(Arc<dyn ObjectStore>);
+
+impl fmt::Display for NoCasStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NoCasStore")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for NoCasStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        if matches!(opts.mode, PutMode::Update(_)) {
+            return Err(object_store::Error::NotImplemented {
+                operation: "conditional put (If-Match) is not supported by this store"
+                    .into(),
+                implementer: "NoCasStore".into(),
+            });
+        }
+        self.0.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.0.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.0.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: futures::stream::BoxStream<'static, Result<Path>>,
+    ) -> futures::stream::BoxStream<'static, Result<Path>> {
+        self.0.delete_stream(locations)
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> futures::stream::BoxStream<'static, Result<ObjectMeta>> {
+        self.0.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.0.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> Result<()> {
+        self.0.copy_opts(from, to, options).await
+    }
+}
+
+fn no_cas_store() -> Arc<NoCasStore> {
+    Arc::new(NoCasStore(Arc::new(InMemory::new())))
+}
+
+fn header(generation: u64) -> ManifestHeader {
+    ManifestHeader {
+        generation,
+        dim: 8,
+        padded_dim: 8,
+        metric: Metric::L2,
+        rotator_type: RotatorType::FhtKacRotator,
+        rotator_data: vec![1, 2, 3],
+        ex_bits: 6,
+        total_bits: 7,
+    }
+}
+
+fn segment_entry(cid: u32, version: u32) -> SegmentManifestEntry {
+    SegmentManifestEntry {
+        segment_filename: manifest::segment_filename(cid, version),
+        segment_version: version,
+        num_vectors: 100,
+        file_size: 1024,
+    }
+}
+
+fn single_cluster_map(
+    cid: u32,
+    segments: Vec<SegmentManifestEntry>,
+) -> BTreeMap<u32, ClusterManifestEntry> {
+    let mut map = BTreeMap::new();
+    map.insert(
+        cid,
+        ClusterManifestEntry {
+            cluster_id: cid,
+            segments,
+        },
+    );
+    map
+}
+
+#[tokio::test]
+async fn test_initial_commit_and_resolve() {
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+
+    let map = single_cluster_map(0, vec![segment_entry(0, 0)]);
+    manifest::commit_delta(&mstore, &header(1), &map)
+        .await
+        .unwrap();
+
+    let view = manifest::resolve_view(&mstore).await.unwrap().unwrap();
+    assert_eq!(view.key(), (1, 1));
+    assert_eq!(view.cluster_map.len(), 1);
+    assert_eq!(view.cluster_map[&0].segments.len(), 1);
+
+    // LATEST v2 carries the unique manifest filename.
+    let snap = manifest::read_latest(&mstore).await.unwrap();
+    assert_eq!(snap.generation, 1);
+    assert_eq!(snap.version, 1);
+    let fname = snap.manifest_filename.expect("LATEST v2 filename");
+    assert!(
+        fname.starts_with("manifests/g00000001_v00000001_"),
+        "{fname}"
+    );
+    assert_eq!(view.manifest_filenames, vec![fname]);
+}
+
+#[tokio::test]
+async fn test_concurrent_delta_flushes_union() {
+    // Two writers race on the same index: both must commit and the final
+    // view must contain *both* delta segments (union by filename).
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+
+    manifest::commit_delta(
+        &mstore,
+        &header(1),
+        &single_cluster_map(0, vec![segment_entry(0, 0)]),
+    )
+    .await
+    .unwrap();
+
+    let mstore_a = ManifestStore::new(mstore.store.clone(), "idx".to_string());
+    let mstore_b = ManifestStore::new(mstore.store.clone(), "idx".to_string());
+    let (ra, rb) = tokio::join!(
+        async move {
+            let seg_a = segment_entry(0, 1);
+            manifest::commit_delta(
+                &mstore_a,
+                &header(1),
+                &single_cluster_map(0, vec![seg_a]),
+            )
+            .await
+        },
+        async move {
+            let seg_b = segment_entry(0, 1);
+            manifest::commit_delta(
+                &mstore_b,
+                &header(1),
+                &single_cluster_map(0, vec![seg_b]),
+            )
+            .await
+        },
+    );
+    ra.unwrap();
+    rb.unwrap();
+
+    let view = manifest::resolve_view(&mstore).await.unwrap().unwrap();
+    assert_eq!(view.key().0, 1, "both writers stay in the same generation");
+    // The union must reference every committed segment file exactly once.
+    let filenames: Vec<String> = view.cluster_map[&0]
+        .segments
+        .iter()
+        .map(|s| s.segment_filename.clone())
+        .collect();
+    assert_eq!(
+        filenames.len(),
+        3,
+        "base + both concurrent deltas: {filenames:?}"
+    );
+    let mut sorted = filenames.clone();
+    sorted.sort();
+    let mut deduped = sorted.clone();
+    deduped.dedup();
+    assert_eq!(sorted, deduped, "no duplicate segment references");
+}
+
+#[tokio::test]
+async fn test_commit_rebuild_publishes_new_generation_without_deletes() {
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+
+    manifest::commit_delta(
+        &mstore,
+        &header(1),
+        &single_cluster_map(0, vec![segment_entry(0, 0)]),
+    )
+    .await
+    .unwrap();
+    let base_key = manifest::resolve_view(&mstore)
+        .await
+        .unwrap()
+        .unwrap()
+        .key();
+
+    // Full replacement map (as produced by compaction).
+    let rebuilt = single_cluster_map(0, vec![segment_entry(0, 0)]);
+    let rebuilt_fname = rebuilt[&0].segments[0].segment_filename.clone();
+    manifest::commit_rebuild(&mstore, &header(2), &rebuilt, base_key)
+        .await
+        .unwrap();
+
+    let view = manifest::resolve_view(&mstore).await.unwrap().unwrap();
+    assert_eq!(view.key(), (2, 1));
+    assert_eq!(view.cluster_map[&0].segments.len(), 1);
+    assert_eq!(
+        view.cluster_map[&0].segments[0].segment_filename,
+        rebuilt_fname
+    );
+
+    // Nothing was deleted: old + new commits both remain listed.
+    let mut objects = Vec::new();
+    let mut stream = mstore.store.list(Some(&Path::from("idx/manifests")));
+    while let Some(meta) = stream.next().await {
+        objects.push(meta.unwrap().location.to_string());
+    }
+    assert_eq!(
+        objects.len(),
+        2,
+        "old + new commits both retained: {objects:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_rebuild_conflicts_when_view_moved() {
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+
+    manifest::commit_delta(
+        &mstore,
+        &header(1),
+        &single_cluster_map(0, vec![segment_entry(0, 0)]),
+    )
+    .await
+    .unwrap();
+    let stale_base = manifest::resolve_view(&mstore)
+        .await
+        .unwrap()
+        .unwrap()
+        .key();
+
+    // A concurrent flush lands, moving the view past the rebuild's base.
+    manifest::commit_delta(
+        &mstore,
+        &header(1),
+        &single_cluster_map(0, vec![segment_entry(0, 1)]),
+    )
+    .await
+    .unwrap();
+
+    let err = manifest::commit_rebuild(
+        &mstore,
+        &header(2),
+        &single_cluster_map(0, vec![segment_entry(0, 0)]),
+        stale_base,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(err, lakesoul_vector::RabitqError::CommitConflict),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_latest_and_deterministic_manifest_are_readable() {
+    // Old indexes store LATEST as "generation:version" and the manifest at
+    // the deterministic name; resolve_view must still load them.
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+
+    let map = single_cluster_map(0, vec![segment_entry(0, 0)]);
+    let legacy_name = manifest::versioned_manifest_filename(1, 0);
+    manifest::save_manifest_to(&mstore, &header(1), &map, &legacy_name)
+        .await
+        .unwrap();
+    manifest::write_latest(&mstore, 1, 0, &legacy_name)
+        .await
+        .unwrap();
+
+    let view = manifest::resolve_view(&mstore).await.unwrap().unwrap();
+    assert_eq!(view.key(), (1, 0));
+    assert_eq!(view.cluster_map[&0].segments.len(), 1);
+
+    // A legacy LATEST without the filename field still parses.
+    let snap = manifest::read_latest(&mstore).await.unwrap();
+    assert_eq!((snap.generation, snap.version), (1, 0));
+    assert!(
+        snap.manifest_filename.is_some(),
+        "filename resolved for legacy pointer"
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_manifest_bin_fallback() {
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+    let map = single_cluster_map(3, vec![segment_entry(3, 0)]);
+    manifest::save_manifest_to(&mstore, &header(1), &map, manifest::MANIFEST_FILENAME)
+        .await
+        .unwrap();
+
+    let view = manifest::resolve_view(&mstore).await.unwrap().unwrap();
+    assert_eq!(
+        view.key(),
+        (0, 0),
+        "legacy manifest.bin resolves at key (0,0)"
+    );
+    assert_eq!(view.cluster_map[&3].segments.len(), 1);
+}
+
+#[tokio::test]
+async fn test_flush_and_search_end_to_end_on_no_cas_store() {
+    use lakesoul_vector::{
+        IdAndVecBatch, IvfRabitqBuilder, IvfRabitqIndex, SearchParams,
+    };
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "idx".to_string());
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let dim = 16usize;
+    let rand_vec = |rng: &mut StdRng| {
+        (0..dim)
+            .map(|_| rng.r#gen::<f32>() * 2.0 - 1.0)
+            .collect::<Vec<f32>>()
+    };
+
+    // Initial build: 64 vectors, 4 clusters.
+    let mut builder =
+        IvfRabitqBuilder::new(dim, 4, 7, Metric::L2, RotatorType::FhtKacRotator, 1, true);
+    let base: Vec<IdAndVecBatch> = (0..4)
+        .map(|b| IdAndVecBatch {
+            ids: (b * 16..b * 16 + 16).collect(),
+            vectors: (0..16).flat_map(|_| rand_vec(&mut rng)).collect(),
+        })
+        .collect();
+    for batch in &base {
+        builder.insert_batch(batch.clone()).unwrap();
+    }
+    let base_stream = base.clone();
+    let index = builder
+        .build(|| futures::stream::iter(base_stream.clone().into_iter()))
+        .await
+        .unwrap();
+    index.save_to_v4(&mstore).await.unwrap();
+
+    // Incremental flush: 16 new vectors via a loaded builder.
+    let mut builder = IvfRabitqBuilder::load(
+        &mstore,
+        dim,
+        4,
+        7,
+        Metric::L2,
+        RotatorType::FhtKacRotator,
+        1,
+        true,
+    )
+    .await
+    .unwrap();
+    builder
+        .insert_batch(IdAndVecBatch {
+            ids: (64..80).collect(),
+            vectors: (0..16).flat_map(|_| rand_vec(&mut rng)).collect(),
+        })
+        .unwrap();
+    builder.flush(&mstore).await.unwrap();
+
+    // The delta is visible: searching for a flushed vector returns its id.
+    let loaded = IvfRabitqIndex::load_from_v4(&mstore).await.unwrap();
+    let probe = rand_vec(&mut rng);
+    let results = loaded.search(&probe, SearchParams::new(20, 4)).unwrap();
+    assert!(!results.is_empty());
+    let ids: Vec<u64> = results.iter().map(|r| r.id).collect();
+    assert!(
+        ids.iter().any(|id| *id >= 64),
+        "flushed vectors reachable: {ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_concurrent_flush_writers_on_local_fs_do_not_lose_data() {
+    use lakesoul_vector::{
+        IdAndVecBatch, IvfRabitqBuilder, IvfRabitqIndex, SearchParams,
+    };
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(
+        object_store::local::LocalFileSystem::new_with_prefix(tmp.path()).unwrap(),
+    );
+    let mstore = ManifestStore::new(store, "idx".to_string());
+
+    let mut rng = StdRng::seed_from_u64(7);
+    let dim = 16usize;
+    let rand_vec = |rng: &mut StdRng| {
+        (0..dim)
+            .map(|_| rng.r#gen::<f32>() * 2.0 - 1.0)
+            .collect::<Vec<f32>>()
+    };
+
+    let mut builder =
+        IvfRabitqBuilder::new(dim, 4, 7, Metric::L2, RotatorType::FhtKacRotator, 1, true);
+    let base: Vec<IdAndVecBatch> = (0..4)
+        .map(|b| IdAndVecBatch {
+            ids: (b * 16..b * 16 + 16).collect(),
+            vectors: (0..16).flat_map(|_| rand_vec(&mut rng)).collect(),
+        })
+        .collect();
+    for batch in &base {
+        builder.insert_batch(batch.clone()).unwrap();
+    }
+    let base_stream = base.clone();
+    let index = builder
+        .build(|| futures::stream::iter(base_stream.clone().into_iter()))
+        .await
+        .unwrap();
+    index.save_to_v4(&mstore).await.unwrap();
+
+    // Two processes (two independent builders) flush concurrently.
+    let flush_one = |rng_seed: u64, id_start: u64, store: Arc<dyn ObjectStore>| {
+        let mstore = ManifestStore::new(store, "idx".to_string());
+        async move {
+            let mut rng = StdRng::seed_from_u64(rng_seed);
+            let mut builder = IvfRabitqBuilder::load(
+                &mstore,
+                dim,
+                4,
+                7,
+                Metric::L2,
+                RotatorType::FhtKacRotator,
+                1,
+                true,
+            )
+            .await
+            .unwrap();
+            builder
+                .insert_batch(IdAndVecBatch {
+                    ids: (id_start..id_start + 16).collect(),
+                    vectors: (0..16).flat_map(|_| rand_vec(&mut rng)).collect(),
+                })
+                .unwrap();
+            builder.flush(&mstore).await.unwrap();
+        }
+    };
+
+    let store_a = mstore.store.clone();
+    let store_b = mstore.store.clone();
+    tokio::join!(flush_one(11, 64, store_a), flush_one(22, 80, store_b),);
+
+    // Both flushed sets must be reachable after resolution.
+    let loaded = IvfRabitqIndex::load_from_v4(&mstore).await.unwrap();
+    let probe = rand_vec(&mut rng);
+    let results = loaded.search(&probe, SearchParams::new(50, 4)).unwrap();
+    let ids: Vec<u64> = results.iter().map(|r| r.id).collect();
+    assert!(
+        ids.iter().any(|id| (64..80).contains(id))
+            && ids.iter().any(|id| (80..96).contains(id)),
+        "both concurrent flushes visible: {ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_retry_budget_is_bounded() {
+    // Sanity: the protocol constant is finite and resolution of an empty
+    // store returns None.
+    assert_eq!(COMMIT_RETRIES, 3);
+    let store = no_cas_store();
+    let mstore = ManifestStore::new(store.clone(), "empty".to_string());
+    assert!(manifest::resolve_view(&mstore).await.unwrap().is_none());
+    let _: Option<ResolvedView> = None;
+}


### PR DESCRIPTION
## Summary

`write_latest` updated the LATEST manifest pointer with `PutMode::Update` (`If-Match` conditional headers). On stores that do not support conditional PUTs this was unsafe:

- **Aliyun OSS** ignores unknown precondition headers on PutObject → the CAS silently always succeeds → concurrent flushes/compactions lose updates without any error.
- **LocalFileSystem** returns `NotImplemented` → the generic error fallback silently downgraded to an unconditional overwrite → same lost-update hazard.

Additionally, delta segments and versioned manifests used deterministic file names written with unconditional overwrite, so concurrent writers could clobber each other's immutable objects even before the LATEST pointer race.

## Changes

The V3 commit protocol removes conditional headers entirely:

- **Unique immutable objects**: every commit is written to `manifests/g{gen:08}_v{ver:08}_{uuid}.bin`; segment files get unique names too. Nothing is ever overwritten or deleted.
- **LATEST v2**: `generation:version:<manifest-filename>` written as a plain overwrite — a best-effort hint only, never a source of truth. Legacy `gen:ver` values and `manifest.bin` remain readable.
- **Derived view** (`resolve_view`): list `manifests/`, take the max `(generation, version)` key, and **union** every commit at that key (dedup by segment filename) — concurrent writers never lose data.
- **`commit_delta`** (incremental flush): rebase-merge onto the freshest view, publish, verify; bounded retries then a loud `CommitConflict` instead of silent loss.
- **`commit_rebuild`** (fresh build / compaction / rebuild): publishes a new generation; refuses races loudly. Compaction is strictly additive — the pre-existing delete-old-segments-*before*-CAS-publish hazard is gone.

## Tests

New integration suite `rust/lakesoul-vector/tests/commit_protocol.rs` (first tests directory for the crate):

- A `NoCasStore` wrapper that rejects conditional puts (simulating Aliyun OSS / LocalFileSystem) — any regression back to `If-Match` fails here.
- Concurrent delta flushes union without duplicates; rebuild conflicts when the view moved; no deletion of old commits; legacy LATEST/`manifest.bin` compatibility; end-to-end build → flush → search, including concurrent writers on LocalFileSystem.

## Verification

- `cargo test -p lakesoul-vector`: 57 unit + 9 integration tests pass.
- `cargo test -p lakesoul-io`: 85 + 26 + 1 pass.
- Clippy: no new warnings; `cargo fmt` clean.
- Python e2e (`tests/vector/`): 19 passed, 2 skipped (incremental auto-build, glove recall, partition regression, Daft vector search).