### PR TITLE
[DataFusion] vector search: SQL index pushdown + property-driven auto index build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,6 +4742,7 @@ dependencies = [
  "lakesoul-io",
  "lakesoul-metadata",
  "lakesoul-metadata-proto",
+ "lakesoul-vector",
  "log",
  "object_store",
  "parquet",

--- a/rust/lakesoul-datafusion/Cargo.toml
+++ b/rust/lakesoul-datafusion/Cargo.toml
@@ -15,6 +15,7 @@ lakesoul-io = { path = "../lakesoul-io" }
 lakesoul-metadata = { path = "../lakesoul-metadata" }
 lakesoul-common = { path = "../lakesoul-common" }
 lakesoul-metadata-proto = { path = "../lakesoul-metadata-proto" }
+lakesoul-vector = { path = "../lakesoul-vector" }
 # datafusion
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }

--- a/rust/lakesoul-datafusion/src/catalog/mod.rs
+++ b/rust/lakesoul-datafusion/src/catalog/mod.rs
@@ -83,6 +83,15 @@ pub struct LakeSoulTableProperty {
     /// Whether use cdc is enabled for the LakeSoul table.
     #[serde(rename = "use_cdc", default, skip_serializing_if = "Option::is_none")]
     pub use_cdc: Option<String>,
+    /// Vector index configurations (JSON array of
+    /// [`VectorIndexTableConfig`](crate::vector_index::VectorIndexTableConfig)
+    /// entries), matching the Python SDK's `vector_index_columns` property.
+    #[serde(
+        rename = "vector_index_columns",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub vector_index_columns: Option<String>,
 }
 
 /// Register a LakeSoul table in the LakeSoul metadata.
@@ -92,6 +101,38 @@ pub(crate) async fn create_table(
     client: MetaDataClientRef,
     table_name: &str,
     config: LakeSoulIOConfig,
+) -> Result<()> {
+    create_table_inner(client, table_name, config, None).await
+}
+
+/// Create a LakeSoul table that declares vector indexes through the
+/// `vector_index_columns` table property, so writes auto-build the indexes
+/// (same semantics as the Python SDK's `vector_index` argument).
+///
+/// The configuration is validated against the table schema and primary
+/// keys *before* any metadata is created.
+#[allow(dead_code)] // used for test
+pub(crate) async fn create_table_with_vector_index(
+    client: MetaDataClientRef,
+    table_name: &str,
+    config: LakeSoulIOConfig,
+    vector_index_configs: &[crate::vector_index::VectorIndexTableConfig],
+) -> Result<()> {
+    crate::vector_index::validate_vector_index_configs(
+        vector_index_configs,
+        config.target_schema().as_ref(),
+        config.primary_keys_slice(),
+    )?;
+    let vector_index_columns = (!vector_index_configs.is_empty())
+        .then(|| crate::vector_index::vector_index_columns_to_json(vector_index_configs));
+    create_table_inner(client, table_name, config, vector_index_columns).await
+}
+
+async fn create_table_inner(
+    client: MetaDataClientRef,
+    table_name: &str,
+    config: LakeSoulIOConfig,
+    vector_index_columns: Option<String>,
 ) -> Result<()> {
     debug!("create_table: {:?}", &table_name);
     let target_schema = config.target_schema();
@@ -116,6 +157,7 @@ pub(crate) async fn create_table(
             table_namespace: "default".to_string(),
             properties: serde_json::to_string(&LakeSoulTableProperty {
                 hash_bucket_num: Some(String::from("4")),
+                vector_index_columns,
                 ..Default::default()
             })?,
             partitions: format!(

--- a/rust/lakesoul-datafusion/src/datasource/file_format/metadata_format.rs
+++ b/rust/lakesoul-datafusion/src/datasource/file_format/metadata_format.rs
@@ -373,6 +373,7 @@ impl FileFormat for LakeSoulMetaDataParquetFormat {
                 order_requirements,
                 self.table_info(),
                 self.client(),
+                self.conf.object_store_options().clone(),
             )
             .await
             .map_err(|report| DataFusionError::External(report.into_boxed_error()))?,
@@ -404,6 +405,13 @@ pub struct LakeSoulHashSinkExec {
     /// The range partitions.
     range_partitions: Arc<Vec<String>>,
 
+    /// The primary keys of the table (used for the vector index build).
+    primary_keys: Vec<String>,
+
+    /// Object store configuration options forwarded to the vector index
+    /// builder after the write commits.
+    object_store_options: std::collections::HashMap<String, String>,
+
     /// The properties of the plan.
     properties: Arc<PlanProperties>,
 }
@@ -421,8 +429,10 @@ impl LakeSoulHashSinkExec {
         sort_order: Option<LexRequirement>,
         table_info: Arc<TableInfo>,
         metadata_client: MetaDataClientRef,
+        object_store_options: std::collections::HashMap<String, String>,
     ) -> Result<Self> {
-        let (range_partitions, _) = parse_table_info_partitions(&table_info.partitions)?;
+        let (range_partitions, primary_keys) =
+            parse_table_info_partitions(&table_info.partitions)?;
         let range_partitions = Arc::new(range_partitions);
         Ok(Self {
             input,
@@ -431,6 +441,8 @@ impl LakeSoulHashSinkExec {
             table_info,
             metadata_client,
             range_partitions,
+            primary_keys,
+            object_store_options,
             properties: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(make_sink_schema()),
                 Partitioning::UnknownPartitioning(1),
@@ -559,6 +571,8 @@ impl LakeSoulHashSinkExec {
         join_handles: Vec<JoinHandle<Result<u64>>>,
         client: MetaDataClientRef,
         table_name: String,
+        primary_keys: Vec<String>,
+        object_store_options: std::collections::HashMap<String, String>,
         partitioned_file_path_and_row_count: Arc<Mutex<PartitionedFile>>,
     ) -> Result<u64> {
         let count = futures::future::join_all(join_handles)
@@ -580,6 +594,53 @@ impl LakeSoulHashSinkExec {
                 &table_name,
                 std::time::SystemTime::now()
             )
+        }
+
+        // Auto-build / incrementally update the vector index from the newly
+        // committed files, driven by the table's `vector_index_columns`
+        // property (same semantics as the Python write path).  Re-fetch the
+        // table info so properties changed after plan construction apply.
+        // The native builder's future is not Send, so it is driven on the
+        // blocking pool via the global runtime.
+        let committed_files: HashMap<String, (Vec<String>, u64)> =
+            partitioned_file_path_and_row_count.clone();
+        drop(partitioned_file_path_and_row_count);
+
+        let table_ref = TableReference::from(table_name.as_str());
+        let namespace = table_ref.schema().unwrap_or("default").to_string();
+        let configs = if let Some(fresh_info) = client
+            .get_table_info_by_table_name(table_ref.table(), &namespace)
+            .await?
+        {
+            crate::vector_index::parse_vector_index_from_table_properties(
+                &fresh_info.properties,
+            )
+            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?
+        } else {
+            Vec::new()
+        };
+        if !configs.is_empty() && !primary_keys.is_empty() {
+            let built = tokio::task::spawn_blocking(move || {
+                lakesoul_io::session::GLOBAL_RUNTIME.block_on(
+                    crate::vector_index::auto_build_vector_index(
+                        &configs,
+                        &primary_keys,
+                        &object_store_options,
+                        &committed_files,
+                    ),
+                )
+            })
+            .await
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "vector index auto build task failed: {error}"
+                ))
+            })?
+            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?;
+            debug!(
+                "auto-built {built} vector index shard(s) for {}",
+                &table_name
+            );
         }
         Ok(count)
     }
@@ -678,6 +739,8 @@ impl ExecutionPlan for LakeSoulHashSinkExec {
             table_info: self.table_info.clone(),
             range_partitions: self.range_partitions.clone(),
             metadata_client: self.metadata_client.clone(),
+            primary_keys: self.primary_keys.clone(),
+            object_store_options: self.object_store_options.clone(),
             properties: self.properties.clone(),
         }))
     }
@@ -727,6 +790,8 @@ impl ExecutionPlan for LakeSoulHashSinkExec {
             join_handles,
             self.metadata_client(),
             table_ref.to_string(),
+            self.primary_keys.clone(),
+            self.object_store_options.clone(),
             partitioned_file_path_and_row_count,
         ));
 

--- a/rust/lakesoul-datafusion/src/datasource/file_format/mod.rs
+++ b/rust/lakesoul-datafusion/src/datasource/file_format/mod.rs
@@ -3,5 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod metadata_format;
+mod vector_search_exec;
 
 pub use metadata_format::LakeSoulMetaDataParquetFormat;
+pub use vector_search_exec::LakeSoulVectorSearchExec;

--- a/rust/lakesoul-datafusion/src/datasource/file_format/vector_search_exec.rs
+++ b/rust/lakesoul-datafusion/src/datasource/file_format/vector_search_exec.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 LakeSoul contributors
+
+//! Physical execution plan that reads the vector-index candidates for a
+//! table.
+//!
+//! The plan is produced by [`LakeSoulTableProvider::scan`] when the logical
+//! plan carries the vector-search marker (see
+//! [`VectorSearchPushdownRule`](crate::planner::vector_search_rule::VectorSearchPushdownRule)).
+//! It reads each partition/bucket through the native [`LakeSoulReader`]
+//! configured with the `vector_search_*` options, so the reader runs the
+//! ANN search against that bucket's IVF+RaBitQ index and returns only the
+//! candidate rows.  The `Sort` + `Limit` nodes above the scan then compute
+//! the exact global top-k over the (small) candidate set.
+
+use std::collections::HashMap;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Schema, SchemaRef};
+use datafusion::common::ScalarValue;
+use datafusion::datasource::listing::PartitionedFile;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::TaskContext;
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::LexOrdering;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
+    PlanProperties, SendableRecordBatchStream,
+    metrics::{ExecutionPlanMetricsSet, MetricsSet},
+    stream::RecordBatchStreamAdapter,
+};
+use object_store::path::Path as StorePath;
+use rootcause::compat::boxed_error::IntoBoxedError;
+
+use lakesoul_io::config::{
+    LakeSoulIOConfig, LakeSoulIOConfigBuilder, OPTION_KEY_VECTOR_SEARCH_COLUMN,
+    OPTION_KEY_VECTOR_SEARCH_METRIC, OPTION_KEY_VECTOR_SEARCH_NPROBE,
+    OPTION_KEY_VECTOR_SEARCH_QUERY, OPTION_KEY_VECTOR_SEARCH_TOP_K,
+};
+use lakesoul_io::reader::{LakeSoulReader, SyncSendableMutableLakeSoulReader};
+
+use crate::udf::vector_search_marker::{
+    LakeSoulVectorSearchOptions, VectorSearchRequest,
+};
+
+/// Execution plan for the vector-index candidate scan.
+#[derive(Debug)]
+pub struct LakeSoulVectorSearchExec {
+    /// Output schema: file columns followed by partition columns.
+    schema: SchemaRef,
+    /// File columns (partition columns excluded).
+    file_schema: SchemaRef,
+    /// (name, type) of the range partition columns.
+    partition_cols: Vec<(String, DataType)>,
+    /// One group of files (one partition/bucket) per partition of the scan.
+    file_groups: Vec<Vec<PartitionedFile>>,
+    /// Values of the partition columns for each file group (aligned with
+    /// `partition_cols`).
+    partition_values: Vec<Vec<ScalarValue>>,
+    /// Object store URL used to reconstruct reader file URIs.
+    object_store_url: ObjectStoreUrl,
+    /// Primary key columns (the vector index returns primary key ids).
+    primary_keys: Vec<String>,
+    /// Object store configuration options (e.g. S3 credentials).
+    object_store_options: HashMap<String, String>,
+    /// Vector search parameters.
+    vector_search: VectorSearchRequest,
+    /// Runtime metrics.
+    metrics: ExecutionPlanMetricsSet,
+    /// Plan properties.
+    properties: Arc<PlanProperties>,
+}
+
+impl LakeSoulVectorSearchExec {
+    /// Create a new vector-search scan plan.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        schema: SchemaRef,
+        file_schema: SchemaRef,
+        partition_cols: Vec<(String, DataType)>,
+        file_groups: Vec<Vec<PartitionedFile>>,
+        partition_values: Vec<Vec<ScalarValue>>,
+        object_store_url: ObjectStoreUrl,
+        primary_keys: Vec<String>,
+        object_store_options: HashMap<String, String>,
+        vector_search: VectorSearchRequest,
+    ) -> DFResult<Self> {
+        Ok(Self {
+            schema: Arc::clone(&schema),
+            file_schema,
+            partition_cols,
+            file_groups,
+            partition_values,
+            object_store_url,
+            primary_keys,
+            object_store_options,
+            vector_search,
+            metrics: ExecutionPlanMetricsSet::new(),
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )),
+        })
+    }
+
+    /// Build the native reader configuration for one file group.
+    fn reader_config(
+        &self,
+        files: &[PartitionedFile],
+        partition_values: &[ScalarValue],
+        nprobe: usize,
+    ) -> DFResult<LakeSoulIOConfig> {
+        let file_uris = files
+            .iter()
+            .map(|f| file_uri(&self.object_store_url, &f.object_meta.location))
+            .collect::<Vec<_>>();
+        let first = file_uris.first().cloned().ok_or_else(|| {
+            DataFusionError::Internal("empty vector-search file group".into())
+        })?;
+
+        let mut builder = LakeSoulIOConfigBuilder::default()
+            .with_files(file_uris)
+            .with_primary_keys(self.primary_keys.clone())
+            .with_schema(Arc::clone(&self.file_schema))
+            .with_prefix(derive_prefix(&first));
+
+        if !self.partition_cols.is_empty() {
+            let partition_schema = Arc::new(Schema::new(
+                self.partition_cols
+                    .iter()
+                    .map(|(name, ty)| {
+                        arrow::datatypes::Field::new(name, ty.clone(), true)
+                    })
+                    .collect::<Vec<_>>(),
+            ));
+            builder = builder.with_partition_schema(partition_schema);
+            for ((name, _), value) in self.partition_cols.iter().zip(partition_values) {
+                builder = builder
+                    .with_default_column_value(name.clone(), scalar_to_string(value));
+            }
+        }
+
+        let mut has_path_style_config = false;
+        for (k, v) in &self.object_store_options {
+            if k == "fs.s3a.path.style.access" {
+                has_path_style_config = true;
+            }
+            builder = builder.with_object_store_option(k.clone(), v.clone());
+        }
+        if !has_path_style_config {
+            builder = builder.with_object_store_option(
+                "fs.s3a.path.style.access".to_string(),
+                "true".to_string(),
+            );
+        }
+
+        builder = builder
+            .with_option(
+                OPTION_KEY_VECTOR_SEARCH_COLUMN,
+                self.vector_search.vec_column.clone(),
+            )
+            .with_option(
+                OPTION_KEY_VECTOR_SEARCH_QUERY,
+                self.vector_search.query_csv.clone(),
+            )
+            // Fetch extra candidates per bucket so the exact global sort
+            // above has recall margin against the approximate within-shard
+            // ranking; the physical `Sort` + `Limit` trims back to top_k.
+            .with_option(
+                OPTION_KEY_VECTOR_SEARCH_TOP_K,
+                self.vector_search
+                    .top_k
+                    .saturating_mul(10)
+                    .max(100)
+                    .to_string(),
+            )
+            .with_option(OPTION_KEY_VECTOR_SEARCH_NPROBE, nprobe.to_string())
+            .with_option(
+                OPTION_KEY_VECTOR_SEARCH_METRIC,
+                self.vector_search.metric.clone(),
+            );
+        Ok(builder.build())
+    }
+}
+
+impl ExecutionPlanProperties for LakeSoulVectorSearchExec {
+    fn output_partitioning(&self) -> &Partitioning {
+        &Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&LexOrdering> {
+        None
+    }
+
+    fn boundedness(&self) -> Boundedness {
+        Boundedness::Bounded
+    }
+
+    fn pipeline_behavior(&self) -> EmissionType {
+        EmissionType::Incremental
+    }
+
+    fn equivalence_properties(&self) -> &EquivalenceProperties {
+        self.properties.equivalence_properties()
+    }
+}
+
+impl ExecutionPlan for LakeSoulVectorSearchExec {
+    fn name(&self) -> &str {
+        "LakeSoulVectorSearchExec"
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(self)
+        } else {
+            Err(DataFusionError::Internal(
+                "LakeSoulVectorSearchExec has no children".to_string(),
+            ))
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "LakeSoulVectorSearchExec only supports 1 partition, got {partition}"
+            )));
+        }
+        let nprobe = context
+            .session_config()
+            .get_extension::<LakeSoulVectorSearchOptions>()
+            .map(|o| o.nprobe)
+            .unwrap_or(64);
+
+        let mut configs = Vec::with_capacity(self.file_groups.len());
+        for (group, values) in self.file_groups.iter().zip(&self.partition_values) {
+            configs.push(self.reader_config(group, values, nprobe)?);
+        }
+        let schema = Arc::clone(&self.schema);
+
+        // Read every bucket's candidates through the native reader.  The
+        // reader's async API is not `Send`, so it is driven through the
+        // blocking wrapper on the global runtime; the candidate set is
+        // bounded by top_k × bucket_count and cheap to collect.
+        let batches = tokio::task::block_in_place(|| {
+            let mut batches: Vec<arrow::record_batch::RecordBatch> = Vec::new();
+            for config in configs {
+                let reader = LakeSoulReader::new(config)
+                    .map_err(|e| DataFusionError::External(e.into_boxed_error()))?;
+                let mut sync_reader =
+                    SyncSendableMutableLakeSoulReader::new_with_global_runtime(reader);
+                sync_reader
+                    .start_blocked()
+                    .map_err(|e| DataFusionError::External(e.into_boxed_error()))?;
+                while let Some(batch) = sync_reader.next_rb_blocked() {
+                    batches.push(
+                        batch.map_err(|e| {
+                            DataFusionError::External(e.into_boxed_error())
+                        })?,
+                    );
+                }
+            }
+            Ok::<_, DataFusionError>(batches)
+        })?;
+        let stream = futures::stream::iter(batches.into_iter().map(Ok));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream))
+            as SendableRecordBatchStream)
+    }
+}
+
+impl DisplayAs for LakeSoulVectorSearchExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "LakeSoulVectorSearchExec(vec={}, top_k={}, metric={})",
+            self.vector_search.vec_column,
+            self.vector_search.top_k,
+            self.vector_search.metric
+        )
+    }
+}
+
+/// Reconstruct a full file URI for the native reader from the object store
+/// URL and the store-relative location.
+fn file_uri(object_store_url: &ObjectStoreUrl, location: &StorePath) -> String {
+    let url = object_store_url.to_string();
+    if url.starts_with("file:") {
+        format!("file:///{}", location.as_ref())
+    } else {
+        format!("{}/{}", url.trim_end_matches('/'), location.as_ref())
+    }
+}
+
+/// Derive the store prefix (parent directory) from a file URI, preserving
+/// the scheme and authority.
+fn derive_prefix(first_file: &str) -> String {
+    let (scheme, rest) = match first_file.split_once("://") {
+        Some((scheme, rest)) => (format!("{scheme}://"), rest),
+        None => ("".to_string(), first_file),
+    };
+    let parent = std::path::Path::new(rest.trim_end_matches('/'))
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    if scheme.is_empty() {
+        parent
+    } else {
+        format!("{scheme}{parent}")
+    }
+}
+
+/// Render a partition value as the string form used by the native reader.
+fn scalar_to_string(value: &ScalarValue) -> String {
+    match value {
+        ScalarValue::Utf8(Some(s)) => s.clone(),
+        ScalarValue::Utf8View(Some(s)) => s.to_string(),
+        ScalarValue::Int64(Some(v)) => v.to_string(),
+        ScalarValue::Int32(Some(v)) => v.to_string(),
+        ScalarValue::Date32(Some(v)) => v.to_string(),
+        _ => value.to_string(),
+    }
+}

--- a/rust/lakesoul-datafusion/src/datasource/table_provider.rs
+++ b/rust/lakesoul-datafusion/src/datasource/table_provider.rs
@@ -109,6 +109,9 @@ pub struct LakeSoulTableProvider {
     pub(crate) range_partitions: Vec<String>,
     pub(crate) pushdown_filters: bool,
     pub(crate) io_config: LakeSoulIOConfig,
+    /// Vector index configurations declared by the table's
+    /// `vector_index_columns` property (empty when the table has none).
+    pub(crate) vector_index_configs: Vec<crate::vector_index::VectorIndexTableConfig>,
     pub(crate) format_registry: Arc<LakeSoulFormatRegistry>,
 }
 impl LakeSoulTableProvider {
@@ -235,6 +238,11 @@ impl LakeSoulTableProvider {
 
         let listing_options = listing_table.options().clone();
         let listing_table_paths = listing_table.table_paths().clone();
+        let vector_index_configs =
+            crate::vector_index::parse_vector_index_from_table_properties(
+                &table_info.properties,
+            )
+            .unwrap_or_default();
         Ok(Self {
             listing_options,
             listing_table_paths,
@@ -247,6 +255,7 @@ impl LakeSoulTableProvider {
             range_partitions,
             pushdown_filters: lakesoul_io_config.file_filter_pushdown(),
             io_config: lakesoul_io_config,
+            vector_index_configs,
             format_registry,
         })
     }
@@ -307,6 +316,30 @@ impl LakeSoulTableProvider {
         let (file_schema, scan_schema) =
             Self::split_schemas(logical_schema.clone(), &range_partitions)?;
 
+        // The `vector_index_columns` option declares vector indexes at
+        // creation time (JSON array, as in the Python SDK); it is validated
+        // against the schema and stored as a table property so writes
+        // auto-build the indexes.
+        // Table-factory options arrive with a `format.` prefix (like
+        // `format.use_cdc`); accept both forms.
+        let vector_index_columns = cmd
+            .options
+            .get("format.vector_index_columns")
+            .or_else(|| cmd.options.get("vector_index_columns"))
+            .cloned();
+        if let Some(raw) = &vector_index_columns {
+            let configs = crate::vector_index::parse_vector_index_columns(Some(raw))
+                .map_err(|report| {
+                    report!("invalid vector_index_columns option: {report}")
+                })?;
+            crate::vector_index::validate_vector_index_configs(
+                &configs,
+                logical_schema.as_ref(),
+                &primary_keys,
+            )
+            .map_err(|report| report!("invalid vector_index_columns option: {report}"))?;
+        }
+
         let (table_schema, table_schema_arrow_ipc, table_schema_arrow_ipc_json_hash) =
             schema_to_metadata_parts(logical_schema.as_ref());
 
@@ -331,6 +364,7 @@ impl LakeSoulTableProvider {
                 },
                 cdc_change_column: cdc_column,
                 use_cdc,
+                vector_index_columns,
                 ..Default::default()
             })
             .unwrap(),
@@ -362,6 +396,11 @@ impl LakeSoulTableProvider {
                 .parquet
                 .schema_force_view_types,
         )?);
+        let vector_index_configs =
+            crate::vector_index::parse_vector_index_from_table_properties(
+                &table_info.properties,
+            )
+            .unwrap_or_default();
         Ok(Self {
             listing_options: LakeSoulMetaDataParquetFormat::default_listing_options()
                 .await?,
@@ -379,6 +418,7 @@ impl LakeSoulTableProvider {
                 .parquet
                 .pushdown_filters, // TODO after more format
             io_config,
+            vector_index_configs,
             format_registry,
         })
     }
@@ -469,7 +509,7 @@ impl LakeSoulTableProvider {
         Ok(all_sort_orders)
     }
 
-    async fn list_files_for_scan<'a>(
+    pub(crate) async fn list_files_for_scan<'a>(
         &'a self,
         ctx: &'a SessionState,
         filters: &'a [Expr],
@@ -541,6 +581,92 @@ impl LakeSoulTableProvider {
         debug!("file_groups: {:#?}", file_groups);
 
         Ok((file_groups, Statistics::new_unknown(self.schema().deref())))
+    }
+
+    /// Build the vector-index candidate scan for a marker request.
+    ///
+    /// Returns `Ok(None)` when the request cannot be served — no primary
+    /// key, no `vector_index_columns` table property declaring the searched
+    /// column, an unsupported metric, a non-vector column, or an empty
+    /// scan — in which case the caller runs the regular full scan instead.
+    async fn try_build_vector_search_exec(
+        &self,
+        session_state: &SessionState,
+        request: crate::udf::vector_search_marker::VectorSearchRequest,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
+        if self.primary_keys.is_empty() {
+            return Ok(None);
+        }
+        if !matches!(request.metric.as_str(), "L2" | "IP") {
+            return Ok(None);
+        }
+        // The table must declare the searched column in its
+        // `vector_index_columns` property (and with a compatible metric).
+        let Some(declared) = self
+            .vector_index_configs
+            .iter()
+            .find(|c| c.column == request.vec_column)
+        else {
+            return Ok(None);
+        };
+        if declared.metric.to_uppercase().as_str() != request.metric {
+            return Ok(None);
+        }
+        let vec_field = match self.file_schema.field_with_name(&request.vec_column) {
+            Ok(field) => field,
+            Err(_) => {
+                return Ok(None);
+            }
+        };
+        if !is_vector_type(vec_field.data_type()) {
+            return Ok(None);
+        }
+        let (partitioned_file_lists, _) = self
+            .list_files_for_scan(session_state, filters, limit)
+            .await
+            .map_err(|report| DataFusionError::External(report.into_boxed_error()))?;
+        if partitioned_file_lists.is_empty() {
+            return Ok(None);
+        }
+
+        let mut groups = Vec::with_capacity(partitioned_file_lists.len());
+        let mut partition_values = Vec::with_capacity(partitioned_file_lists.len());
+        for files in &partitioned_file_lists {
+            // The native reader searches the index shard of *one* hash
+            // bucket per reader, so split each partition's files by bucket.
+            let mut by_bucket: std::collections::BTreeMap<u32, Vec<PartitionedFile>> =
+                std::collections::BTreeMap::new();
+            for file in files {
+                let bucket = lakesoul_io::helpers::extract_hash_bucket_id(
+                    file.object_meta.location.as_ref(),
+                )
+                .unwrap_or(0);
+                by_bucket.entry(bucket).or_default().push(file.clone());
+            }
+            for bucket_files in by_bucket.into_values() {
+                let values = bucket_files
+                    .first()
+                    .map(|f| f.partition_values.clone())
+                    .unwrap_or_default();
+                groups.push(bucket_files);
+                partition_values.push(values);
+            }
+        }
+
+        let exec = crate::datasource::file_format::LakeSoulVectorSearchExec::try_new(
+            self.scan_schema.clone(),
+            self.file_schema.clone(),
+            self.table_partition_cols().to_vec(),
+            groups,
+            partition_values,
+            self.table_paths()[0].object_store(),
+            self.primary_keys.clone(),
+            self.io_config.object_store_options().clone(),
+            request,
+        )?;
+        Ok(Some(Arc::new(exec)))
     }
 
     fn format_scan_groups(
@@ -709,8 +835,28 @@ impl TableProvider for LakeSoulTableProvider {
             .as_any()
             .downcast_ref::<SessionState>()
             .unwrap();
+
+        // Vector search pushdown: when the optimizer annotated the scan
+        // with the vector-search marker, read only the index candidates
+        // through the native reader.  The `Sort` + `Limit` above the scan
+        // then compute the exact global top-k.
+        let vector_search =
+            crate::udf::vector_search_marker::parse_vector_search_request(filters);
+        let filters: Vec<Expr> = filters
+            .iter()
+            .filter(|f| !crate::udf::vector_search_marker::is_marker_expr(f))
+            .cloned()
+            .collect();
+        if let Some(request) = vector_search
+            && let Some(exec) = self
+                .try_build_vector_search_exec(session_state, request, &filters, limit)
+                .await?
+        {
+            return Ok(exec);
+        }
+
         let (partitioned_file_lists, statistics) = self
-            .list_files_for_scan(session_state, filters, limit)
+            .list_files_for_scan(session_state, &filters, limit)
             .await
             .map_err(|report| DataFusionError::External(report.into_boxed_error()))?;
 
@@ -958,8 +1104,22 @@ impl TableProvider for LakeSoulTableProvider {
     }
 }
 
+/// True for list-of-numbers types accepted by the vector index.
+fn is_vector_type(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::List(field) | DataType::LargeList(field) => {
+            matches!(field.data_type(), DataType::Float32 | DataType::Float64)
+        }
+        DataType::FixedSizeList(field, _) => {
+            matches!(field.data_type(), DataType::Float32 | DataType::Float64)
+        }
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
     use chrono::TimeZone;
     use object_store::{ObjectMeta, path::Path};

--- a/rust/lakesoul-datafusion/src/lakesoul_table/mod.rs
+++ b/rust/lakesoul-datafusion/src/lakesoul_table/mod.rs
@@ -327,6 +327,11 @@ impl LakeSoulTable {
             range_partitions: self.range_partitions().to_vec(),
             pushdown_filters,
             io_config,
+            vector_index_configs:
+                crate::vector_index::parse_vector_index_from_table_properties(
+                    &self.table_info().properties,
+                )
+                .unwrap_or_default(),
             format_registry,
         }))
     }

--- a/rust/lakesoul-datafusion/src/lib.rs
+++ b/rust/lakesoul-datafusion/src/lib.rs
@@ -39,6 +39,8 @@ pub mod datasource;
 pub mod lakesoul_table;
 pub mod planner;
 pub mod tpch;
+pub mod udf;
+pub mod vector_index;
 
 #[cfg(feature = "adbc")]
 #[expect(dead_code)]
@@ -53,6 +55,15 @@ pub fn create_lakesoul_session_ctx(
     meta_client: MetaDataClientRef,
     args: &cli::CoreArgs,
 ) -> Result<Arc<SessionContext>> {
+    create_lakesoul_session_ctx_with_config(
+        meta_client,
+        args,
+        create_lakesoul_session_config()?,
+    )
+}
+
+/// Build the default [`SessionConfig`] used by LakeSoul sessions.
+pub fn create_lakesoul_session_config() -> Result<SessionConfig> {
     let mut session_config = SessionConfig::from_env()?
         .with_information_schema(true)
         .with_create_default_catalog_and_schema(false)
@@ -89,7 +100,16 @@ pub fn create_lakesoul_session_ctx(
         .options_mut()
         .execution
         .listing_table_factory_infer_partitions = false;
+    Ok(session_config)
+}
 
+/// Create a LakeSoul session context with a caller-supplied session
+/// configuration (e.g. with vector-search extension options attached).
+pub fn create_lakesoul_session_ctx_with_config(
+    meta_client: MetaDataClientRef,
+    args: &cli::CoreArgs,
+    session_config: SessionConfig,
+) -> Result<Arc<SessionContext>> {
     let planner = LakeSoulQueryPlanner::new_ref();
 
     let mut state = SessionStateBuilder::new()
@@ -97,6 +117,9 @@ pub fn create_lakesoul_session_ctx(
         .with_runtime_env(Arc::new(RuntimeEnv::default()))
         .with_default_features()
         .with_query_planner(planner)
+        .with_optimizer_rule(Arc::new(
+            crate::planner::vector_search_rule::VectorSearchPushdownRule,
+        ))
         .build();
     state.table_factories_mut().insert(
         "LAKESOUL".to_string(),
@@ -106,6 +129,7 @@ pub fn create_lakesoul_session_ctx(
         )),
     );
     let ctx = Arc::new(SessionContext::new_with_state(state));
+    ctx.register_udf((*crate::udf::vector_search_marker::marker_udf()).clone());
 
     let catalog = Arc::new(LakeSoulCatalog::new(meta_client.clone(), ctx.clone()));
 

--- a/rust/lakesoul-datafusion/src/planner/mod.rs
+++ b/rust/lakesoul-datafusion/src/planner/mod.rs
@@ -6,5 +6,6 @@
 
 mod physical_planner;
 pub mod query_planner;
+pub mod vector_search_rule;
 
 pub use query_planner::LakeSoulQueryPlanner;

--- a/rust/lakesoul-datafusion/src/planner/vector_search_rule.rs
+++ b/rust/lakesoul-datafusion/src/planner/vector_search_rule.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 LakeSoul contributors
+
+//! Logical optimizer rule that rewrites
+//! `ORDER BY <distance>(vec, q) LIMIT k` into a LakeSoul vector-index
+//! search.
+//!
+//! The rule recognizes the pattern
+//!
+//! ```text
+//! Limit(fetch=k)
+//! └── Sort([array_distance(vec, q) ASC] | [inner_product(vec, q) DESC])
+//!     └── [Projection / Filter]*
+//!         └── TableScan
+//! ```
+//!
+//! and appends an internal marker call to the `TableScan.filters` list.
+//! The scan provider then switches the table read to the vector-index
+//! candidate path while the physical `Sort` + `Limit` stay in place for the
+//! exact re-rank of the (small) candidate set.  Any plan shape that does
+//! not match — including `cosine_distance`, which the LakeSoul index does
+//! not support — is left untouched and executes as a regular full scan.
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::ScalarValue;
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::logical_expr::{Cast, Expr, LogicalPlan, SortExpr, TableScan};
+use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
+
+use crate::udf::vector_search_marker::{VECTOR_SEARCH_MARKER, marker_expr};
+
+/// Logical optimizer rule for the vector-search pushdown (see module docs).
+#[derive(Debug, Default)]
+pub struct VectorSearchPushdownRule;
+
+/// Detected vector-search specification extracted from a matching plan.
+#[derive(Debug, Clone)]
+pub(crate) struct VectorSearchSpec {
+    pub vec_column: String,
+    pub query: Vec<f32>,
+    pub top_k: usize,
+    /// `"L2"` or `"IP"`.
+    pub metric: String,
+}
+
+fn is_marker(expr: &Expr) -> bool {
+    matches!(expr, Expr::ScalarFunction(call) if call.func.name() == VECTOR_SEARCH_MARKER)
+}
+
+impl OptimizerRule for VectorSearchPushdownRule {
+    fn name(&self) -> &str {
+        "lakesoul_vector_search_pushdown"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> DFResult<Transformed<LogicalPlan>> {
+        match detect(&plan) {
+            Some((spec, target)) => {
+                let rewritten = rewrite_chain(plan, &spec, &target)
+                    .expect("matching plan must be rewritable");
+                Ok(Transformed::yes(rewritten))
+            }
+            None => Ok(Transformed::no(plan)),
+        }
+    }
+}
+
+/// Match the `Limit → Sort(distance) → [Projection/Filter]* → TableScan`
+/// pattern.  Returns the spec and the `Arc` of the target `TableScan` (the
+/// same Arc stored inside the plan tree).
+fn detect(plan: &LogicalPlan) -> Option<(VectorSearchSpec, Arc<LogicalPlan>)> {
+    let limit = match plan {
+        LogicalPlan::Limit(limit) => limit,
+        _ => return None,
+    };
+    let sort = match limit.input.as_ref() {
+        LogicalPlan::Sort(sort) => sort,
+        _ => return None,
+    };
+    // The optimizer may merge the limit into the Sort node as a fetch.
+    let top_k = sort.fetch.or_else(|| fetch_value(limit.fetch.as_deref()))?;
+    if top_k == 0 {
+        return None;
+    }
+    if sort.expr.len() != 1 {
+        return None;
+    }
+    let sort_expr = &sort.expr[0];
+    let metric = distance_metric(&sort_expr.expr)?;
+    let expected_asc = metric == "L2";
+    if sort_expr.asc != expected_asc {
+        return None;
+    }
+
+    let mut current = Arc::clone(&sort.input);
+    loop {
+        match current.as_ref() {
+            LogicalPlan::Projection(projection) => {
+                current = Arc::clone(&projection.input);
+            }
+            LogicalPlan::Filter(filter) => {
+                current = Arc::clone(&filter.input);
+            }
+            LogicalPlan::TableScan(ts) => {
+                if ts.filters.iter().any(is_marker) {
+                    return None;
+                }
+                let (vec_column, query) = extract_distance_args(sort_expr, ts)?;
+                return Some((
+                    VectorSearchSpec {
+                        vec_column,
+                        query,
+                        top_k,
+                        metric: metric.to_string(),
+                    },
+                    current,
+                ));
+            }
+            _ => return None,
+        }
+    }
+}
+
+/// Evaluate a literal `LIMIT` fetch expression to a usize.
+fn fetch_value(fetch: Option<&Expr>) -> Option<usize> {
+    match fetch? {
+        Expr::Literal(ScalarValue::Int64(Some(v)), _) => Some((*v).max(0) as usize),
+        Expr::Literal(ScalarValue::UInt64(Some(v)), _) => Some(*v as usize),
+        Expr::Literal(ScalarValue::UInt32(Some(v)), _) => Some(*v as usize),
+        Expr::Literal(ScalarValue::Int32(Some(v)), _) => Some((*v).max(0) as usize),
+        _ => None,
+    }
+}
+
+/// The distance metric implied by a function call, or None for functions
+/// the LakeSoul index cannot serve (e.g. `cosine_distance`).
+fn distance_metric(expr: &Expr) -> Option<&'static str> {
+    let call = as_scalar_function(unwrap_cast(expr))?;
+    match call.func.name() {
+        "array_distance" => Some("L2"),
+        "inner_product" | "dot_product" => Some("IP"),
+        _ => None,
+    }
+}
+
+fn as_scalar_function(expr: &Expr) -> Option<&ScalarFunction> {
+    match expr {
+        Expr::ScalarFunction(call) => Some(call),
+        _ => None,
+    }
+}
+
+/// Extract (vector column name, query vector) from the distance call args,
+/// validating the column type against the scan schema.
+fn extract_distance_args(
+    sort_expr: &SortExpr,
+    ts: &TableScan,
+) -> Option<(String, Vec<f32>)> {
+    let call = as_scalar_function(unwrap_cast(&sort_expr.expr))?;
+    if call.args.len() != 2 {
+        return None;
+    }
+    let col = match unwrap_cast(&call.args[0]) {
+        Expr::Column(col) => col,
+        _ => return None,
+    };
+    if !ts
+        .projected_schema
+        .field_with_unqualified_name(&col.name)
+        .is_ok()
+    {
+        return None;
+    }
+    let field = ts
+        .projected_schema
+        .field_with_unqualified_name(&col.name)
+        .ok()?;
+    if !is_vector_type(field.data_type()) {
+        return None;
+    }
+    let query = extract_query(unwrap_cast(&call.args[1]))?;
+    if query.is_empty() {
+        return None;
+    }
+    Some((col.name.clone(), query))
+}
+
+/// True for list-of-numbers types accepted by the vector index.
+fn is_vector_type(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::List(field) | DataType::LargeList(field) => {
+            matches!(field.data_type(), DataType::Float32 | DataType::Float64)
+        }
+        DataType::FixedSizeList(field, _) => {
+            matches!(field.data_type(), DataType::Float32 | DataType::Float64)
+        }
+        _ => false,
+    }
+}
+
+/// Extract the query vector from a constant expression: a `make_array(...)`
+/// call of numeric literals, or a list/fixed-size-list literal.
+fn extract_query(expr: &Expr) -> Option<Vec<f32>> {
+    match expr {
+        Expr::ScalarFunction(call) if call.func.name() == "make_array" => call
+            .args
+            .iter()
+            .map(|arg| match arg {
+                Expr::Literal(ScalarValue::Float32(Some(v)), _) => Some(*v),
+                Expr::Literal(ScalarValue::Float64(Some(v)), _) => Some(*v as f32),
+                Expr::Literal(ScalarValue::Int64(Some(v)), _) => Some(*v as f32),
+                Expr::Literal(ScalarValue::Int32(Some(v)), _) => Some(*v as f32),
+                _ => None,
+            })
+            .collect(),
+        Expr::Literal(ScalarValue::List(array), _) => {
+            let array = array.as_ref();
+            let values = array.value(0);
+            match values.data_type() {
+                DataType::Float64 => {
+                    let values = values
+                        .as_any()
+                        .downcast_ref::<arrow::array::Float64Array>()?;
+                    Some(
+                        values
+                            .iter()
+                            .map(|v| v.map(|v| v as f32).unwrap_or_default())
+                            .collect(),
+                    )
+                }
+                DataType::Float32 => {
+                    let values = values
+                        .as_any()
+                        .downcast_ref::<arrow::array::Float32Array>()?;
+                    Some(values.iter().map(|v| v.unwrap_or_default()).collect())
+                }
+                _ => None,
+            }
+        }
+        Expr::Literal(ScalarValue::FixedSizeList(array), _) => {
+            let array = array.as_ref();
+            let values = array.value(0);
+            match values.data_type() {
+                DataType::Float64 => {
+                    let values = values
+                        .as_any()
+                        .downcast_ref::<arrow::array::Float64Array>()?;
+                    Some(
+                        values
+                            .iter()
+                            .map(|v| v.map(|v| v as f32).unwrap_or_default())
+                            .collect(),
+                    )
+                }
+                DataType::Float32 => {
+                    let values = values
+                        .as_any()
+                        .downcast_ref::<arrow::array::Float32Array>()?;
+                    Some(values.iter().map(|v| v.unwrap_or_default()).collect())
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Strip surrounding `Cast` / `Alias` wrappers.
+fn unwrap_cast(expr: &Expr) -> &Expr {
+    let mut current = expr;
+    loop {
+        current = match current {
+            Expr::Cast(cast) => {
+                let Cast { expr, .. } = cast;
+                expr
+            }
+            Expr::Alias(alias) => &alias.expr,
+            other => return other,
+        };
+    }
+}
+
+/// Rebuild the plan chain with the marker appended to the target scan.
+///
+/// Rebuilds every node between the root and the target `TableScan` via the
+/// `TreeNode` machinery (the node structs are non-exhaustive); the target
+/// scan gets the marker filter appended.
+fn rewrite_chain(
+    plan: LogicalPlan,
+    spec: &VectorSearchSpec,
+    target: &Arc<LogicalPlan>,
+) -> Option<LogicalPlan> {
+    if let LogicalPlan::TableScan(ts) = &plan
+        && let LogicalPlan::TableScan(target_ts) = target.as_ref()
+        && Arc::ptr_eq(&ts.source, &target_ts.source)
+    {
+        return Some(rewrite_scan(&plan, spec));
+    }
+    let mut changed = false;
+    let rewritten = plan
+        .map_children(|child| {
+            let unchanged = child.clone();
+            match rewrite_chain(child, spec, target) {
+                Some(rewritten) => {
+                    changed = true;
+                    Ok(Transformed::yes(rewritten))
+                }
+                None => Ok(Transformed::no(unchanged)),
+            }
+        })
+        .ok()?;
+    changed.then_some(rewritten.data)
+}
+
+/// Append the marker filter to a TableScan, preserving everything else.
+fn rewrite_scan(scan: &LogicalPlan, spec: &VectorSearchSpec) -> LogicalPlan {
+    let LogicalPlan::TableScan(ts) = scan else {
+        unreachable!("target must be a TableScan")
+    };
+    let mut filters = ts.filters.clone();
+    filters.push(marker_expr(
+        &spec.vec_column,
+        &spec.query,
+        spec.top_k,
+        &spec.metric,
+    ));
+    LogicalPlan::TableScan(TableScan {
+        table_name: ts.table_name.clone(),
+        source: Arc::clone(&ts.source),
+        projection: ts.projection.clone(),
+        projected_schema: ts.projected_schema.clone(),
+        filters,
+        fetch: ts.fetch,
+    })
+}

--- a/rust/lakesoul-datafusion/src/tests/mod.rs
+++ b/rust/lakesoul-datafusion/src/tests/mod.rs
@@ -14,6 +14,8 @@ mod hash_tests;
 mod insert_tests;
 #[cfg(test)]
 mod upsert_tests;
+#[cfg(test)]
+mod vector_search_tests;
 // mod compaction_tests;
 // mod streaming_tests;
 #[cfg(feature = "ci")]

--- a/rust/lakesoul-datafusion/src/tests/vector_search_tests.rs
+++ b/rust/lakesoul-datafusion/src/tests/vector_search_tests.rs
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 LakeSoul contributors
+
+//! Vector search through DataFusion SQL.
+//!
+//! `ORDER BY array_distance(vec, q) LIMIT k` (and the inner-product
+//! variant) is rewritten by [`VectorSearchPushdownRule`] into a scan over
+//! the IVF+RaBitQ index candidates.  These tests cover the optimizer rule
+//! directly and end-to-end through SQL against a real table with a built
+//! index.
+
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::util::display::array_value_to_string;
+use datafusion::common::tree_node::TreeNode;
+use datafusion::datasource::memory::MemTable;
+use datafusion::datasource::provider_as_source;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
+use datafusion::optimizer::OptimizerRule;
+use datafusion::prelude::{col, lit};
+use lakesoul_io::config::LakeSoulIOConfigBuilder;
+use lakesoul_metadata::MetaDataClient;
+
+use crate::cli::CoreArgs;
+use crate::planner::vector_search_rule::VectorSearchPushdownRule;
+use crate::udf::vector_search_marker::LakeSoulVectorSearchOptions;
+
+const DIM: usize = 8;
+
+fn vector_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt64, false),
+        Field::new(
+            "vec",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            false,
+        ),
+    ]))
+}
+
+fn random_vectors(n: usize) -> Vec<Vec<f32>> {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    (0..n)
+        .map(|_| (0..DIM).map(|_| rng.r#gen::<f32>() * 2.0 - 1.0).collect())
+        .collect()
+}
+
+fn brute_force_topk(vectors: &[Vec<f32>], query: &[f32], k: usize) -> Vec<u64> {
+    let mut scored: Vec<(f32, u64)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let d: f32 = v.iter().zip(query).map(|(a, b)| (a - b) * (a - b)).sum();
+            (d, i as u64)
+        })
+        .collect();
+    scored.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    scored.into_iter().take(k).map(|(_, id)| id).collect()
+}
+
+/// Build a `Limit(Sort(array_distance(vec, ARRAY[...])))` plan over a
+/// mem-table source with the vector schema.
+fn build_limit_sort_plan(sort_expr: Expr, limit: usize) -> DFResult<LogicalPlan> {
+    let mem_table = Arc::new(MemTable::try_new(vector_schema(), vec![vec![]])?);
+    let source = provider_as_source(mem_table);
+    LogicalPlanBuilder::scan("t", source, None)?
+        .sort(vec![sort_expr.sort(true, false)])?
+        .limit(0, Some(limit))?
+        .build()
+}
+
+fn udf_call(udf: Arc<datafusion::logical_expr::ScalarUDF>, args: Vec<Expr>) -> Expr {
+    Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+        udf, args,
+    ))
+}
+
+fn array_literal(values: &[f32]) -> Expr {
+    udf_call(
+        datafusion::functions_nested::make_array::make_array_udf(),
+        values.iter().map(|v| lit(*v as f64)).collect(),
+    )
+}
+
+fn array_distance_expr() -> Expr {
+    udf_call(
+        datafusion::functions_nested::distance::array_distance_udf(),
+        vec![
+            col("vec"),
+            array_literal(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),
+        ],
+    )
+}
+
+fn cosine_distance_expr() -> Expr {
+    udf_call(
+        datafusion::functions_nested::cosine_distance::cosine_distance_udf(),
+        vec![
+            col("vec"),
+            array_literal(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),
+        ],
+    )
+}
+
+fn inner_product_expr() -> Expr {
+    udf_call(
+        datafusion::functions_nested::inner_product::inner_product_udf(),
+        vec![
+            col("vec"),
+            array_literal(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),
+        ],
+    )
+}
+
+fn has_marker(plan: &LogicalPlan) -> bool {
+    let mut found = false;
+    plan.apply(&mut |node: &LogicalPlan| {
+        if let LogicalPlan::TableScan(ts) = node
+            && ts.filters.iter().any(|f| {
+                matches!(f, Expr::ScalarFunction(call)
+                    if call.func.name() == crate::udf::vector_search_marker::VECTOR_SEARCH_MARKER)
+            })
+        {
+            found = true;
+        }
+        Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
+    })
+    .unwrap();
+    found
+}
+
+#[test]
+fn rule_rewrites_array_distance_limit() {
+    let plan = build_limit_sort_plan(array_distance_expr(), 10).unwrap();
+    let rewritten = VectorSearchPushdownRule
+        .rewrite(
+            plan.clone(),
+            &datafusion::optimizer::OptimizerContext::new(),
+        )
+        .unwrap()
+        .data;
+    assert!(has_marker(&rewritten), "marker must be injected");
+    // idempotent: a second pass must not change the plan again
+    let second = VectorSearchPushdownRule
+        .rewrite(
+            rewritten.clone(),
+            &datafusion::optimizer::OptimizerContext::new(),
+        )
+        .unwrap();
+    assert!(!second.transformed);
+}
+
+#[test]
+fn rule_ignores_cosine_distance() {
+    let plan = build_limit_sort_plan(cosine_distance_expr(), 10).unwrap();
+    let result = VectorSearchPushdownRule
+        .rewrite(plan, &datafusion::optimizer::OptimizerContext::new())
+        .unwrap();
+    assert!(!result.transformed, "cosine_distance must fall back");
+}
+
+#[test]
+fn rule_ignores_inner_product_asc() {
+    // inner_product must be DESC; an ASC sort is a different semantic.
+    let mem_table = Arc::new(MemTable::try_new(vector_schema(), vec![vec![]]).unwrap());
+    let source = provider_as_source(mem_table);
+    let plan = LogicalPlanBuilder::scan("t", source, None)
+        .unwrap()
+        .sort(vec![inner_product_expr().sort(true, false)])
+        .unwrap()
+        .limit(0, Some(10))
+        .unwrap()
+        .build()
+        .unwrap();
+    let result = VectorSearchPushdownRule
+        .rewrite(plan, &datafusion::optimizer::OptimizerContext::new())
+        .unwrap();
+    assert!(!result.transformed, "inner_product ASC must not match");
+}
+
+#[test]
+fn rule_ignores_missing_limit() {
+    let mem_table = Arc::new(MemTable::try_new(vector_schema(), vec![vec![]]).unwrap());
+    let source = provider_as_source(mem_table);
+    let plan = LogicalPlanBuilder::scan("t", source, None)
+        .unwrap()
+        .sort(vec![array_distance_expr().sort(true, false)])
+        .unwrap()
+        .build()
+        .unwrap();
+    let result = VectorSearchPushdownRule
+        .rewrite(plan, &datafusion::optimizer::OptimizerContext::new())
+        .unwrap();
+    assert!(!result.transformed, "no LIMIT must not match");
+}
+
+// ---------------------------------------------------------------------------
+// E2E (requires PostgreSQL)
+// ---------------------------------------------------------------------------
+
+fn make_batch(ids: &[u64], vectors: &[Vec<f32>]) -> RecordBatch {
+    let id_array = arrow::array::UInt64Array::from(ids.to_vec());
+    let mut builder = arrow::array::FixedSizeListBuilder::new(
+        arrow::array::Float32Builder::new(),
+        DIM as i32,
+    );
+    for vector in vectors {
+        for value in vector {
+            builder.values().append_value(*value);
+        }
+        builder.append(true);
+    }
+    let vec_array = builder.finish();
+    RecordBatch::try_new(
+        vector_schema(),
+        vec![Arc::new(id_array), Arc::new(vec_array)],
+    )
+    .unwrap()
+}
+
+fn clean_table_dir(table_name: &str) {
+    // The native index/files are not removed by drop_table; remove the
+    // on-disk state so each run starts from a clean table.
+    let path = std::path::Path::new("default").join(table_name);
+    let _ = std::fs::remove_dir_all(&path);
+    let _ = std::fs::remove_dir_all(
+        std::env::current_dir()
+            .unwrap()
+            .join("default")
+            .join(table_name),
+    );
+}
+
+fn default_args() -> CoreArgs {
+    CoreArgs {
+        warehouse_prefix: None,
+        endpoint: None,
+        s3_bucket: None,
+        s3_access_key: None,
+        s3_secret_key: None,
+        s3_virtual_host_style: false,
+        worker_threads: 2,
+    }
+}
+
+/// The vector index configuration used by the tests (declared at table
+/// creation through the `vector_index_columns` table property).
+fn vector_configs() -> Vec<crate::vector_index::VectorIndexTableConfig> {
+    vec![crate::vector_index::VectorIndexTableConfig {
+        column: "vec".to_string(),
+        dim: DIM,
+        nlist: 4,
+        total_bits: 7,
+        metric: "L2".to_string(),
+        rotator_type: "FhtKac".to_string(),
+        seed: 42,
+        use_faster_config: true,
+    }]
+}
+
+/// Assert that every hash bucket of the table has a vector index.
+fn assert_vector_index_built(table_name: &str) {
+    let root = std::env::current_dir()
+        .unwrap()
+        .join("default")
+        .join(table_name);
+    let index_dir = root.join("_vector_index").join("vec");
+    assert!(index_dir.exists(), "no _vector_index dir at {index_dir:?}");
+    let bucket_count = std::fs::read_dir(&index_dir).unwrap().count();
+    assert!(bucket_count >= 1, "expected >= 1 index shard dir");
+}
+
+async fn explain_plan(
+    ctx: &Arc<datafusion::execution::context::SessionContext>,
+    sql: &str,
+) -> String {
+    let df = ctx.sql(sql).await.unwrap();
+    let batches = df.collect().await.unwrap();
+    let mut text = String::new();
+    for batch in &batches {
+        for col in batch.columns() {
+            for row in 0..batch.num_rows() {
+                text.push_str(
+                    &array_value_to_string(col.as_ref(), row).unwrap_or_default(),
+                );
+                text.push('\n');
+            }
+        }
+    }
+    text
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sql_vector_search_end_to_end() {
+    use crate::catalog::create_table_with_vector_index;
+
+    let client = Arc::new(MetaDataClient::from_env().await.unwrap());
+    let table_name = "vec_search_sql_e2e";
+    let _ = client.drop_table(table_name, "default").await;
+    clean_table_dir(table_name);
+
+    // 1. Create the table (u64 pk + FixedSizeList<Float32, 8>) and declare
+    //    the vector index through the `vector_index_columns` property.
+    let builder = LakeSoulIOConfigBuilder::new()
+        .with_schema(vector_schema())
+        .with_primary_keys(vec!["id".to_string()])
+        .with_hash_bucket_num("4");
+    create_table_with_vector_index(
+        client.clone(),
+        table_name,
+        builder.build(),
+        &vector_configs(),
+    )
+    .await
+    .unwrap();
+
+    // 2. Write 200 random vectors — the index is auto-built after commit.
+    let n = 200u64;
+    let vectors = random_vectors(n as usize);
+    let ids: Vec<u64> = (0..n).collect();
+    let batch = make_batch(&ids, &vectors);
+    crate::lakesoul_table::LakeSoulTable::for_name(table_name)
+        .await
+        .unwrap()
+        .execute_upsert(batch)
+        .await
+        .unwrap();
+    assert_vector_index_built(table_name);
+
+    // 4. Query through SQL.
+    let ctx = crate::create_lakesoul_session_ctx(client, &default_args()).unwrap();
+    let query = [0.1f32, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7, 0.8];
+    let q = query
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "select id from \"LAKESOUL\".default.{table_name} \
+         order by array_distance(vec, ARRAY[{q}]) limit 5"
+    );
+
+    let df = ctx.sql(&sql).await.unwrap();
+    let batches = df.collect().await.unwrap();
+    let mut ids_result = Vec::new();
+    for batch in &batches {
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt64Array>()
+            .unwrap();
+        ids_result.extend(arr.values().iter().copied());
+    }
+    assert_eq!(ids_result.len(), 5, "LIMIT 5 rows: {ids_result:?}");
+
+    let truth = brute_force_topk(&vectors, &query, 5);
+    let recall = ids_result.iter().filter(|id| truth.contains(id)).count() as f64 / 5.0;
+    assert!(
+        recall >= 0.5,
+        "recall too low: {recall} (got {ids_result:?}, truth {truth:?})"
+    );
+
+    // 5. The physical plan uses the vector-index scan.
+    let explain = explain_plan(&ctx, &format!("EXPLAIN VERBOSE {sql}")).await;
+    assert!(
+        explain.contains("LakeSoulVectorSearchExec"),
+        "plan must use the vector-index exec:\n{explain}"
+    );
+
+    // 6. cosine_distance falls back to the full scan.
+    let cosine_sql = format!(
+        "select id from \"LAKESOUL\".default.{table_name} \
+         order by cosine_distance(vec, ARRAY[{q}]) limit 5"
+    );
+    let explain = explain_plan(&ctx, &format!("EXPLAIN VERBOSE {cosine_sql}")).await;
+    assert!(
+        !explain.contains("LakeSoulVectorSearchExec"),
+        "cosine_distance must fall back:\n{explain}"
+    );
+
+    // 7. An incremental write auto-builds delta segments: vectors written
+    //    afterwards become searchable.
+    let more = random_vectors(100);
+    let more_ids: Vec<u64> = (200..300).collect();
+    let more_batch = make_batch(&more_ids, &more);
+    crate::lakesoul_table::LakeSoulTable::for_name(table_name)
+        .await
+        .unwrap()
+        .execute_upsert(more_batch)
+        .await
+        .unwrap();
+
+    let probe = more[7].clone();
+    let pq = probe
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let incremental_sql = format!(
+        "select id from \"LAKESOUL\".default.{table_name} \
+         order by array_distance(vec, ARRAY[{pq}]) limit 5"
+    );
+    let df = ctx.sql(&incremental_sql).await.unwrap();
+    let batches = df.collect().await.unwrap();
+    let mut incremental_ids = Vec::new();
+    for batch in &batches {
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt64Array>()
+            .unwrap();
+        incremental_ids.extend(arr.values().iter().copied());
+    }
+    assert!(
+        incremental_ids.iter().any(|id| *id >= 200),
+        "incremental write must be searchable: {incremental_ids:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sql_vector_search_with_where_and_nprobe() {
+    use crate::catalog::create_table_with_vector_index;
+
+    let client = Arc::new(MetaDataClient::from_env().await.unwrap());
+    let table_name = "vec_search_sql_where";
+    let _ = client.drop_table(table_name, "default").await;
+    clean_table_dir(table_name);
+
+    let builder = LakeSoulIOConfigBuilder::new()
+        .with_schema(vector_schema())
+        .with_primary_keys(vec!["id".to_string()])
+        .with_hash_bucket_num("4");
+    create_table_with_vector_index(
+        client.clone(),
+        table_name,
+        builder.build(),
+        &vector_configs(),
+    )
+    .await
+    .unwrap();
+
+    let n = 120u64;
+    let vectors = random_vectors(n as usize);
+    let ids: Vec<u64> = (0..n).collect();
+    let batch = make_batch(&ids, &vectors);
+    crate::lakesoul_table::LakeSoulTable::for_name(table_name)
+        .await
+        .unwrap()
+        .execute_upsert(batch)
+        .await
+        .unwrap();
+    assert_vector_index_built(table_name);
+
+    // A session with a custom nprobe extension.
+    let session_config = crate::create_lakesoul_session_config()
+        .unwrap()
+        .with_extension(Arc::new(LakeSoulVectorSearchOptions { nprobe: 1 }));
+    let ctx = crate::create_lakesoul_session_ctx_with_config(
+        client,
+        &default_args(),
+        session_config,
+    )
+    .unwrap();
+
+    let q = [0.1f32, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7, 0.8]
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "select id from \"LAKESOUL\".default.{table_name} \
+         where id % 2 = 0 \
+         order by array_distance(vec, ARRAY[{q}]) limit 5"
+    );
+    let explain = explain_plan(&ctx, &format!("EXPLAIN VERBOSE {sql}")).await;
+    assert!(
+        explain.contains("LakeSoulVectorSearchExec"),
+        "WHERE variant must still use the vector-index exec:\n{explain}"
+    );
+
+    let df = ctx.sql(&sql).await.unwrap();
+    let batches = df.collect().await.unwrap();
+    let mut ids_result = Vec::new();
+    for batch in &batches {
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt64Array>()
+            .unwrap();
+        ids_result.extend(arr.values().iter().copied());
+    }
+    assert!(
+        !ids_result.is_empty(),
+        "expected at least one candidate row passing the WHERE filter"
+    );
+    assert!(
+        ids_result.iter().all(|id| id % 2 == 0),
+        "WHERE must be applied on candidate rows: {ids_result:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sql_vector_search_falls_back_without_index() {
+    use crate::catalog::create_table;
+
+    let client = Arc::new(MetaDataClient::from_env().await.unwrap());
+    let table_name = "vec_search_sql_noindex";
+    let _ = client.drop_table(table_name, "default").await;
+    clean_table_dir(table_name);
+
+    let builder = LakeSoulIOConfigBuilder::new()
+        .with_schema(vector_schema())
+        .with_primary_keys(vec!["id".to_string()])
+        .with_hash_bucket_num("4");
+    create_table(client.clone(), table_name, builder.build())
+        .await
+        .unwrap();
+
+    let n = 60u64;
+    let vectors = random_vectors(n as usize);
+    let ids: Vec<u64> = (0..n).collect();
+    let batch = make_batch(&ids, &vectors);
+    crate::lakesoul_table::LakeSoulTable::for_name(table_name)
+        .await
+        .unwrap()
+        .execute_upsert(batch)
+        .await
+        .unwrap();
+    // No vector index is built.
+
+    let ctx = crate::create_lakesoul_session_ctx(client, &default_args()).unwrap();
+    let q = [0.1f32, -0.2, 0.3, 0.4, -0.5, 0.6, 0.7, 0.8]
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "select id from \"LAKESOUL\".default.{table_name} \
+         order by array_distance(vec, ARRAY[{q}]) limit 5"
+    );
+    let explain = explain_plan(&ctx, &format!("EXPLAIN VERBOSE {sql}")).await;
+    assert!(
+        !explain.contains("LakeSoulVectorSearchExec"),
+        "without an index the query must fall back to a full scan:\n{explain}"
+    );
+
+    // The result is still correct (exact top-5 over all rows).
+    let df = ctx.sql(&sql).await.unwrap();
+    let batches = df.collect().await.unwrap();
+    let mut ids_result = Vec::new();
+    for batch in &batches {
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::UInt64Array>()
+            .unwrap();
+        ids_result.extend(arr.values().iter().copied());
+    }
+    let truth = brute_force_topk(&vectors, &q_str_to_vec(&q), 5);
+    assert_eq!(ids_result, truth, "fallback must be exact");
+}
+
+fn q_str_to_vec(q: &str) -> Vec<f32> {
+    q.split(',').map(|s| s.trim().parse().unwrap()).collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sql_create_table_declares_vector_index_via_option() {
+    // The `vector_index_columns` OPTIONS entry of `CREATE EXTERNAL TABLE`
+    // must be validated at creation and stored as a table property (no
+    // post-hoc property update needed).
+    let client = Arc::new(MetaDataClient::from_env().await.unwrap());
+    let table_name = "vec_search_sql_create_opt";
+    let _ = client.drop_table(table_name, "default").await;
+    clean_table_dir(table_name);
+
+    let ctx =
+        crate::create_lakesoul_session_ctx(client.clone(), &default_args()).unwrap();
+    let vector_option = serde_json::json!([{
+        "column": "vec",
+        "dim": DIM,
+        "nlist": 4,
+        "total_bits": 7,
+        "metric": "L2",
+    }])
+    .to_string();
+
+    // A `FLOAT[]` column validates against the vector-index rules (List of
+    // floats); the option is stored as the table property.
+    let create_sql = format!(
+        "CREATE EXTERNAL TABLE \"LAKESOUL\".default.{table_name} (
+            id BIGINT NOT NULL PRIMARY KEY,
+            vec FLOAT[] NOT NULL
+         ) STORED AS LAKESOUL \
+         LOCATION 'default/{table_name}' \
+         OPTIONS ('vector_index_columns' '{vector_option}', 'hash_bucket_num' '4')"
+    );
+    ctx.sql(&create_sql).await.unwrap().collect().await.unwrap();
+
+    // The property round-trips: the provider must expose the declared
+    // vector configs, and a fresh table lookup keeps them.
+    let table_info = client
+        .get_table_info_by_table_name(table_name, "default")
+        .await
+        .unwrap()
+        .expect("table must exist");
+    let configs = crate::vector_index::parse_vector_index_from_table_properties(
+        &table_info.properties,
+    )
+    .unwrap();
+    assert_eq!(configs.len(), 1);
+    assert_eq!(configs[0].column, "vec");
+    assert_eq!(configs[0].dim, DIM);
+
+    // An invalid option value is rejected before any metadata is created.
+    let table_name2 = "vec_search_sql_create_badopt";
+    let _ = client.drop_table(table_name2, "default").await;
+    clean_table_dir(table_name2);
+    let bad_sql = format!(
+        "CREATE EXTERNAL TABLE \"LAKESOUL\".default.{table_name2} (
+            id BIGINT NOT NULL PRIMARY KEY,
+            vec FLOAT[] NOT NULL
+         ) STORED AS LAKESOUL \
+         LOCATION 'default/{table_name2}' \
+         OPTIONS ('vector_index_columns' 'not-json')"
+    );
+    let err = ctx.sql(&bad_sql).await.unwrap_err();
+    assert!(
+        err.to_string().contains("invalid vector_index_columns"),
+        "expected an option validation error, got: {err}"
+    );
+}

--- a/rust/lakesoul-datafusion/src/udf/mod.rs
+++ b/rust/lakesoul-datafusion/src/udf/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 LakeSoul contributors
+
+//! Internal scalar UDFs and session options for LakeSoul.
+
+pub mod vector_search_marker;

--- a/rust/lakesoul-datafusion/src/udf/vector_search_marker.rs
+++ b/rust/lakesoul-datafusion/src/udf/vector_search_marker.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 LakeSoul contributors
+
+//! Internal marker UDF and session options for the vector-search pushdown.
+//!
+//! The [`VectorSearchPushdownRule`](crate::planner::vector_search_rule::VectorSearchPushdownRule)
+//! rewrites `ORDER BY <distance>(vec, q) LIMIT k` into a LakeSoul
+//! vector-index search by appending a marker call to the `TableScan`
+//! filters.  The marker is never evaluated: [`LakeSoulTableProvider::scan`]
+//! recognizes it, extracts the search parameters, and strips it before the
+//! standard filter pipeline.  Its return value (always true) only matters
+//! if some planner stage left it behind.
+
+use std::sync::Arc;
+
+use arrow::array::BooleanArray;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::logical_expr::{
+    ColumnarValue, Expr, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+
+/// Function name of the internal vector-search marker.
+pub const VECTOR_SEARCH_MARKER: &str = "__lakesoul_vector_search";
+
+/// Parsed marker arguments: (vector column, query, per-bucket candidate
+/// count, distance metric).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VectorSearchRequest {
+    /// Name of the vector column to search.
+    pub vec_column: String,
+    /// Query vector serialized as a comma-separated list of `f32` values.
+    pub query_csv: String,
+    /// Number of candidates requested per bucket (the SQL `LIMIT` value).
+    pub top_k: usize,
+    /// Distance metric: `"L2"` or `"IP"`.
+    pub metric: String,
+}
+
+/// Build the marker expression appended to a `TableScan.filters` list.
+pub fn marker_expr(vec_column: &str, query: &[f32], top_k: usize, metric: &str) -> Expr {
+    let query_csv = query
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    Expr::ScalarFunction(ScalarFunction::new_udf(
+        marker_udf(),
+        vec![
+            Expr::Column(datafusion::common::Column::new_unqualified(
+                vec_column.to_string(),
+            )),
+            Expr::Literal(datafusion::common::ScalarValue::Utf8(Some(query_csv)), None),
+            Expr::Literal(
+                datafusion::common::ScalarValue::Int64(Some(top_k as i64)),
+                None,
+            ),
+            Expr::Literal(
+                datafusion::common::ScalarValue::Utf8(Some(metric.to_string())),
+                None,
+            ),
+        ],
+    ))
+}
+
+/// Return true if `expr` is the internal vector-search marker call.
+pub fn is_marker_expr(expr: &Expr) -> bool {
+    matches!(expr, Expr::ScalarFunction(call) if call.func.name() == VECTOR_SEARCH_MARKER)
+}
+
+/// Parse a vector-search request from `filters`; returns None when no
+/// marker is present.
+pub fn parse_vector_search_request(filters: &[Expr]) -> Option<VectorSearchRequest> {
+    filters
+        .iter()
+        .find(|f| is_marker_expr(f))
+        .and_then(|marker| {
+            let Expr::ScalarFunction(call) = marker else {
+                return None;
+            };
+            if call.args.len() != 4 {
+                return None;
+            }
+            let vec_column = match &call.args[0] {
+                Expr::Column(col) => col.name.clone(),
+                _ => return None,
+            };
+            let query_csv = match &call.args[1] {
+                Expr::Literal(datafusion::common::ScalarValue::Utf8(Some(s)), _) => {
+                    s.clone()
+                }
+                _ => return None,
+            };
+            let top_k = match &call.args[2] {
+                Expr::Literal(datafusion::common::ScalarValue::Int64(Some(k)), _) => {
+                    (*k).max(1) as usize
+                }
+                _ => return None,
+            };
+            let metric = match &call.args[3] {
+                Expr::Literal(datafusion::common::ScalarValue::Utf8(Some(s)), _) => {
+                    s.clone()
+                }
+                _ => return None,
+            };
+            Some(VectorSearchRequest {
+                vec_column,
+                query_csv,
+                top_k,
+                metric,
+            })
+        })
+}
+
+/// The internal marker UDF.  Never evaluated as a physical function.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct VectorSearchMarkerUDF {
+    signature: Signature,
+}
+
+impl Default for VectorSearchMarkerUDF {
+    fn default() -> Self {
+        Self {
+            // Volatile so the optimizer's simplify_expressions pass never
+            // constant-folds the marker call into a literal `true`.
+            signature: Signature::user_defined(Volatility::Volatile),
+        }
+    }
+}
+
+impl ScalarUDFImpl for VectorSearchMarkerUDF {
+    fn name(&self) -> &str {
+        VECTOR_SEARCH_MARKER
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Boolean)
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: datafusion::logical_expr::ScalarFunctionArgs,
+    ) -> DFResult<ColumnarValue> {
+        Ok(ColumnarValue::Array(Arc::new(BooleanArray::from(vec![
+            true; args.number_rows
+        ]))))
+    }
+}
+
+/// Return the marker UDF (a new Arc is cheap; it is only used by name).
+pub fn marker_udf() -> Arc<ScalarUDF> {
+    Arc::new(ScalarUDF::new_from_impl(VectorSearchMarkerUDF::default()))
+}
+
+/// Session-level options for LakeSoul vector search.
+///
+/// Set via `session_config.set_extension(Arc::new(LakeSoulVectorSearchOptions { nprobe: 8 }))`
+/// and read in the scan path with
+/// `session_state.config().get_extension::<LakeSoulVectorSearchOptions>()`.
+#[derive(Debug, Clone)]
+pub struct LakeSoulVectorSearchOptions {
+    /// Number of IVF clusters to probe in each bucket index.
+    pub nprobe: usize,
+}
+
+impl Default for LakeSoulVectorSearchOptions {
+    fn default() -> Self {
+        Self { nprobe: 64 }
+    }
+}

--- a/rust/lakesoul-datafusion/src/vector_index.rs
+++ b/rust/lakesoul-datafusion/src/vector_index.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2026 LakeSoul contributors
+
+//! Vector index configuration and the automatic index build for writes.
+//!
+//! Like the Python SDK, a table enables vector search by storing a
+//! `vector_index_columns` table property — a JSON array of index
+//! configurations.  After a write commits, the sink reads that property
+//! and builds/updates one IVF+RaBitQ index shard per
+//! `(partition, hash bucket)` from the newly written files; the Rust
+//! builder performs an incremental delta update when the shard index
+//! already exists.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use lakesoul_io::helpers::extract_hash_bucket_id;
+use lakesoul_io::vector::builder::VectorShardIndexBuilder;
+use lakesoul_vector::{Metric, RotatorType, VectorIndexConfig};
+use object_store::ObjectStore;
+use object_store::local::LocalFileSystem;
+use rootcause::{bail, report};
+
+use crate::Result;
+
+/// Property key holding the vector index configurations (JSON).
+pub const VECTOR_INDEX_COLUMNS_KEY: &str = "vector_index_columns";
+
+fn default_nlist() -> usize {
+    256
+}
+
+fn default_total_bits() -> usize {
+    7
+}
+
+fn default_metric() -> String {
+    "L2".to_string()
+}
+
+fn default_rotator_type() -> String {
+    "FhtKac".to_string()
+}
+
+fn default_seed() -> u64 {
+    42
+}
+
+fn default_use_faster_config() -> bool {
+    true
+}
+
+/// One entry of the `vector_index_columns` table property (JSON).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VectorIndexTableConfig {
+    /// Vector column name (must exist in the table schema).
+    pub column: String,
+    /// Vector dimension.
+    pub dim: usize,
+    /// Number of IVF clusters.
+    #[serde(default = "default_nlist")]
+    pub nlist: usize,
+    /// RaBitQ total bits (1-16).
+    #[serde(default = "default_total_bits")]
+    pub total_bits: usize,
+    /// Distance metric: `"L2"` or `"IP"`.
+    #[serde(default = "default_metric")]
+    pub metric: String,
+    /// Rotation: `"FhtKac"` or `"Matrix"`.
+    #[serde(default = "default_rotator_type")]
+    pub rotator_type: String,
+    /// Random seed.
+    #[serde(default = "default_seed")]
+    pub seed: u64,
+    /// Fast quantization mode.
+    #[serde(default = "default_use_faster_config")]
+    pub use_faster_config: bool,
+}
+
+impl VectorIndexTableConfig {
+    /// Convert into the native vector index configuration.
+    pub fn to_vector_index_config(&self) -> Result<VectorIndexConfig> {
+        let metric = match self.metric.to_uppercase().as_str() {
+            "L2" => Metric::L2,
+            "IP" | "INNERPRODUCT" => Metric::InnerProduct,
+            other => bail!("unsupported vector index metric: {other}"),
+        };
+        let rotator_type = match self.rotator_type.to_lowercase().as_str() {
+            "fhtkac" => RotatorType::FhtKacRotator,
+            "matrix" => RotatorType::MatrixRotator,
+            other => bail!("unsupported vector index rotator type: {other}"),
+        };
+        Ok(VectorIndexConfig {
+            column_name: self.column.clone(),
+            dim: self.dim,
+            nlist: self.nlist,
+            total_bits: self.total_bits,
+            metric,
+            rotator_type,
+            seed: self.seed,
+            use_faster_config: self.use_faster_config,
+        })
+    }
+}
+
+/// Serialize configurations into the `vector_index_columns` property value.
+pub fn vector_index_columns_to_json(configs: &[VectorIndexTableConfig]) -> String {
+    serde_json::to_string(configs).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Validate that a table schema can support the configured vector indexes,
+/// before any metadata is created (mirrors the Python SDK).
+///
+/// Requires an `UInt64`/`Int64` primary key (the index maps search results
+/// to primary key values) and `FixedSizeList`/`List` of `Float32`/`Float64`
+/// vector columns whose dimension matches the configured `dim`.
+pub fn validate_vector_index_configs(
+    configs: &[VectorIndexTableConfig],
+    schema: &arrow::datatypes::Schema,
+    primary_keys: &[String],
+) -> Result<()> {
+    use arrow::datatypes::DataType;
+    if configs.is_empty() {
+        return Ok(());
+    }
+    let Some(pk_column) = primary_keys.first() else {
+        bail!(
+            "a vector index requires an id column: pass primary_keys=[...] \
+             when creating a table with vector_index (the index maps search \
+             results to primary key values)"
+        );
+    };
+    let Some(pk_index) = schema.index_of(pk_column).ok() else {
+        bail!("vector index primary key '{pk_column}' not found in table schema");
+    };
+    match schema.field(pk_index).data_type() {
+        DataType::UInt64 | DataType::Int64 => {}
+        other => bail!(
+            "vector index primary key '{pk_column}' must be UInt64 or Int64, got {other}"
+        ),
+    }
+    for config in configs {
+        let column = &config.column;
+        let Some(column_index) = schema.index_of(column).ok() else {
+            bail!("vector index column '{column}' not found in table schema");
+        };
+        let data_type = schema.field(column_index).data_type();
+        let (element_type, fixed_len) = match data_type {
+            DataType::FixedSizeList(field, len) => {
+                (field.data_type(), Some(*len as usize))
+            }
+            DataType::List(field) | DataType::LargeList(field) => {
+                (field.data_type(), None)
+            }
+            other => {
+                bail!(
+                    "vector index column '{column}' must be FixedSizeList or List \
+                     of Float32/Float64, got {other}"
+                )
+            }
+        };
+        match element_type {
+            DataType::Float32 | DataType::Float64 => {}
+            other => bail!(
+                "vector index column '{column}' elements must be Float32/Float64, got {other}"
+            ),
+        }
+        if let Some(len) = fixed_len
+            && config.dim != len
+        {
+            bail!(
+                "vector index column '{column}' dim {} does not match schema \
+                 FixedSizeList size {len}",
+                config.dim
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Parse a `vector_index_columns` property value.
+///
+/// The value is normally a JSON string containing a JSON array; a raw JSON
+/// array is accepted as well.  Empty or missing values yield an empty list.
+pub fn parse_vector_index_columns(
+    raw: Option<&str>,
+) -> Result<Vec<VectorIndexTableConfig>> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    let raw = raw.trim();
+    if raw.is_empty() || raw == "[]" {
+        return Ok(Vec::new());
+    }
+    let value: serde_json::Value = serde_json::from_str(raw)?;
+    let array = match value {
+        serde_json::Value::String(s) => {
+            let inner = s.trim();
+            if inner.is_empty() {
+                return Ok(Vec::new());
+            }
+            serde_json::from_str::<serde_json::Value>(inner)?
+        }
+        value => value,
+    };
+    Ok(serde_json::from_value(array)?)
+}
+
+/// Extract the vector index configurations from a table's raw properties
+/// JSON (the `TableInfo.properties` column).
+pub fn parse_vector_index_from_table_properties(
+    properties_json: &str,
+) -> Result<Vec<VectorIndexTableConfig>> {
+    let properties: serde_json::Value = serde_json::from_str(properties_json)?;
+    match properties.get(VECTOR_INDEX_COLUMNS_KEY) {
+        Some(serde_json::Value::String(s)) => parse_vector_index_columns(Some(s)),
+        Some(value) => Ok(serde_json::from_value(value.clone())?),
+        None => Ok(Vec::new()),
+    }
+}
+
+/// Build (or incrementally update) the vector index for newly committed
+/// files of a write.
+///
+/// Files are grouped by `(partition_desc, hash_bucket_id)`; each group is
+/// one index shard and is handed to the native builder, which derives the
+/// index location from the files' directory and performs a delta update
+/// when the shard index already exists.  Fails loudly when any shard of a
+/// configured column fails.
+///
+/// `partition_files` maps a partition description to its newly written
+/// (file path, row count) pairs, as produced by the write sink.
+pub async fn auto_build_vector_index(
+    configs: &[VectorIndexTableConfig],
+    primary_keys: &[String],
+    object_store_options: &HashMap<String, String>,
+    partition_files: &HashMap<String, (Vec<String>, u64)>,
+) -> Result<usize> {
+    if configs.is_empty() || partition_files.is_empty() {
+        return Ok(0);
+    }
+    let Some(pk_column) = primary_keys.first() else {
+        bail!("a vector index requires a table with a primary key");
+    };
+    let Some(first_file) = partition_files
+        .values()
+        .find_map(|(files, _)| files.first())
+    else {
+        return Ok(0);
+    };
+    let store = store_for_files(first_file, object_store_options)?;
+
+    let mut built = 0usize;
+    for config in configs {
+        let vector_config = config.to_vector_index_config()?;
+        let mut failures: Vec<String> = Vec::new();
+        // One shard per (partition_desc, hash_bucket_id) — files from
+        // different range partitions must never share a shard.
+        let mut shards: HashMap<(String, u32), Vec<String>> = HashMap::new();
+        for (partition_desc, (files, _)) in partition_files {
+            for file in files {
+                if let Some(bucket) = extract_hash_bucket_id(file) {
+                    shards
+                        .entry((partition_desc.clone(), bucket))
+                        .or_default()
+                        .push(file.clone());
+                }
+            }
+        }
+        for ((partition_desc, bucket), bucket_files) in shards {
+            let result = VectorShardIndexBuilder::new(
+                store.clone(),
+                vector_config.clone(),
+                bucket_files,
+                pk_column.clone(),
+                object_store_options.clone(),
+                None,
+            )
+            .build()
+            .await;
+            match result {
+                Ok(()) => built += 1,
+                Err(error) => failures.push(format!(
+                    "partition {partition_desc:?} bucket {bucket}: {error}"
+                )),
+            }
+        }
+        if !failures.is_empty() {
+            return Err(report!(
+                "vector index build failed for column '{}': {}",
+                config.column,
+                failures.join("; ")
+            ));
+        }
+    }
+    Ok(built)
+}
+
+/// Build an object store for the vector index from the table's files.
+fn store_for_files(
+    first_file: &str,
+    object_store_options: &HashMap<String, String>,
+) -> Result<Arc<dyn ObjectStore>> {
+    if first_file.starts_with("s3://") || first_file.starts_with("s3a://") {
+        Ok(Arc::new(
+            lakesoul_io::object_store::create_s3_store_from_options(
+                object_store_options,
+            )?,
+        ))
+    } else {
+        Ok(Arc::new(LocalFileSystem::new()))
+    }
+}

--- a/rust/lakesoul-io/src/config/mod.rs
+++ b/rust/lakesoul-io/src/config/mod.rs
@@ -164,6 +164,16 @@ impl LakeSoulIOConfig {
             .or_else(|| std::env::var(format!("LAKESOUL_{}", key.to_uppercase())).ok())
     }
 
+    /// Returns the object store configuration options (e.g. S3 credentials)
+    pub fn object_store_options(&self) -> &HashMap<String, String> {
+        &self.object_store_options
+    }
+
+    /// Returns the additional configuration options map
+    pub fn options(&self) -> &HashMap<String, String> {
+        &self.options
+    }
+
     /// Returns the root directory path for files
     pub fn prefix(&self) -> &String {
         &self.prefix

--- a/rust/lakesoul-io/src/object_store.rs
+++ b/rust/lakesoul-io/src/object_store.rs
@@ -20,35 +20,33 @@ use crate::{
 };
 
 fn create_s3_store(config: &LakeSoulIOConfig) -> Result<AmazonS3> {
+    create_s3_store_from_options(&config.object_store_options)
+}
+
+/// Build an S3 store from `fs.s3a.*` configuration options (env-first).
+///
+/// Used by callers that need an object store outside a DataFusion runtime
+/// (e.g. the vector-index auto build after a write).
+pub fn create_s3_store_from_options(
+    options: &std::collections::HashMap<String, String>,
+) -> Result<AmazonS3> {
     // ENV First
-    let key = std::env::var("AWS_ACCESS_KEY_ID").ok().or_else(|| {
-        config
-            .object_store_options
-            .get("fs.s3a.access.key")
-            .cloned()
-    });
-    let secret = std::env::var("AWS_SECRET_ACCESS_KEY").ok().or_else(|| {
-        config
-            .object_store_options
-            .get("fs.s3a.secret.key")
-            .cloned()
-    });
+    let key = std::env::var("AWS_ACCESS_KEY_ID")
+        .ok()
+        .or_else(|| options.get("fs.s3a.access.key").cloned());
+    let secret = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .ok()
+        .or_else(|| options.get("fs.s3a.secret.key").cloned());
     let region = std::env::var("AWS_REGION").ok().or_else(|| {
-        std::env::var("AWS_DEFAULT_REGION").ok().or_else(|| {
-            config
-                .object_store_options
-                .get("fs.s3a.endpoint.region")
-                .cloned()
-        })
+        std::env::var("AWS_DEFAULT_REGION")
+            .ok()
+            .or_else(|| options.get("fs.s3a.endpoint.region").cloned())
     });
     let mut endpoint = std::env::var("AWS_ENDPOINT")
         .ok()
-        .or_else(|| config.object_store_options.get("fs.s3a.endpoint").cloned());
-    let bucket = config.object_store_options.get("fs.s3a.bucket").cloned();
-    let virtual_path_style = config
-        .object_store_options
-        .get("fs.s3a.path.style.access")
-        .cloned();
+        .or_else(|| options.get("fs.s3a.endpoint").cloned());
+    let bucket = options.get("fs.s3a.bucket").cloned();
+    let virtual_path_style = options.get("fs.s3a.path.style.access").cloned();
     let virtual_path_style = virtual_path_style.is_none_or(|s| s == "true");
     if !virtual_path_style
         && let (Some(endpoint_str), Some(bucket)) = (&endpoint, &bucket)
@@ -79,8 +77,7 @@ fn create_s3_store(config: &LakeSoulIOConfig) -> Result<AmazonS3> {
     retry_config.backoff.base = 2.5;
     retry_config.backoff.max_backoff = Duration::from_secs(20);
 
-    let skip_signature = config
-        .object_store_options
+    let skip_signature = options
         .get("fs.s3a.s3.signing-algorithm")
         .cloned()
         .is_some_and(|s| s == "NoOpSignerType")

--- a/rust/lakesoul-metadata/src/metadata_client.rs
+++ b/rust/lakesoul-metadata/src/metadata_client.rs
@@ -1158,7 +1158,7 @@ impl MetaDataClient {
 
             // 更新properties
             self.execute_update(
-                DaoType::UpdateTableInfoById as i32,
+                DaoType::UpdateTableInfoPropertiesById as i32,
                 [table_id, &serde_json::to_string(&new_properties)?].join(PARAM_DELIM),
             )
             .await


### PR DESCRIPTION
## Summary

Vector search through the DataFusion SQL layer, with the same table-property driven lifecycle as the Python SDK.

Part of #798 Phase 3.

### 1. SQL plan transformation

`ORDER BY array_distance(vec, ARRAY[...]) LIMIT k` (and the `inner_product`/`dot_product` DESC variant) is rewritten into a scan over the IVF+RaBitQ index candidates:

- **`VectorSearchPushdownRule`** (logical optimizer rule) matches `Limit → Sort(<distance>(vec, const) ASC/DESC) → TableScan` and appends an internal marker call to the scan filters.
- **`LakeSoulTableProvider::scan`** recognizes the marker, validates the request against the table's `vector_index_columns` property, and returns a custom **`LakeSoulVectorSearchExec`** that reads each `(partition, bucket)` shard through the native reader (with `vector_search_*` options). Each partition's files are split by hash bucket so every reader searches its own shard index.
- The physical `Sort` + `Limit` stay in place and re-rank the (small) candidate set exactly; extra per-bucket candidates (`top_k × 10`, min 100) give the exact sort recall margin.
- Anything that does not match — `cosine_distance`, missing `LIMIT`, tables without the property or the column/metric — falls back to a regular full scan with unchanged semantics.
- The distance functions are DataFusion built-ins (`array_distance` for L2, `inner_product`/`dot_product` for IP). `nprobe` is configurable through a session extension (`LakeSoulVectorSearchOptions`).

### 2. Property-driven index lifecycle (mirrors the Python SDK)

- **Create**: `vector_index_columns` can be declared at table creation — programmatically via `create_table_with_vector_index`, or in SQL:
  `CREATE EXTERNAL TABLE ... STORED AS LAKESOUL OPTIONS ('vector_index_columns' '[...]')`.
  Configs are validated against the schema and primary keys (UInt64/Int64 pk, list-of-float vector column, dim match) before any metadata is written.
- **Write**: after every commit the sink re-reads the table property and auto-builds/updates one index shard per `(partition_desc, hash_bucket_id)` from the newly written files — incremental delta update when the shard index already exists, full build otherwise.
- **Read**: the vector-search path is chosen purely from the table property (no extra index existence probing).

## Also fixed

- `MetaDataClient::update_table_properties` used the wrong DaoType (`UpdateTableInfoById` → `UpdateTableInfoPropertiesById`).
- `LakeSoulTableProperty` gains the `vector_index_columns` field.
- lakesoul-io exposes `create_s3_store_from_options` for store-options-only contexts.

## Tests

- Optimizer rule unit tests: array_distance match, cosine/inner-product-ASC/no-LIMIT fallback, idempotence.
- PG end-to-end: L2 `array_distance` top-k recall, WHERE applied over candidates, nprobe session option, incremental writes searchable after the second auto build, no-index/no-property and cosine fallback correctness, SQL `CREATE TABLE` option round-trip and invalid-value rejection.

## Verification

- `cargo test -p lakesoul-datafusion --lib`: 32 passed.
- `cargo test -p lakesoul-vector`: 66 passed; `cargo test -p lakesoul-io`: 113 passed.
- Clippy: no new warnings; `cargo fmt` clean.